### PR TITLE
Fix @pagopa/eslint-config vitest rules

### DIFF
--- a/.changeset/chilled-trains-occur.md
+++ b/.changeset/chilled-trains-occur.md
@@ -1,0 +1,5 @@
+---
+"@pagopa/eslint-config": patch
+---
+
+Fix vitest configuration; ignore "generated" folder

--- a/packages/eslint-config/index.js
+++ b/packages/eslint-config/index.js
@@ -12,19 +12,21 @@ export default [
   prettier,
   perfectionistNatural,
   {
-    files: ["tests/**", "__tests__/**"],
+    files: ["**/tests/**", "**/__tests__/**"],
+    ...vitest.configs.recommended,
     rules: {
-      ...vitest.configs.recommended,
-      "prefer-called-with": ["error"],
-      "prefer-equality-matcher": ["error"],
-      "prefer-expect-resolves": ["error"],
-      "prefer-spy-on": ["error"],
-      "prefer-todo": ["error"],
+      ...vitest.configs.recommended.rules,
+      "@typescript-eslint/no-empty-function": "off",
+      "vitest/prefer-called-with": "error",
+      "vitest/prefer-equality-matcher": "error",
+      "vitest/prefer-expect-resolves": "error",
+      "vitest/prefer-spy-on": "error",
+      "vitest/prefer-todo": "error",
     },
   },
   {
     rules: {
-      "@typescript-eslint/no-unused-expressions": ["error"],
+      "@typescript-eslint/no-unused-expressions": "error",
       "@typescript-eslint/no-unused-vars": ["error", { args: "after-used" }],
       "arrow-body-style": "error",
       complexity: "error",
@@ -41,5 +43,8 @@ export default [
       "prefer-const": "error",
       radix: "error",
     },
+  },
+  {
+    ignores: ["**/generated/*"],
   },
 ];


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

### List of changes
1. Fix `eslint-vitest-plugin` configuration
2. Now `eslint` will ignore by default `generated` files

<!--- Describe your changes in detail -->

### Motivation and context
The current configuration is not working as expected

<!--- Why is this change required? What problem does it solve? -->

### Type of changes

- [ ] Add new resources
- [ ] Update configuration to existing resources
- [ ] Remove existing resources

### Does this introduce a change to production resources with possible user impact?

- [ ] Yes, users may be impacted applying this change
- [ ] No

### Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->
