### PR TITLE
Remove networking variables from azure_app_service_exposed module

### DIFF
--- a/infra/modules/azure_app_service_exposed/app_service.tf
+++ b/infra/modules/azure_app_service_exposed/app_service.tf
@@ -7,7 +7,6 @@ resource "azurerm_linux_web_app" "this" {
 
   https_only                    = true
   public_network_access_enabled = true
-  virtual_network_subnet_id     = var.azurerm_subnet_id
 
   identity {
     type = "SystemAssigned"
@@ -19,7 +18,6 @@ resource "azurerm_linux_web_app" "this" {
     vnet_route_all_enabled            = true
     health_check_path                 = var.health_check_path
     health_check_eviction_time_in_min = 2
-    ip_restriction_default_action     = "Deny"
 
     application_stack {
       node_version = var.stack == "node" ? "${var.node_version}-lts" : null

--- a/infra/modules/azure_app_service_exposed/app_service_slot.tf
+++ b/infra/modules/azure_app_service_exposed/app_service_slot.tf
@@ -7,7 +7,6 @@ resource "azurerm_linux_web_app_slot" "this" {
 
   https_only                    = true
   public_network_access_enabled = true
-  virtual_network_subnet_id     = var.azurerm_subnet_id
 
   identity {
     type = "SystemAssigned"
@@ -19,7 +18,6 @@ resource "azurerm_linux_web_app_slot" "this" {
     vnet_route_all_enabled            = true
     health_check_path                 = var.health_check_path
     health_check_eviction_time_in_min = 2
-    ip_restriction_default_action     = "Deny"
 
     application_stack {
       node_version = var.stack == "node" ? "${var.node_version}-lts" : null

--- a/infra/modules/azure_app_service_exposed/variables.tf
+++ b/infra/modules/azure_app_service_exposed/variables.tf
@@ -97,11 +97,3 @@ variable "sticky_app_setting_names" {
   description = "(Optional) A list of application setting names that are not swapped between slots"
   default     = []
 }
-
-# ------------ NETWORKING ------------ #
-
-variable "azurerm_subnet_id" {
-  type        = string
-  description = "(Optional) Id of the subnet the Function App uses for outbound connectivity"
-  default     = null
-}


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

### List of changes
1. Remove networking settings

<!--- Describe your changes in detail -->

### Motivation and context
The current module is misconfigured because setting ip_restriction_default_action to Deny prevents exposing the service to the internet (that is not the expected behaviour of this module).

<!--- Why is this change required? What problem does it solve? -->

