### PR TITLE
fix: App service staging slot name is too long

### DIFF
--- a/infra/modules/azure_app_service/app_service_slot.tf
+++ b/infra/modules/azure_app_service/app_service_slot.tf
@@ -1,7 +1,7 @@
 resource "azurerm_linux_web_app_slot" "this" {
   count = local.app_service.is_slot_enabled
 
-  name = "${local.project}-${var.environment.domain}-${var.environment.app_name}-staging-app-${var.environment.instance_number}"
+  name = local.app_service_slot.name
 
   app_service_id = azurerm_linux_web_app.this.id
 

--- a/infra/modules/azure_app_service/locals.tf
+++ b/infra/modules/azure_app_service/locals.tf
@@ -20,6 +20,10 @@ locals {
     is_slot_enabled        = var.tier == "test" ? 0 : 1
   }
 
+  app_service_slot = {
+    name = "staging-app"
+  }
+
   application_insights = {
     enable = var.application_insights_connection_string != null
   }

--- a/infra/modules/azure_app_service/locals.tf
+++ b/infra/modules/azure_app_service/locals.tf
@@ -21,7 +21,7 @@ locals {
   }
 
   app_service_slot = {
-    name = "staging-app"
+    name = "staging"
   }
 
   application_insights = {


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

### List of changes

<!--- Describe your changes in detail -->
Set app service staging slot name to "staging"

### Motivation and context
The slot staging name is automatically concatenated to the name of the app service, therefore it is not necessary to do it via terraform to prevent extremely long names

<!--- Why is this change required? What problem does it solve? -->

### Type of changes

- [ ] Add new resources
- [X] Update configuration to existing resources
- [ ] Remove existing resources

### Does this introduce a change to production resources with possible user impact?

- [ ] Yes, users may be impacted applying this change
- [X] No

### Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->
