### PR TITLE
[DEVEX-110] Manage names too long in GitHub self-hosted runner module

### DIFF
--- a/infra/modules/github_selfhosted_runner_on_container_app_jobs/README.md
+++ b/infra/modules/github_selfhosted_runner_on_container_app_jobs/README.md
@@ -32,8 +32,8 @@
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
 | <a name="input_container_app_environment"></a> [container\_app\_environment](#input\_container\_app\_environment) | Name and resource group of the Container App Environment to use as host | <pre>object({<br>    name                = string<br>    resource_group_name = string<br>  })</pre> | n/a | yes |
+| <a name="input_container_app_job_name"></a> [container\_app\_job\_name](#input\_container\_app\_job\_name) | (Optional) Override Container App Job name auto generated | `string` | `""` | no |
 | <a name="input_env_short"></a> [env\_short](#input\_env\_short) | Environment short name | `string` | n/a | yes |
-| <a name="input_job_name"></a> [job\_name](#input\_job\_name) | n/a | `string` | `""` | no |
 | <a name="input_key_vault"></a> [key\_vault](#input\_key\_vault) | Name and resource group of the KeyVault holding secrets for this job | <pre>object({<br>    name                = string<br>    resource_group_name = string<br>  })</pre> | n/a | yes |
 | <a name="input_key_vault_secret_name"></a> [key\_vault\_secret\_name](#input\_key\_vault\_secret\_name) | Name of the KeyVault secret containing the GITHUB\_PAT value | `string` | `"github-runner-pat"` | no |
 | <a name="input_prefix"></a> [prefix](#input\_prefix) | Project prefix | `string` | n/a | yes |

--- a/infra/modules/github_selfhosted_runner_on_container_app_jobs/README.md
+++ b/infra/modules/github_selfhosted_runner_on_container_app_jobs/README.md
@@ -33,6 +33,7 @@
 |------|-------------|------|---------|:--------:|
 | <a name="input_container_app_environment"></a> [container\_app\_environment](#input\_container\_app\_environment) | Name and resource group of the Container App Environment to use as host | <pre>object({<br>    name                = string<br>    resource_group_name = string<br>  })</pre> | n/a | yes |
 | <a name="input_env_short"></a> [env\_short](#input\_env\_short) | Environment short name | `string` | n/a | yes |
+| <a name="input_job_name"></a> [job\_name](#input\_job\_name) | n/a | `string` | `""` | no |
 | <a name="input_key_vault"></a> [key\_vault](#input\_key\_vault) | Name and resource group of the KeyVault holding secrets for this job | <pre>object({<br>    name                = string<br>    resource_group_name = string<br>  })</pre> | n/a | yes |
 | <a name="input_key_vault_secret_name"></a> [key\_vault\_secret\_name](#input\_key\_vault\_secret\_name) | Name of the KeyVault secret containing the GITHUB\_PAT value | `string` | `"github-runner-pat"` | no |
 | <a name="input_prefix"></a> [prefix](#input\_prefix) | Project prefix | `string` | n/a | yes |

--- a/infra/modules/github_selfhosted_runner_on_container_app_jobs/main.tf
+++ b/infra/modules/github_selfhosted_runner_on_container_app_jobs/main.tf
@@ -26,7 +26,7 @@ module "container_app_job_selfhosted_runner" {
   }
 
   job = {
-    name = var.job_name == "" ? replace(replace(var.repo_name, "${var.prefix}-", ""), "${var.env_short}-", "") : var.job_name
+    name = substr(replace(replace(var.repo_name, "${var.prefix}-", ""), "${var.env_short}-", ""), 0, 32)
     repo = var.repo_name
   }
 

--- a/infra/modules/github_selfhosted_runner_on_container_app_jobs/main.tf
+++ b/infra/modules/github_selfhosted_runner_on_container_app_jobs/main.tf
@@ -26,7 +26,7 @@ module "container_app_job_selfhosted_runner" {
   }
 
   job = {
-    name = substr(replace(replace(var.repo_name, "${var.prefix}-", ""), "${var.env_short}-", ""), 0, 32)
+    name = substr(replace(replace(var.repo_name, "${var.prefix}-", ""), "${var.env_short}-", ""), 0, 25)
     repo = var.repo_name
   }
 

--- a/infra/modules/github_selfhosted_runner_on_container_app_jobs/main.tf
+++ b/infra/modules/github_selfhosted_runner_on_container_app_jobs/main.tf
@@ -26,7 +26,7 @@ module "container_app_job_selfhosted_runner" {
   }
 
   job = {
-    name = substr(replace(replace(var.repo_name, "${var.prefix}-", ""), "${var.env_short}-", ""), 0, 25)
+    name = substr(replace(replace(var.repo_name, "${var.prefix}-", ""), "${var.env_short}-", ""), 0, 20)
     repo = var.repo_name
   }
 

--- a/infra/modules/github_selfhosted_runner_on_container_app_jobs/main.tf
+++ b/infra/modules/github_selfhosted_runner_on_container_app_jobs/main.tf
@@ -26,7 +26,7 @@ module "container_app_job_selfhosted_runner" {
   }
 
   job = {
-    name = replace(replace(var.repo_name, "${var.prefix}-", ""), "${var.env_short}-", "")
+    name = var.job_name == "" ? replace(replace(var.repo_name, "${var.prefix}-", ""), "${var.env_short}-", "") : var.job_name
     repo = var.repo_name
   }
 

--- a/infra/modules/github_selfhosted_runner_on_container_app_jobs/main.tf
+++ b/infra/modules/github_selfhosted_runner_on_container_app_jobs/main.tf
@@ -26,7 +26,7 @@ module "container_app_job_selfhosted_runner" {
   }
 
   job = {
-    name = substr(replace(replace(var.repo_name, "${var.prefix}-", ""), "${var.env_short}-", ""), 0, 20)
+    name = var.container_app_job_name == "" ? substr(replace(replace(var.repo_name, "${var.prefix}-", ""), "${var.env_short}-", ""), 0, 20) : var.container_app_job_name
     repo = var.repo_name
   }
 

--- a/infra/modules/github_selfhosted_runner_on_container_app_jobs/variables.tf
+++ b/infra/modules/github_selfhosted_runner_on_container_app_jobs/variables.tf
@@ -40,7 +40,8 @@ variable "key_vault_secret_name" {
   description = "Name of the KeyVault secret containing the GITHUB_PAT value"
 }
 
-variable "job_name" {
-  type    = string
-  default = ""
+variable "container_app_job_name" {
+  type        = string
+  default     = ""
+  description = "(Optional) Override Container App Job name auto generated"
 }

--- a/infra/modules/github_selfhosted_runner_on_container_app_jobs/variables.tf
+++ b/infra/modules/github_selfhosted_runner_on_container_app_jobs/variables.tf
@@ -39,3 +39,8 @@ variable "key_vault_secret_name" {
   default     = "github-runner-pat"
   description = "Name of the KeyVault secret containing the GITHUB_PAT value"
 }
+
+variable "job_name" {
+  type    = string
+  default = ""
+}


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

### List of changes

<!--- Describe your changes in detail -->
Truncate container app job name after 20 characters and add a variable to override it if the generated value is not ok

### Motivation and context

<!--- Why is this change required? What problem does it solve? -->
If the repository name is too long, the module fails to apply because of max length in container app job name.

### Type of changes

- [ ] Add new resources
- [X] Update configuration to existing resources
- [ ] Remove existing resources

### Does this introduce a change to production resources with possible user impact?

- [ ] Yes, users may be impacted applying this change
- [X] No

### Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->
