### PR TITLE
[CES-9] - Avoid overwriting of the terraform plan comment

### DIFF
--- a/.github/workflows/infra_plan.yaml
+++ b/.github/workflows/infra_plan.yaml
@@ -138,7 +138,7 @@ jobs:
               issue_number: context.issue.number
             })
             const botComment = comments.find(comment => {
-              return comment.user.type === 'Bot' && comment.body.includes(`#### 📖 Terraform Plan ('${{ steps.directory.outputs.dir }}')`)
+              return comment.user.type === 'Bot' && comment.body.includes(`Terraform Plan ('${{ steps.directory.outputs.dir }}')`)
             })
             const commentBody = `#### 📖 Terraform Plan ('${{ steps.directory.outputs.dir }}') - ${status}
             <details>

--- a/.github/workflows/infra_plan.yaml
+++ b/.github/workflows/infra_plan.yaml
@@ -138,7 +138,7 @@ jobs:
               issue_number: context.issue.number
             })
             const botComment = comments.find(comment => {
-              return comment.user.type === 'Bot' && comment.body.includes('Terraform Plan')
+              return comment.user.type === 'Bot' && comment.body.includes(`#### 📖 Terraform Plan ('${{ steps.directory.outputs.dir }}')`)
             })
             const commentBody = `#### 📖 Terraform Plan ('${{ steps.directory.outputs.dir }}') - ${status}
             <details>

--- a/.github/workflows/infra_plan.yaml
+++ b/.github/workflows/infra_plan.yaml
@@ -151,20 +151,20 @@ jobs:
             </details>
             `;
             if (botComment) {
-              await github.rest.issues.updateComment({
+              await github.rest.issues.deleteComment({
                 owner: context.repo.owner,
                 repo: context.repo.repo,
-                body: commentBody,
                 comment_id: botComment.id
               })
-            } else {
-              await github.rest.issues.createComment({
-                owner: context.repo.owner,
-                repo: context.repo.repo,
-                body: commentBody,
-                issue_number: context.issue.number
-              })
             }
+            
+            await github.rest.issues.createComment({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              body: commentBody,
+              issue_number: context.issue.number
+            })
+            
 
       # Fail the workflow if the Terraform plan failed
       - name: Check Terraform Plan Result


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

### List of changes

<!--- Describe your changes in detail -->
The selection of the existing comment is now based on the directory that caused the plan.

### Motivation and context

<!--- Why is this change required? What problem does it solve? -->
When an existing comment is selected, it does not check for the directory that plan relates to. For this reason, including the directory in the check should remove the issue of overwriting comments.

### Type of changes

- [ ] Add new resources
- [ ] Update configuration to existing resources
- [ ] Remove existing resources

### Does this introduce a change to production resources with possible user impact?

- [ ] Yes, users may be impacted applying this change
- [X] No

### Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->
