### PR TITLE
[DEVEX-117] Add js_code_review reusable workflow

### DIFF
--- a/.github/workflows/js_code_review.yaml
+++ b/.github/workflows/js_code_review.yaml
@@ -1,0 +1,51 @@
+name: "Code Review"
+
+on:
+  workflow_call: {}
+
+jobs:
+  js_code_review:
+    runs-on: ubuntu-22.04
+
+    steps:
+      - name: Check out code
+        uses: actions/checkout@0ad4b8fadaa221de15dcec353f45205ec38ea70b # v4.1.4
+
+      # Corepack is an official tool by Node.js that manages package managers versions
+      - name: Setup yarn
+        run: corepack enable
+
+      - name: Setup Node.js
+        uses: actions/setup-node@60edb5dd545a775178f52524783378180af0d1f8 # v4.0.2
+        with:
+          node-version-file: ".node-version"
+          cache: "yarn"
+
+      - name: Install dependencies
+        run: yarn install --immutable
+
+      - name: Setup turbo cache
+        uses: actions/cache@0c45773b623bea8c8e75f6c82b208c3cf94ea4f9 # v4.0.2
+        with:
+          path: node_modules/.cache/turbo
+          key: ${{ runner.os }}-turbo-${{ github.sha }}
+          restore-keys: |
+            ${{ runner.os }}-turbo-
+
+      # The code-review script must be defined in the root workspace
+      # Example: "turbo run typecheck format:check lint:check //#test:coverage"
+      # See https://github.com/pagopa/io-fims/pull/41
+      - name: Run code-review script
+        run: yarn run code-review
+
+      # Codecov provides reports and metrics about test coverage data.
+      # To enable set CODECOV_TOKEN secret at repo level and make sure
+      # that your "code-review" script creates a "coverage/" folder in
+      # the root workspace.
+      - name: Upload coverage report to codecov.io
+        env:
+          CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
+        if: ${{ env.CODECOV_TOKEN != '' }}
+        uses: codecov/codecov-action@84508663e988701840491b86de86b666e8a86bed # v4.3.0
+        with:
+          token: ${{ env.CODECOV_TOKEN }}


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

### List of changes
1. Add a new github reusable workflow: `js_code_review` that runs the `code-review` script in javascript monorepo. This workflow is configured to cache `turbo` output and sends (only when is enabled) test coverage reports to https://about.codecov.io/

### How to use this workflow

Create a file named `code-review.yaml` in `.github/workflows` with the following content

```yaml
name: Code Review

on:
  workflow_dispatch:
  pull_request:
    types: [opened, synchronize]
    paths:
      - apps/**
      - packages/**

jobs:
  js_code_review:
    uses: pagopa/dx/.github/workflows/js_code_review.yaml@c461016f071d813b2012c88674df41c753f56b16
    name: Code Review
    secrets: inherit
```
