### PR TITLE
Reduce function app slot name to staging

### DIFF
--- a/infra/modules/azure_function_app/function_app_slot.tf
+++ b/infra/modules/azure_function_app/function_app_slot.tf
@@ -1,7 +1,7 @@
 resource "azurerm_linux_function_app_slot" "this" {
   count = local.function_app.is_slot_enabled
 
-  name            = "${local.project}-${var.environment.domain}-${var.environment.app_name}-staging-func-${var.environment.instance_number}"
+  name            = "staging"
   function_app_id = azurerm_linux_function_app.this.id
 
   storage_account_name          = azurerm_storage_account.this.name


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

### List of changes

<!--- Describe your changes in detail -->
Changed the name of the function app slot resource from the complete one to "staging".

### Motivation and context

<!--- Why is this change required? What problem does it solve? -->
The name of the staging slot is automatically concatenated with the name of the function app itself.
For this reason, the resulting name is extremely long and redundant.

Example:
![image](https://github.com/pagopa/dx/assets/43080407/e3a343fc-8803-4071-bc8b-88e8720e5463)

This would become:
io-p-itn-svc-app-be-func-01-staging

### Type of changes

- [ ] Add new resources
- [X] Update configuration to existing resources
- [ ] Remove existing resources

### Does this introduce a change to production resources with possible user impact?

- [ ] Yes, users may be impacted applying this change
- [X] No

### Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->
