### PR TITLE
[CES-8] - Disabled cancel-in-progress in infra_plan workflow

### DIFF
--- a/.github/workflows/infra_plan.yaml
+++ b/.github/workflows/infra_plan.yaml
@@ -33,7 +33,7 @@ jobs:
     environment: ${{ inputs.environment }}-ci
     concurrency:
       group: ${{ github.workflow }}-ci
-      cancel-in-progress: true
+      cancel-in-progress: false
     permissions:
       id-token: write
       contents: read


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

### List of changes

<!--- Describe your changes in detail -->
Disabled cancel-in-progress in infra_plan workflow

### Motivation and context

<!--- Why is this change required? What problem does it solve? -->
Infrastructure plan workflows in the same concurrency group are now preemptive. The cancellation of a running workflow causes the terraform state to remain locked and make new workflow runs get stuck.

### Type of changes

- [ ] Add new resources
- [ ] Update configuration to existing resources
- [ ] Remove existing resources

### Does this introduce a change to production resources with possible user impact?

- [ ] Yes, users may be impacted applying this change
- [X] No

### Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->
