### PR TITLE
[DEVEX-138] Add `fn` suffix to Function App Storage Account name

### DIFF
--- a/infra/modules/azure_function_app/locals.tf
+++ b/infra/modules/azure_function_app/locals.tf
@@ -18,7 +18,7 @@ locals {
 
   storage_account = {
     replication_type = var.tier == "test" ? "LRS" : "ZRS"
-    name             = replace("${local.project}${var.environment.domain}${var.environment.app_name}st${var.environment.instance_number}", "-", "")
+    name             = replace("${local.project}${var.environment.domain}${var.environment.app_name}stfn${var.environment.instance_number}", "-", "")
   }
 
   private_dns_zone = {

--- a/infra/modules/azure_function_app/variables.tf
+++ b/infra/modules/azure_function_app/variables.tf
@@ -14,7 +14,7 @@ variable "environment" {
   })
 
   validation {
-    condition     = length("${var.environment.prefix}${var.environment.env_short}loc${var.environment.domain}${var.environment.app_name}st${var.environment.instance_number}") <= 24
+    condition     = length("${var.environment.prefix}${var.environment.env_short}loc${var.environment.domain}${var.environment.app_name}stfn${var.environment.instance_number}") <= 24
     error_message = "Storage Account name must have less than 25 characters. Current value is \"${var.environment.prefix}${var.environment.env_short}loc${var.environment.domain}${var.environment.app_name}st${var.environment.instance_number}\""
   }
 


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

### List of changes

<!--- Describe your changes in detail -->
Add `fn` suffix to the name of Storage Account created in Azure Function App module

### Motivation and context

<!--- Why is this change required? What problem does it solve? -->

If a workload is composed by a Function App and a Storage Account, the name of the Storage Account would be exactly the same as the one created as a backend for the Function App itself.

Example:
Function App: `io-p-services-cms-webapp-fn-01`
Function App Storage Account: `io-p-services-cms-webapp-st-01`
Storage Account with application-specific business logic: `io-p-services-cms-webapp-st-01`

Applying this pr they would be:
Function App: `io-p-services-cms-webapp-fn-01`
Function App Storage Account: `io-p-services-cms-webapp-stfn-01`
Storage Account with application-specific business logic: `io-p-services-cms-webapp-st-01`

The abbreviation `stfn` has been deducted from [Microsoft abbreviation list](https://learn.microsoft.com/en-us/azure/cloud-adoption-framework/ready/azure-best-practices/resource-abbreviations#compute-and-web), in particular from `VM storage account` entry (`stvm`)

N.B. Storage Account names don't have `-` in names, I've included them in for readiness ease

### Type of changes

- [ ] Add new resources
- [X] Update configuration to existing resources
- [ ] Remove existing resources

### Does this introduce a change to production resources with possible user impact?

- [X] Yes, users may be impacted applying this change
- [ ] No

### Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->
