### PR TITLE
Add optional slot swap

### DIFF
--- a/.github/workflows/web_app_deploy.yaml
+++ b/.github/workflows/web_app_deploy.yaml
@@ -127,8 +127,8 @@ jobs:
 
   deploy:
     name: Deploy
-    if: ${{ !github.event.act }}
-    needs: [build]
+    if: ${{ always() && !github.event.act }}
+    needs:  [build]
     runs-on: ${{ inputs.use_private_agent == true && 'self-hosted' || 'ubuntu-22-04' }}
     environment: ${{ inputs.environment }}-cd
     permissions:

--- a/.github/workflows/web_app_deploy.yaml
+++ b/.github/workflows/web_app_deploy.yaml
@@ -32,6 +32,11 @@ on:
         type: boolean
         required: false
         default: true
+      skip_artifact_creation:
+        description: Skip Artifact creation when is already created by another step
+        type: boolean
+        required: false
+        default: false
 
 concurrency:
   group: ${{ github.workflow }}-cd
@@ -46,6 +51,7 @@ jobs:
     runs-on: ubuntu-22.04
     env:
       WORKSPACE: ${{ inputs.workspace_name }}
+    if: ${{ !inputs.skip_artifact_creation }}
 
     steps:
       - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1

--- a/.github/workflows/web_app_deploy.yaml
+++ b/.github/workflows/web_app_deploy.yaml
@@ -22,6 +22,16 @@ on:
         type: boolean
         required: false
         default: true
+      health_check_path:
+        description: The health probe path exposed by the Web App.
+        type: string
+        default: ""
+        required: false
+      skip_swap_step:
+        description: Skip slot swap for selective deployment and testing.
+        type: boolean
+        default: false
+        required: false
       use_private_agent:
         description: Use a private agent to deploy the built artifact.
         type: boolean
@@ -160,8 +170,17 @@ jobs:
            --type zip \
            --async false
 
+      - name: Ping Staging Health
+        if: ${{ inputs.use_staging_slot == 'true' && input.health_check_path != ''}}
+        run: |
+          curl \
+            --retry 5 \
+            --retry-max-time 120 \
+            --retry-all-errors \
+            -f 'https://${{ inputs.web_app_name }}-staging.azurewebsites.net${{ inputs.health_check_path }}'
+
       - name: Swap Staging and Production Slots
-        if: ${{ inputs.use_staging_slot == true }}
+        if: ${{ inputs.use_staging_slot == true && input.skip_swap_step == false }}
         run: |
           az webapp deployment slot swap \
             -g ${{ inputs.resource_group_name }} \

--- a/.github/workflows/web_app_deploy.yaml
+++ b/.github/workflows/web_app_deploy.yaml
@@ -32,11 +32,11 @@ on:
         type: boolean
         required: false
         default: true
-      skip_artifact_creation:
-        description: Skip Artifact creation when is already created by another step
+      use_create_artifact:
+        description: Use the job to create a new artifact
         type: boolean
         required: false
-        default: false
+        default: true
 
 concurrency:
   group: ${{ github.workflow }}-cd
@@ -51,7 +51,7 @@ jobs:
     runs-on: ubuntu-22.04
     env:
       WORKSPACE: ${{ inputs.workspace_name }}
-    if: ${{ !inputs.skip_artifact_creation }}
+    if: ${{ inputs.use_create_artifact }}
 
     steps:
       - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1

--- a/.github/workflows/web_app_deploy.yaml
+++ b/.github/workflows/web_app_deploy.yaml
@@ -171,7 +171,7 @@ jobs:
            --async false
 
       - name: Ping Staging Health
-        if: ${{ inputs.use_staging_slot == 'true' && input.health_check_path != ''}}
+        if: ${{ inputs.use_staging_slot == 'true' && inputs.health_check_path != ''}}
         run: |
           curl \
             --retry 5 \

--- a/.github/workflows/web_app_deploy.yaml
+++ b/.github/workflows/web_app_deploy.yaml
@@ -180,7 +180,7 @@ jobs:
             -f 'https://${{ inputs.web_app_name }}-staging.azurewebsites.net${{ inputs.health_check_path }}'
 
       - name: Swap Staging and Production Slots
-        if: ${{ inputs.use_staging_slot == true && input.skip_swap_step == false }}
+        if: ${{ inputs.use_staging_slot == true && inputs.skip_swap_step == false }}
         run: |
           az webapp deployment slot swap \
             -g ${{ inputs.resource_group_name }} \

--- a/.github/workflows/web_app_deploy.yaml
+++ b/.github/workflows/web_app_deploy.yaml
@@ -22,15 +22,10 @@ on:
         type: boolean
         required: false
         default: true
-      health_check_path:
-        description: The health probe path exposed by the Web App.
-        type: string
-        default: ""
-        required: false
-      skip_swap_step:
+      swap_slot_step:
         description: Skip slot swap for selective deployment and testing.
         type: boolean
-        default: false
+        default: true
         required: false
       use_private_agent:
         description: Use a private agent to deploy the built artifact.
@@ -170,17 +165,11 @@ jobs:
            --type zip \
            --async false
 
-      - name: Ping Staging Health
-        if: ${{ inputs.use_staging_slot == 'true' && inputs.health_check_path != ''}}
-        run: |
-          curl \
-            --retry 5 \
-            --retry-max-time 120 \
-            --retry-all-errors \
-            -f 'https://${{ inputs.web_app_name }}-staging.azurewebsites.net${{ inputs.health_check_path }}'
+      # Ping healthcheck endpoint in not needed when the webapp has a custom warmup
+      # configuration https://learn.microsoft.com/en-us/azure/app-service/deploy-staging-slots?tabs=portal#specify-custom-warm-up
 
       - name: Swap Staging and Production Slots
-        if: ${{ inputs.use_staging_slot == true && inputs.skip_swap_step == false }}
+        if: ${{ inputs.use_staging_slot == true && inputs.swap_slot_step == true }}
         run: |
           az webapp deployment slot swap \
             -g ${{ inputs.resource_group_name }} \

--- a/.github/workflows/web_app_deploy.yaml
+++ b/.github/workflows/web_app_deploy.yaml
@@ -23,7 +23,7 @@ on:
         required: false
         default: true
       swap_slot_step:
-        description: Skip slot swap for selective deployment and testing.
+        description: Swap production and staging slot.
         type: boolean
         default: true
         required: false


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

### List of changes
Add some improvements in deploy webapp pipeline:
- Add ping health check endpoint when a slot is present
- Add optional swap step configuration for selective deploy in production

<!--- Describe your changes in detail -->

### Motivation and context
The deploy pipeline has not a step that verify that the health check endpoint is alive after the deployment. A broken web app could be deployed causing production outages.
For some kind of deploy the team should have the possibility to deploy only on staging slots testing the application before the production switch. Moreover some deploy could be handled with progressive traffic routing between stage and productions slots.

<!--- Why is this change required? What problem does it solve? -->

### Type of changes

- [ ] Add new resources
- [X] Update configuration to existing resources
- [ ] Remove existing resources

### Does this introduce a change to production resources with possible user impact?

- [ ] Yes, users may be impacted applying this change
- [X] No

### Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->
