### PR TITLE
Fix function app slot host id collision

### DIFF
--- a/infra/modules/azure_function_app/README.md
+++ b/infra/modules/azure_function_app/README.md
@@ -12,7 +12,7 @@
 
 | Name | Version |
 |------|---------|
-| <a name="provider_azurerm"></a> [azurerm](#provider\_azurerm) | 3.104.0 |
+| <a name="provider_azurerm"></a> [azurerm](#provider\_azurerm) | 3.107.0 |
 
 ## Modules
 

--- a/infra/modules/azure_function_app/function_app.tf
+++ b/infra/modules/azure_function_app/function_app.tf
@@ -1,5 +1,5 @@
 resource "azurerm_linux_function_app" "this" {
-  name                = "${local.project}-${var.environment.domain}-${var.environment.app_name}-func-${var.environment.instance_number}"
+  name                = local.function_app.name
   location            = var.environment.location
   resource_group_name = var.resource_group_name
 
@@ -44,7 +44,7 @@ resource "azurerm_linux_function_app" "this" {
       SLOT_TASK_HUBNAME = "ProductionTaskHub",
     },
     # https://learn.microsoft.com/en-us/azure/azure-functions/errors-diagnostics/diagnostic-events/azfd0004#options-for-addressing-collisions
-    length(azurerm_linux_function_app.this.name) > 32 ? { AzureFunctionsWebHost__hostid = "production" } : {},
+    length(local.function_app.name) > 32 ? { AzureFunctionsWebHost__hostid = "production" } : {},
     var.app_settings,
     local.application_insights.enable ? {
       # https://docs.microsoft.com/en-us/azure/azure-monitor/app/sampling

--- a/infra/modules/azure_function_app/function_app.tf
+++ b/infra/modules/azure_function_app/function_app.tf
@@ -43,6 +43,8 @@ resource "azurerm_linux_function_app" "this" {
       # https://learn.microsoft.com/en-us/azure/azure-functions/functions-reference?tabs=blob&pivots=programming-language-csharp#connecting-to-host-storage-with-an-identity
       SLOT_TASK_HUBNAME = "ProductionTaskHub",
     },
+    # https://learn.microsoft.com/en-us/azure/azure-functions/errors-diagnostics/diagnostic-events/azfd0004#options-for-addressing-collisions
+    length(azurerm_linux_function_app.this.name) > 32 ? { AzureFunctionsWebHost__hostid = "production" } : {},
     var.app_settings,
     local.application_insights.enable ? {
       # https://docs.microsoft.com/en-us/azure/azure-monitor/app/sampling

--- a/infra/modules/azure_function_app/function_app.tf
+++ b/infra/modules/azure_function_app/function_app.tf
@@ -57,6 +57,7 @@ resource "azurerm_linux_function_app" "this" {
       [
         "SLOT_TASK_HUBNAME",
       ],
+      length(local.function_app.name) > 32 ? ["AzureFunctionsWebHost__hostid"] : [],
       var.sticky_app_setting_names,
     )
   }

--- a/infra/modules/azure_function_app/function_app_slot.tf
+++ b/infra/modules/azure_function_app/function_app_slot.tf
@@ -45,7 +45,7 @@ resource "azurerm_linux_function_app_slot" "this" {
       SLOT_TASK_HUBNAME = "StagingTaskHub",
     },
     # https://learn.microsoft.com/en-us/azure/azure-functions/errors-diagnostics/diagnostic-events/azfd0004#options-for-addressing-collisions
-    length(azurerm_linux_function_app.this.name) > 32 ? { AzureFunctionsWebHost__hostid = local.function_app_slot.name } : {},
+    length("${azurerm_linux_function_app.this.name}-${local.function_app_slot.name}") > 32 ? { AzureFunctionsWebHost__hostid = local.function_app_slot.name } : {},
     var.slot_app_settings
   )
 

--- a/infra/modules/azure_function_app/function_app_slot.tf
+++ b/infra/modules/azure_function_app/function_app_slot.tf
@@ -1,7 +1,7 @@
 resource "azurerm_linux_function_app_slot" "this" {
   count = local.function_app.is_slot_enabled
 
-  name            = "staging"
+  name            = local.function_app_slot.name
   function_app_id = azurerm_linux_function_app.this.id
 
   storage_account_name          = azurerm_storage_account.this.name
@@ -44,6 +44,8 @@ resource "azurerm_linux_function_app_slot" "this" {
       # https://learn.microsoft.com/en-us/azure/azure-functions/functions-reference?tabs=blob&pivots=programming-language-csharp#connecting-to-host-storage-with-an-identity
       SLOT_TASK_HUBNAME = "StagingTaskHub",
     },
+    # https://learn.microsoft.com/en-us/azure/azure-functions/errors-diagnostics/diagnostic-events/azfd0004#options-for-addressing-collisions
+    length(local.function_app_slot.host_id) > 32 ? {AzureFunctionsWebHost__hostid = local.function_app_slot.truncated_host_id} : {},
     var.slot_app_settings
   )
 

--- a/infra/modules/azure_function_app/function_app_slot.tf
+++ b/infra/modules/azure_function_app/function_app_slot.tf
@@ -45,7 +45,7 @@ resource "azurerm_linux_function_app_slot" "this" {
       SLOT_TASK_HUBNAME = "StagingTaskHub",
     },
     # https://learn.microsoft.com/en-us/azure/azure-functions/errors-diagnostics/diagnostic-events/azfd0004#options-for-addressing-collisions
-    length("${azurerm_linux_function_app.this.name}-${local.function_app_slot.name}") > 32 ? { AzureFunctionsWebHost__hostid = local.function_app_slot.name } : {},
+    length(azurerm_linux_function_app.this.name) > 32 ? { AzureFunctionsWebHost__hostid = local.function_app_slot.name } : {},
     var.slot_app_settings
   )
 

--- a/infra/modules/azure_function_app/function_app_slot.tf
+++ b/infra/modules/azure_function_app/function_app_slot.tf
@@ -1,7 +1,7 @@
 resource "azurerm_linux_function_app_slot" "this" {
   count = local.function_app.is_slot_enabled
 
-  name            = local.function_app.slot_name
+  name            = local.function_app_slot.name
   function_app_id = azurerm_linux_function_app.this.id
 
   storage_account_name          = azurerm_storage_account.this.name
@@ -45,7 +45,7 @@ resource "azurerm_linux_function_app_slot" "this" {
       SLOT_TASK_HUBNAME = "StagingTaskHub",
     },
     # https://learn.microsoft.com/en-us/azure/azure-functions/errors-diagnostics/diagnostic-events/azfd0004#options-for-addressing-collisions
-    length(local.function_app_slot.host_id) > 32 ? { AzureFunctionsWebHost__hostid = local.function_app_slot.truncated_host_id } : {},
+    length("${azurerm_linux_function_app.this.name}-${local.function_app_slot.name}") > 32 ? { AzureFunctionsWebHost__hostid = local.function_app_slot.name } : {},
     var.slot_app_settings
   )
 

--- a/infra/modules/azure_function_app/function_app_slot.tf
+++ b/infra/modules/azure_function_app/function_app_slot.tf
@@ -1,7 +1,7 @@
 resource "azurerm_linux_function_app_slot" "this" {
   count = local.function_app.is_slot_enabled
 
-  name            = local.function_app_slot.name
+  name            = local.function_app.slot_name
   function_app_id = azurerm_linux_function_app.this.id
 
   storage_account_name          = azurerm_storage_account.this.name
@@ -45,7 +45,7 @@ resource "azurerm_linux_function_app_slot" "this" {
       SLOT_TASK_HUBNAME = "StagingTaskHub",
     },
     # https://learn.microsoft.com/en-us/azure/azure-functions/errors-diagnostics/diagnostic-events/azfd0004#options-for-addressing-collisions
-    length(local.function_app_slot.host_id) > 32 ? {AzureFunctionsWebHost__hostid = local.function_app_slot.truncated_host_id} : {},
+    length(local.function_app_slot.host_id) > 32 ? { AzureFunctionsWebHost__hostid = local.function_app_slot.truncated_host_id } : {},
     var.slot_app_settings
   )
 

--- a/infra/modules/azure_function_app/locals.tf
+++ b/infra/modules/azure_function_app/locals.tf
@@ -7,6 +7,7 @@ locals {
   }
 
   function_app = {
+    name                   = "${local.project}-${var.environment.domain}-${var.environment.app_name}-func-${var.environment.instance_number}"
     sku_name               = var.tier == "test" ? "B1" : var.tier == "standard" ? "P0v3" : "P1v3"
     zone_balancing_enabled = var.tier != "test"
     is_slot_enabled        = var.tier == "test" ? 0 : 1

--- a/infra/modules/azure_function_app/locals.tf
+++ b/infra/modules/azure_function_app/locals.tf
@@ -10,7 +10,10 @@ locals {
     sku_name               = var.tier == "test" ? "B1" : var.tier == "standard" ? "P0v3" : "P1v3"
     zone_balancing_enabled = var.tier != "test"
     is_slot_enabled        = var.tier == "test" ? 0 : 1
-    slot_name              = "staging"
+  }
+
+  function_app_slot = {
+    name = "staging"
   }
 
   application_insights = {
@@ -24,10 +27,5 @@ locals {
 
   private_dns_zone = {
     resource_group_name = var.private_dns_zone_resource_group_name == null ? var.virtual_network.resource_group_name : var.private_dns_zone_resource_group_name
-  }
-
-  function_app_slot = {
-    host_id           = "${azurerm_linux_function_app.this.name}-${local.function_app.slot_name}"
-    truncated_host_id = substr("${azurerm_linux_function_app.this.name}-${local.function_app.slot_name}", length("${azurerm_linux_function_app.this.name}-${local.function_app.slot_name}") - 32, -1)
   }
 }

--- a/infra/modules/azure_function_app/locals.tf
+++ b/infra/modules/azure_function_app/locals.tf
@@ -10,6 +10,7 @@ locals {
     sku_name               = var.tier == "test" ? "B1" : var.tier == "standard" ? "P0v3" : "P1v3"
     zone_balancing_enabled = var.tier != "test"
     is_slot_enabled        = var.tier == "test" ? 0 : 1
+    slot_name              = "staging"
   }
 
   application_insights = {
@@ -26,8 +27,7 @@ locals {
   }
 
   function_app_slot = {
-    name = "staging"
-    host_id = "${azurerm_linux_function_app.this.name}-${local.function_app_slot.name}"
-    truncated_host_id = substr(local.function_app_slot.host_id, length(local.function_app_slot.host_id) - 32, -1)
+    host_id           = "${azurerm_linux_function_app.this.name}-${local.function_app.slot_name}"
+    truncated_host_id = substr("${azurerm_linux_function_app.this.name}-${local.function_app.slot_name}", length("${azurerm_linux_function_app.this.name}-${local.function_app.slot_name}") - 32, -1)
   }
 }

--- a/infra/modules/azure_function_app/locals.tf
+++ b/infra/modules/azure_function_app/locals.tf
@@ -24,4 +24,10 @@ locals {
   private_dns_zone = {
     resource_group_name = var.private_dns_zone_resource_group_name == null ? var.virtual_network.resource_group_name : var.private_dns_zone_resource_group_name
   }
+
+  function_app_slot = {
+    name = "staging"
+    host_id = "${azurerm_linux_function_app.this.name}-${local.function_app_slot.name}"
+    truncated_host_id = substr(local.function_app_slot.host_id, length(local.function_app_slot.host_id) - 32, -1)
+  }
 }


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

### List of changes
Set the AzureFunctionsWebHost__hostid environment variable on function app and its slot when the function name is longer than 32 characters

<!--- Describe your changes in detail -->

### Motivation and context

<!--- Why is this change required? What problem does it solve? -->
In the newly implemented trial-system project, an issue has been encountered. The name of the staging slot (that is the concatenation of the function app name and "staging") was longer than 32 characters.

The default host id (used to create a container in the function's storage account), equals to the complete name truncated to 32 characters. When the complete slot name is longer than 32 characters, the host id (aka container name) may collide with the one used by the function app and cause problems.

For this reason, in this PR, we are going to set the host id statically to avoid collisions. "production" for the function app and the slot name for the function app slots (e.g. "staging").

More information here:
https://learn.microsoft.com/en-us/azure/azure-functions/storage-considerations?tabs=azure-cli#avoiding-host-id-collisions
https://learn.microsoft.com/en-us/azure/azure-functions/errors-diagnostics/diagnostic-events/azfd0004
### Type of changes

- [ ] Add new resources
- [X] Update configuration to existing resources
- [ ] Remove existing resources

### Does this introduce a change to production resources with possible user impact?

- [ ] Yes, users may be impacted applying this change
- [X] No

### Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->
