### PR TITLE
[DEVEX-41] Remove region from input parameters in infra workflows

### DIFF
--- a/.github/workflows/infra_apply.yaml
+++ b/.github/workflows/infra_apply.yaml
@@ -5,10 +5,6 @@ on:
         description: Environment where the resources will be deployed.
         type: string
         required: true
-      region:
-        description: Azure region where the resources will be deployed.
-        type: string
-        required: true
       base_path:
         description: The base path on which the script will look for Terraform projects
         type: string
@@ -57,19 +53,18 @@ jobs:
         id: directory
         env:
           ENVIRONMENT: ${{ inputs.environment }}
-          REGION: ${{ inputs.region }}
           BASE_PATH: ${{ inputs.base_path }}
         run: |
           set -euo pipefail
 
-          if [ -z "$ENVIRONMENT" ] || [ -z "$REGION" ]; then
-            echo "Both environment and region must be provided."
+          if [ -z "$ENVIRONMENT" ]; then
+            echo "Environment must be provided."
             exit 1
           else
             # The directory is expected to be in the format
-            #  ${inputs.base_path}/"$ENVIRONMENT"/"$REGION"
-            # Example: infra/resources/prod/westeurope
-            printf "dir=%q/%q/%q" "$BASE_PATH" "$ENVIRONMENT" "$REGION" >> "$GITHUB_OUTPUT"
+            #  ${inputs.base_path}/"$ENVIRONMENT""
+            # Example: infra/resources/prod
+            printf "dir=%q/%q" "$BASE_PATH" "$ENVIRONMENT" >> "$GITHUB_OUTPUT"
           fi
 
       - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1

--- a/.github/workflows/infra_plan.yaml
+++ b/.github/workflows/infra_plan.yaml
@@ -5,10 +5,6 @@ on:
         description: Environment where the resources will be deployed.
         type: string
         required: true
-      region:
-        description: Azure region where the resources will be deployed.
-        type: string
-        required: true
       base_path:
         description: The base path on which the script will look for Terraform projects
         type: string
@@ -54,19 +50,18 @@ jobs:
         id: directory
         env:
           ENVIRONMENT: ${{ inputs.environment }}
-          REGION: ${{ inputs.region }}
           BASE_PATH: ${{ inputs.base_path }}
         run: |
           set -euo pipefail
 
-          if [ -z "$ENVIRONMENT" ] || [ -z "$REGION" ]; then
-            echo "Both environment and region must be provided."
+          if [ -z "$ENVIRONMENT" ]; then
+            echo "Environment must be provided."
             exit 1
           else
             # The directory is expected to be in the format
-            #  infra/resources/${{ inputs.environment }}/${{ inputs.region }}
-            # Example: infra/resources/prod/westeurope
-            printf "dir=%q/%q/%q" "$BASE_PATH" "$ENVIRONMENT" "$REGION" >> "$GITHUB_OUTPUT"
+            #  infra/resources/${{ inputs.environment }}
+            # Example: infra/resources/prod
+            printf "dir=%q/%q" "$BASE_PATH" "$ENVIRONMENT" >> "$GITHUB_OUTPUT"
           fi
 
       - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

### List of changes

<!--- Describe your changes in detail -->
Remove `region` input parameter

### Motivation and context

<!--- Why is this change required? What problem does it solve? -->
A Terraform config might have more than one region. We took the decision to remove the region from folder hierarchy for this reason then

### Type of changes

- [ ] Add new resources
- [X] Update configuration to existing resources
- [ ] Remove existing resources

### Does this introduce a change to production resources with possible user impact?

- [ ] Yes, users may be impacted applying this change
- [X] No

### Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->
