### PR TITLE
[DEVEX-153] Add support for subnet service endpoints in compute modules

### DIFF
--- a/infra/modules/azure_app_service/README.md
+++ b/infra/modules/azure_app_service/README.md
@@ -52,6 +52,7 @@
 | <a name="input_sticky_app_setting_names"></a> [sticky\_app\_setting\_names](#input\_sticky\_app\_setting\_names) | (Optional) A list of application setting names that are not swapped between slots | `list(string)` | `[]` | no |
 | <a name="input_subnet_cidr"></a> [subnet\_cidr](#input\_subnet\_cidr) | CIDR block to use for the subnet the Function App uses for outbound connectivity | `string` | n/a | yes |
 | <a name="input_subnet_pep_id"></a> [subnet\_pep\_id](#input\_subnet\_pep\_id) | Id of the subnet which holds private endpoints | `string` | n/a | yes |
+| <a name="input_subnet_service_endpoints"></a> [subnet\_service\_endpoints](#input\_subnet\_service\_endpoints) | (Optional) Enable service endpoints for the underlying subnet. This variable should be set only if function dependencies do not use private endpoints | <pre>object({<br>    cosmos  = optional(bool, false)<br>    storage = optional(bool, false)<br>    web     = optional(bool, false)<br>  })</pre> | `null` | no |
 | <a name="input_tags"></a> [tags](#input\_tags) | Resources tags | `map(any)` | n/a | yes |
 | <a name="input_tier"></a> [tier](#input\_tier) | Resource tiers depending on demanding workload. Allowed values are 'premium', 'standard', 'test'. Note, "test" does not support deployment slots. | `string` | `"premium"` | no |
 | <a name="input_virtual_network"></a> [virtual\_network](#input\_virtual\_network) | Virtual network in which to create the subnet | <pre>object({<br>    name                = string<br>    resource_group_name = string<br>  })</pre> | n/a | yes |

--- a/infra/modules/azure_app_service/locals.tf
+++ b/infra/modules/azure_app_service/locals.tf
@@ -2,6 +2,14 @@ locals {
   location_short = var.environment.location == "italynorth" ? "itn" : var.environment.location == "westeurope" ? "weu" : var.environment.location == "germanywestcentral" ? "gwc" : "neu"
   project        = "${var.environment.prefix}-${var.environment.env_short}-${local.location_short}"
 
+  subnet = {
+    enable_service_endpoints = var.subnet_service_endpoints != null ? concat(
+      var.subnet_service_endpoints.cosmos ? ["Microsoft.CosmosDB"] : [],
+      var.subnet_service_endpoints.web ? ["Microsoft.Web"] : [],
+      var.subnet_service_endpoints.storage ? ["Microsoft.Storage"] : [],
+    ) : []
+  }
+
   app_service_plan = {
     enable = var.app_service_plan_id == null
   }

--- a/infra/modules/azure_app_service/subnets.tf
+++ b/infra/modules/azure_app_service/subnets.tf
@@ -4,9 +4,7 @@ resource "azurerm_subnet" "this" {
   resource_group_name  = data.azurerm_virtual_network.this.resource_group_name
   address_prefixes     = [var.subnet_cidr]
 
-  service_endpoints = [
-    "Microsoft.Web"
-  ]
+  service_endpoints = local.subnet.enable_service_endpoints
 
   delegation {
     name = "default"

--- a/infra/modules/azure_app_service/variables.tf
+++ b/infra/modules/azure_app_service/variables.tf
@@ -118,3 +118,13 @@ variable "private_dns_zone_resource_group_name" {
   default     = null
   description = "(Optional) The name of the resource group holding private DNS zone to use for private endpoints. Default is Virtual Network resource group"
 }
+
+variable "subnet_service_endpoints" {
+  type = object({
+    cosmos  = optional(bool, false)
+    storage = optional(bool, false)
+    web     = optional(bool, false)
+  })
+  description = "(Optional) Enable service endpoints for the underlying subnet. This variable should be set only if function dependencies do not use private endpoints"
+  default     = null
+}

--- a/infra/modules/azure_function_app/README.md
+++ b/infra/modules/azure_function_app/README.md
@@ -67,6 +67,7 @@
 | <a name="input_sticky_app_setting_names"></a> [sticky\_app\_setting\_names](#input\_sticky\_app\_setting\_names) | (Optional) A list of application setting names that are not swapped between slots | `list(string)` | `[]` | no |
 | <a name="input_subnet_cidr"></a> [subnet\_cidr](#input\_subnet\_cidr) | CIDR block to use for the subnet the Function App uses for outbound connectivity | `string` | n/a | yes |
 | <a name="input_subnet_pep_id"></a> [subnet\_pep\_id](#input\_subnet\_pep\_id) | Id of the subnet which holds private endpoints | `string` | n/a | yes |
+| <a name="input_subnet_service_endpoints"></a> [subnet\_service\_endpoints](#input\_subnet\_service\_endpoints) | (Optional) Enable service endpoints for the underlying subnet. This variable should be set only if function dependencies do not use private endpoints | <pre>object({<br>    cosmos  = optional(bool, false)<br>    storage = optional(bool, false)<br>    web     = optional(bool, false)<br>  })</pre> | `null` | no |
 | <a name="input_tags"></a> [tags](#input\_tags) | Resources tags | `map(any)` | n/a | yes |
 | <a name="input_tier"></a> [tier](#input\_tier) | Resource tiers depending on demanding workload. Allowed values are 'premium', 'standard', 'test'. Note, "test" does not support deployment slots. | `string` | `"premium"` | no |
 | <a name="input_virtual_network"></a> [virtual\_network](#input\_virtual\_network) | Virtual network in which to create the subnet | <pre>object({<br>    name                = string<br>    resource_group_name = string<br>  })</pre> | n/a | yes |

--- a/infra/modules/azure_function_app/locals.tf
+++ b/infra/modules/azure_function_app/locals.tf
@@ -2,6 +2,14 @@ locals {
   location_short = var.environment.location == "italynorth" ? "itn" : var.environment.location == "westeurope" ? "weu" : var.environment.location == "germanywestcentral" ? "gwc" : "neu"
   project        = "${var.environment.prefix}-${var.environment.env_short}-${local.location_short}"
 
+  subnet = {
+    enable_service_endpoints = var.subnet_service_endpoints != null ? concat(
+      var.subnet_service_endpoints.cosmos ? ["Microsoft.CosmosDB"] : [],
+      var.subnet_service_endpoints.web ? ["Microsoft.Web"] : [],
+      var.subnet_service_endpoints.storage ? ["Microsoft.Storage"] : [],
+    ) : []
+  }
+
   app_service_plan = {
     enable = var.app_service_plan_id == null
   }

--- a/infra/modules/azure_function_app/subnets.tf
+++ b/infra/modules/azure_function_app/subnets.tf
@@ -4,9 +4,7 @@ resource "azurerm_subnet" "this" {
   resource_group_name  = data.azurerm_virtual_network.this.resource_group_name
   address_prefixes     = [var.subnet_cidr]
 
-  service_endpoints = [
-    "Microsoft.Web"
-  ]
+  service_endpoints = local.subnet.enable_service_endpoints
 
   delegation {
     name = "default"

--- a/infra/modules/azure_function_app/variables.tf
+++ b/infra/modules/azure_function_app/variables.tf
@@ -123,3 +123,13 @@ variable "private_dns_zone_resource_group_name" {
   default     = null
   description = "(Optional) The name of the resource group holding private DNS zone to use for private endpoints. Default is Virtual Network resource group"
 }
+
+variable "subnet_service_endpoints" {
+  type = object({
+    cosmos  = optional(bool, false)
+    storage = optional(bool, false)
+    web     = optional(bool, false)
+  })
+  description = "(Optional) Enable service endpoints for the underlying subnet. This variable should be set only if function dependencies do not use private endpoints"
+  default     = null
+}


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

### List of changes

<!--- Describe your changes in detail -->
Add support for service endpoint configuration in subnet created by modules

### Motivation and context

<!--- Why is this change required? What problem does it solve? -->
Service endpoints needs to communicate with resources which don't have a private endpoint. Actually lot of resources don't have them, so this requirement is still valid

### Type of changes

- [ ] Add new resources
- [X] Update configuration to existing resources
- [ ] Remove existing resources

### Does this introduce a change to production resources with possible user impact?

- [X] Yes, users may be impacted applying this change
- [ ] No

### Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->
