### PR TITLE
Fix Function App module issue against host ID collision

### DIFF
--- a/infra/modules/azure_function_app/README.md
+++ b/infra/modules/azure_function_app/README.md
@@ -12,7 +12,7 @@
 
 | Name | Version |
 |------|---------|
-| <a name="provider_azurerm"></a> [azurerm](#provider\_azurerm) | >= 3.100.0 |
+| <a name="provider_azurerm"></a> [azurerm](#provider\_azurerm) | 3.113.0 |
 
 ## Modules
 

--- a/infra/modules/azure_function_app/function_app.tf
+++ b/infra/modules/azure_function_app/function_app.tf
@@ -44,7 +44,7 @@ resource "azurerm_linux_function_app" "this" {
       SLOT_TASK_HUBNAME = "ProductionTaskHub",
     },
     # https://learn.microsoft.com/en-us/azure/azure-functions/errors-diagnostics/diagnostic-events/azfd0004#options-for-addressing-collisions
-    length(local.function_app.name) > 32 ? { AzureFunctionsWebHost__hostid = "production" } : {},
+    length(local.function_app.name) > 32 && !(contains(keys(var.app_settings), "AzureFunctionsWebHost__hostid")) ? { AzureFunctionsWebHost__hostid = "production" } : {},
     var.app_settings,
     local.application_insights.enable ? {
       # https://docs.microsoft.com/en-us/azure/azure-monitor/app/sampling
@@ -56,8 +56,9 @@ resource "azurerm_linux_function_app" "this" {
     app_setting_names = concat(
       [
         "SLOT_TASK_HUBNAME",
+        "APPINSIGHTS_SAMPLING_PERCENTAGE",
+        "AzureFunctionsWebHost__hostid"
       ],
-      length(local.function_app.name) > 32 ? ["AzureFunctionsWebHost__hostid"] : [],
       var.sticky_app_setting_names,
     )
   }

--- a/infra/modules/azure_function_app/function_app_slot.tf
+++ b/infra/modules/azure_function_app/function_app_slot.tf
@@ -39,13 +39,15 @@ resource "azurerm_linux_function_app_slot" "this" {
       WEBSITE_RUN_FROM_PACKAGE = 1
       # https://docs.microsoft.com/en-us/azure/virtual-network/what-is-ip-address-168-63-129-16
       WEBSITE_DNS_SERVER = "168.63.129.16"
-      # https://docs.microsoft.com/en-us/azure/azure-monitor/app/sampling
-      APPINSIGHTS_SAMPLING_PERCENTAGE = var.application_insights_sampling_percentage
       # https://learn.microsoft.com/en-us/azure/azure-functions/functions-reference?tabs=blob&pivots=programming-language-csharp#connecting-to-host-storage-with-an-identity
       SLOT_TASK_HUBNAME = "StagingTaskHub",
     },
+    local.application_insights.enable ? {
+      # https://docs.microsoft.com/en-us/azure/azure-monitor/app/sampling
+      APPINSIGHTS_SAMPLING_PERCENTAGE = "100"
+    } : {},
     # https://learn.microsoft.com/en-us/azure/azure-functions/errors-diagnostics/diagnostic-events/azfd0004#options-for-addressing-collisions
-    length("${azurerm_linux_function_app.this.name}-${local.function_app_slot.name}") > 32 ? { AzureFunctionsWebHost__hostid = local.function_app_slot.name } : {},
+    length("${azurerm_linux_function_app.this.name}-${local.function_app_slot.name}") > 32 && !(contains(keys(var.slot_app_settings), "AzureFunctionsWebHost__hostid")) ? { AzureFunctionsWebHost__hostid = local.function_app_slot.name } : {},
     var.slot_app_settings
   )
 

--- a/infra/modules/azure_function_app/variables.tf
+++ b/infra/modules/azure_function_app/variables.tf
@@ -88,10 +88,14 @@ variable "app_settings" {
   description = "Application settings"
 
   validation {
-    condition = length(
-      lookup(var.app_settings, "AzureFunctionsWebHost__hostid", "")
-    ) <= 32
-    error_message = "The value for AzureFunctionsWebHost__hostid must not exceed 32 characters."
+    condition = (
+      !(contains(keys(var.app_settings), "AzureFunctionsWebHost__hostid")) ? true :
+      (
+        var.app_settings["AzureFunctionsWebHost__hostid"] == null ? true :
+        length(var.app_settings["AzureFunctionsWebHost__hostid"]) <= 32
+      )
+    )
+    error_message = "The value for AzureFunctionsWebHost__hostid must be null or must not exceed 32 characters."
   }
 }
 
@@ -101,10 +105,14 @@ variable "slot_app_settings" {
   default     = {}
 
   validation {
-    condition = length(
-      lookup(var.slot_app_settings, "AzureFunctionsWebHost__hostid", "")
-    ) <= 32
-    error_message = "The value for AzureFunctionsWebHost__hostid must not exceed 32 characters."
+    condition = (
+      !(contains(keys(var.slot_app_settings), "AzureFunctionsWebHost__hostid")) ? true :
+      (
+        var.slot_app_settings["AzureFunctionsWebHost__hostid"] == null ? true :
+        length(var.slot_app_settings["AzureFunctionsWebHost__hostid"]) <= 32
+      )
+    )
+    error_message = "The value for AzureFunctionsWebHost__hostid must be null or must not exceed 32 characters."
   }
 }
 

--- a/infra/modules/azure_function_app/variables.tf
+++ b/infra/modules/azure_function_app/variables.tf
@@ -99,6 +99,13 @@ variable "slot_app_settings" {
   type        = map(string)
   description = "Staging slot application settings"
   default     = {}
+
+  validation {
+    condition = length(
+      lookup(var.slot_app_settings, "AzureFunctionsWebHost__hostid", "")
+    ) <= 32
+    error_message = "The value for AzureFunctionsWebHost__hostid must not exceed 32 characters."
+  }
 }
 
 variable "sticky_app_setting_names" {

--- a/infra/modules/azure_function_app/variables.tf
+++ b/infra/modules/azure_function_app/variables.tf
@@ -86,6 +86,13 @@ variable "application_insights_sampling_percentage" {
 variable "app_settings" {
   type        = map(string)
   description = "Application settings"
+
+  validation {
+    condition = length(
+      lookup(var.app_settings, "AzureFunctionsWebHost__hostid", "")
+    ) <= 32
+    error_message = "The value for AzureFunctionsWebHost__hostid must not exceed 32 characters."
+  }
 }
 
 variable "slot_app_settings" {

--- a/infra/resources/dev/.terraform.lock.hcl
+++ b/infra/resources/dev/.terraform.lock.hcl
@@ -2,25 +2,24 @@
 # Manual edits may be lost in future updates.
 
 provider "registry.terraform.io/hashicorp/azurerm" {
-  version     = "3.100.0"
-  constraints = "<= 3.100.0"
+  version     = "3.114.0"
+  constraints = "~> 3.30, >= 3.100.0, <= 3.114.0"
   hashes = [
-    "h1:+4FqPxz8dEwP4YMolGItV7ZvUHVZ48aDCPbSBrqF4Wo=",
-    "h1:/3X1KgoKBqJo0xe3XDUD0fxfqUK+0Fn8SghwvwY+BIA=",
-    "h1:LT5rJLMwtCzHaGWOiV30hnFSaC/SL3QJRhN6yBpNTog=",
-    "h1:enbRDNbwcLJ5xx6CN1QlbqOG64gu4LwC2ayue0WoyP0=",
-    "h1:ikA/yAt8g/dS+FcbNBPY6E2KVafjNKkiUCOZmyiTfwY=",
-    "zh:20c3259fd94ab41c6c3425fb428d8bd279addb755c8ea1fe0b3e1c3bea4363cb",
-    "zh:4c4a8d5dbd8a9d7b60934b0ffed442fe50ab1b0559b9693399e3f66eca53d045",
-    "zh:7c21f569b839e40d4976beb6143adaccc5688d1a754dde054cb6f19ca33576b2",
-    "zh:88042b599de9ff8ec200e26636e06682e024a28331c4c48db8589d6a03279a8a",
-    "zh:95c20834eee3b46a85e338988bf14a9a70f74f9cae45ec934cf157dedaa40f28",
-    "zh:beeed81f4483dec0b64bf1aaf611c5030ad6e4c88c4bd75f956835653a1a29c0",
-    "zh:d76fa7371648b5bdc17115b5e42fa616fe4c6d2998f727a0956c0bddc4842365",
-    "zh:d89fcaa83a1ff7c9f29c49b31c60c29d8a84486e11d34573d767a5cd208da7d8",
-    "zh:ddbe18aee99fb7e2c93343f7f8a95837461a047ca660553c88c873761205ed76",
-    "zh:e6e70c7635bb4472810bfd0a31949640e72c535e6e8707454ea7e86dcb5fcd89",
-    "zh:f0575689ce28e220bc8daa4d2fefbfd90afde01a14343c61dfd6489960e22ff4",
+    "h1:9gfR0VCUpoynii31LxsLaK9fV1blcnJQi3vnjJLSiaI=",
+    "h1:af8gzp2nuiJVXGW2v3Ch9+W/SjbwFCTpWaylAhbiby4=",
+    "h1:fIM8Lbg5w2m2HbETUx+aAYnTVtktETwOqnKZyVVajIo=",
+    "h1:sP1K3rtDj2pVQqBBn50rOXe+QPFBAKRbI2uExOxnh3M=",
+    "zh:016b6f4662d1cfcddbe968624e899c1a20c6df0ed5014cdeed19c3e945ea80ee",
+    "zh:08448eeaaa9e9e84a2887282f9524faa2bb000fbdfcdac610c088a74e36e6911",
+    "zh:17975bb18d0ad3e2530261773e4fbfae078bfc4db4e0a5458b823b3ec79642e1",
+    "zh:3030ad1b13fe487ce791c851c6b5f3035af08f60b335d7be5ce6ce76af43062f",
+    "zh:68b2914edae1049506aab9f2c11c5b2b2c8d01aa3e0ad53e07ce75ae58906a45",
+    "zh:cffa9af324a0c621317b6d33f80a28159d01706846877d5784d37dad76635d78",
+    "zh:d36d44617b890a8a6d404a016c10428c3393e072d484addfb56334183893998b",
+    "zh:d5c217d7a24b32b18cb9ad47544050c5ec9e6b40ce3f34ff37be5e2d232b4dad",
+    "zh:d5cd83a9701a9bcd17bbd86beb5accdc6c487fcfa472b868bc581e4d5b67d59d",
+    "zh:f4ba0bd65d9a10f8185e163217e10e5fa91e386c68e6773c188881b088315477",
     "zh:f569b65999264a9416862bca5cd2a6177d94ccb0424f3a4ef424428912b9cb3c",
+    "zh:f807554e5e08e38e6526e363641219e89ad9eda0b24ec09f25e61c74eece2490",
   ]
 }

--- a/infra/resources/dev/README.md
+++ b/infra/resources/dev/README.md
@@ -6,7 +6,7 @@
 
 | Name | Version |
 |------|---------|
-| <a name="requirement_azurerm"></a> [azurerm](#requirement\_azurerm) | <= 3.111.0 |
+| <a name="requirement_azurerm"></a> [azurerm](#requirement\_azurerm) | <= 3.114.0 |
 
 ## Providers
 

--- a/infra/resources/dev/main.tf
+++ b/infra/resources/dev/main.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     azurerm = {
       source  = "hashicorp/azurerm"
-      version = "<= 3.111.0"
+      version = "<= 3.114.0"
     }
   }
 
@@ -10,7 +10,7 @@ terraform {
     resource_group_name  = "terraform-state-rg"
     storage_account_name = "tfdevdx"
     container_name       = "terraform-state"
-    key                  = "dx.resources.tfstate"
+    key                  = "dx.resources.dev.tfstate"
   }
 }
 


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

### List of changes

<!--- Describe your changes in detail -->
Fix the issue by adding `AzureFunctionsWebHost__hostid` a sticky setting.

Add validation to avoid double entry for `AzureFunctionsWebHost__hostid` key in case of is already passed by the client.
Set `APPINSIGHTS_SAMPLING_PERCENTAGE` as sticky setting and set it to 100% for staging slot

Update azurerm provider and state file name

### Motivation and context

<!--- Why is this change required? What problem does it solve? -->

An issue with host id collision was found. Steps to reproduce it:
- Create a function so that staging function name is longer than 32 chars (i.e. `ts-d-itn-consumers-01`
- The Function App will use the default value for `AzureFunctionsWebHost__hostid`, while the staging slot overrides it using `staging` as it is longer than 32 chars
- When swapping the slots, the main one takes `staging` as value as well, so the two host ids collide and staging slot loses the app setting

Adding the key name in sticky setting list fixes the issue

### Type of changes

- [ ] Add new resources
- [X] Update configuration to existing resources
- [ ] Remove existing resources

### Does this introduce a change to production resources with possible user impact?

- [ ] Yes, users may be impacted applying this change
- [X] No

### Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->
