### PR TITLE
[DEVEX-110] Add Terraform module to deploy GitHub self hosted runners

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,6 +65,8 @@ Terraform definitions are intended to work for an environment in a specific regi
 
 ### GitHub SelfHosted Runner on Container App job
 
+This module helps to create the necessary infrastructure to run GitHub Actions on a self-hosted agent. Generally, this scenario pertains to infrastructure pipelines requiring access to private resources such as AKS and Storage Accounts. If there aren't private resources, please use GitHub managed runners.
+
 This module creates a Container App Job on an existing Container App Environment. It requires your repository name as input, in order to create a trigger on the GitHub Actions status of that repository. Moreover, it has a dependencies on a KeyVault where it creates a read-only access policy to access secrets.
 
 N.B. If you are adding a new Container App Job, it is likely that your repository must be added to GITHUB PAT access scope. Ask for this one-time operation to `engineering-team-cloud-eng` team.

--- a/README.md
+++ b/README.md
@@ -11,6 +11,8 @@ DevEx repository for shared tools and pipelines.
     - [infra\_apply.yaml](#infra_applyyaml)
       - [What it does](#what-it-does-1)
       - [Requirements](#requirements-1)
+  - [Terraform Modules](#terraform-modules)
+    - [GitHub SelfHosted Runner on Container App job](#github-selfhosted-runner-on-container-app-job)
 
 ## GitHub Action Templates
 
@@ -58,3 +60,11 @@ This workflow is set to be run once per time, abolishing concurrent runs.
 This workflow template leverages on managed identities to authenticate with Azure. Managed identities can be easily created through the module `azure_federated_identity_with_github` available in this repository.
 
 Terraform definitions are intended to work for an environment in a specific region. Each pair environment/region is a Terraform project on its own and they will be located in the `<env>/<region>` subfolder. Every automation will expect resources to be in such folders.
+
+## Terraform Modules
+
+### GitHub SelfHosted Runner on Container App job
+
+This module creates a Container App Job on an existing Container App Environment. It requires your repository name as input, in order to create a trigger on the GitHub Actions status of that repository. Moreover, it has a dependencies on a KeyVault where it creates a read-only access policy to access secrets.
+
+N.B. If you are adding a new Container App Job, it is likely that your repository must be added to GITHUB PAT access scope. Ask for this one-time operation to `engineering-team-cloud-eng` team.

--- a/infra/modules/github_selfhosted_runner_on_container_app_jobs/README.md
+++ b/infra/modules/github_selfhosted_runner_on_container_app_jobs/README.md
@@ -1,0 +1,47 @@
+# DX Typescript - GitHub SelfHosted Runner on Azure Container App Job
+
+<!-- markdownlint-disable -->
+<!-- BEGINNING OF PRE-COMMIT-TERRAFORM DOCS HOOK -->
+## Requirements
+
+| Name | Version |
+|------|---------|
+| <a name="requirement_azurerm"></a> [azurerm](#requirement\_azurerm) | >= 3.86.0, <= 3.100.0 |
+
+## Providers
+
+| Name | Version |
+|------|---------|
+| <a name="provider_azurerm"></a> [azurerm](#provider\_azurerm) | 3.97.1 |
+
+## Modules
+
+| Name | Source | Version |
+|------|--------|---------|
+| <a name="module_container_app_job_selfhosted_runner"></a> [container\_app\_job\_selfhosted\_runner](#module\_container\_app\_job\_selfhosted\_runner) | github.com/pagopa/terraform-azurerm-v3//container_app_job_gh_runner | v8.4.0 |
+
+## Resources
+
+| Name | Type |
+|------|------|
+| [azurerm_container_app_environment.runner](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/data-sources/container_app_environment) | data source |
+| [azurerm_key_vault.kv](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/data-sources/key_vault) | data source |
+
+## Inputs
+
+| Name | Description | Type | Default | Required |
+|------|-------------|------|---------|:--------:|
+| <a name="input_container_app_environment"></a> [container\_app\_environment](#input\_container\_app\_environment) | Name and resource group of the Container App Environment to use as host | <pre>object({<br>    name                = string<br>    resource_group_name = string<br>  })</pre> | n/a | yes |
+| <a name="input_env_short"></a> [env\_short](#input\_env\_short) | Environment short name | `string` | n/a | yes |
+| <a name="input_key_vault"></a> [key\_vault](#input\_key\_vault) | Name and resource group of the KeyVault holding secrets for this job | <pre>object({<br>    name                = string<br>    resource_group_name = string<br>  })</pre> | n/a | yes |
+| <a name="input_key_vault_secret_name"></a> [key\_vault\_secret\_name](#input\_key\_vault\_secret\_name) | Name of the KeyVault secret containing the GITHUB\_PAT value | `string` | `"github-runner-pat"` | no |
+| <a name="input_prefix"></a> [prefix](#input\_prefix) | Project prefix | `string` | n/a | yes |
+| <a name="input_repo_name"></a> [repo\_name](#input\_repo\_name) | This repository name | `string` | n/a | yes |
+| <a name="input_tags"></a> [tags](#input\_tags) | Resources tags | `map(any)` | n/a | yes |
+
+## Outputs
+
+| Name | Description |
+|------|-------------|
+| <a name="output_container_app_job"></a> [container\_app\_job](#output\_container\_app\_job) | n/a |
+<!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->

--- a/infra/modules/github_selfhosted_runner_on_container_app_jobs/data.tf
+++ b/infra/modules/github_selfhosted_runner_on_container_app_jobs/data.tf
@@ -1,0 +1,9 @@
+data "azurerm_container_app_environment" "runner" {
+  name                = var.container_app_environment.name
+  resource_group_name = var.container_app_environment.resource_group_name
+}
+
+data "azurerm_key_vault" "kv" {
+  name                = var.key_vault.name
+  resource_group_name = var.key_vault.resource_group_name
+}

--- a/infra/modules/github_selfhosted_runner_on_container_app_jobs/main.tf
+++ b/infra/modules/github_selfhosted_runner_on_container_app_jobs/main.tf
@@ -1,0 +1,34 @@
+terraform {
+  required_providers {
+    azurerm = {
+      source  = "hashicorp/azurerm"
+      version = ">= 3.86.0, <= 3.100.0"
+    }
+  }
+}
+
+module "container_app_job_selfhosted_runner" {
+  source = "github.com/pagopa/terraform-azurerm-v3//container_app_job_gh_runner?ref=v8.4.0"
+
+  location  = data.azurerm_container_app_environment.runner.location
+  prefix    = var.prefix
+  env_short = var.env_short
+
+  key_vault = {
+    resource_group_name = data.azurerm_key_vault.kv.resource_group_name
+    name                = data.azurerm_key_vault.kv.name
+    secret_name         = var.key_vault_secret_name
+  }
+
+  environment = {
+    name                = data.azurerm_container_app_environment.runner.name
+    resource_group_name = data.azurerm_container_app_environment.runner.resource_group_name
+  }
+
+  job = {
+    name = replace(replace(var.repo_name, "${var.prefix}-", ""), "${var.env_short}-", "")
+    repo = var.repo_name
+  }
+
+  tags = var.tags
+}

--- a/infra/modules/github_selfhosted_runner_on_container_app_jobs/outputs.tf
+++ b/infra/modules/github_selfhosted_runner_on_container_app_jobs/outputs.tf
@@ -1,0 +1,7 @@
+output "container_app_job" {
+  value = {
+    id                  = module.container_app_job_selfhosted_runner.id
+    name                = module.container_app_job_selfhosted_runner.name
+    resource_group_name = module.container_app_job_selfhosted_runner.resource_group_name
+  }
+}

--- a/infra/modules/github_selfhosted_runner_on_container_app_jobs/variables.tf
+++ b/infra/modules/github_selfhosted_runner_on_container_app_jobs/variables.tf
@@ -1,0 +1,41 @@
+variable "tags" {
+  type        = map(any)
+  description = "Resources tags"
+}
+
+variable "env_short" {
+  type        = string
+  description = "Environment short name"
+}
+
+variable "prefix" {
+  type        = string
+  description = "Project prefix"
+}
+
+variable "repo_name" {
+  type        = string
+  description = "This repository name"
+}
+
+variable "container_app_environment" {
+  type = object({
+    name                = string
+    resource_group_name = string
+  })
+  description = "Name and resource group of the Container App Environment to use as host"
+}
+
+variable "key_vault" {
+  type = object({
+    name                = string
+    resource_group_name = string
+  })
+  description = "Name and resource group of the KeyVault holding secrets for this job"
+}
+
+variable "key_vault_secret_name" {
+  type        = string
+  default     = "github-runner-pat"
+  description = "Name of the KeyVault secret containing the GITHUB_PAT value"
+}


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

### List of changes

<!--- Describe your changes in detail -->
This code wraps the existing module to deploy a Container App job on an existing CAE, to use as GitHub self hosted runner.

### Motivation and context

<!--- Why is this change required? What problem does it solve? -->
Useful when a GitHub Actions must run in a VNET

### Type of changes

- [X] Add new resources
- [ ] Update configuration to existing resources
- [ ] Remove existing resources

### Does this introduce a change to production resources with possible user impact?

- [ ] Yes, users may be impacted applying this change
- [X] No

### Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->
