### PR TITLE
fix: GitHub Pages deployment workflow

### DIFF
--- a/.github/workflows/docs_website_publish.yaml
+++ b/.github/workflows/docs_website_publish.yaml
@@ -48,7 +48,7 @@ jobs:
       - name: Upload Build Artifact
         uses: actions/upload-pages-artifact@v3
         with:
-          path: build
+          path: ./website/build
 
   deploy:
     name: Deploy to GitHub Pages


### PR DESCRIPTION
This pull request fixes the workflow for GitHub Pages deployment. The path for uploading the build artifact has been updated to "./website/build".