### PR TITLE
[CES-12] Added a Keep Alive action to keep the repository active when it contains cron actions

### DIFF
--- a/.github/actions/keep-alive/action.yaml
+++ b/.github/actions/keep-alive/action.yaml
@@ -6,8 +6,6 @@ runs:
   steps:
     - name: Checkout
       uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
-      with:
-        fetch-depth: 0 # Recover all the commit history to be sure that main commit is here
 
     - name: keep-alive
       shell: bash

--- a/.github/actions/keep-alive/action.yaml
+++ b/.github/actions/keep-alive/action.yaml
@@ -12,5 +12,5 @@ runs:
       run: |
         git config --local user.email "cron@github.com"
         git config --local user.name "Keepalive"
-        git commit --allow-empty -m "Keeping the repository alive" --dry-run || echo "No changes to commit"
-        # git push
+        git commit --allow-empty -m "Keeping the repository alive" || echo "No changes to commit"
+        git push

--- a/.github/actions/keep-alive/action.yaml
+++ b/.github/actions/keep-alive/action.yaml
@@ -1,0 +1,18 @@
+name: Keep Alive
+description: An action to keep the repository alive.
+
+runs:
+  using: composite
+  steps:
+    - name: Checkout
+      uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
+      with:
+        fetch-depth: 0 # Recover all the commit history to be sure that main commit is here
+
+    - name: keep-alive
+      shell: bash
+      run: |
+        git config --local user.email "cron@github.com"
+        git config --local user.name "Keepalive"
+        git commit --allow-empty -m "Keeping the repository alive" || echo "No changes to commit"
+        git push

--- a/.github/actions/keep-alive/action.yaml
+++ b/.github/actions/keep-alive/action.yaml
@@ -12,5 +12,5 @@ runs:
       run: |
         git config --local user.email "cron@github.com"
         git config --local user.name "Keepalive"
-        git commit --allow-empty -m "Keeping the repository alive" || echo "No changes to commit"
-        git push
+        git commit --allow-empty -m "Keeping the repository alive" --dry-run || echo "No changes to commit"
+        # git push

--- a/.github/workflows/infra_drift_detection.yml
+++ b/.github/workflows/infra_drift_detection.yml
@@ -228,3 +228,17 @@ jobs:
         env:
           SLACK_WEBHOOK_URL: ${{ env.SLACK_WEBHOOK_URL }}
           SLACK_WEBHOOK_TYPE: ${{ env.SLACK_WEBHOOK_TYPE }}
+
+  keep_alive:
+    if: ${{ github.event_name == 'schedule' }}
+    needs: terraform_driftdetection_job
+    runs-on: 'ubuntu-20.04'
+    permissions:
+      actions: read
+    steps:
+      - name: Checkout
+        uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.7
+
+      - name: Keep Alive
+        uses: ./.github/actions/keep-alive/action.yaml
+        

--- a/.github/workflows/infra_drift_detection.yml
+++ b/.github/workflows/infra_drift_detection.yml
@@ -228,17 +228,3 @@ jobs:
         env:
           SLACK_WEBHOOK_URL: ${{ env.SLACK_WEBHOOK_URL }}
           SLACK_WEBHOOK_TYPE: ${{ env.SLACK_WEBHOOK_TYPE }}
-
-  keep_alive:
-    if: ${{ github.event_name == 'schedule' }}
-    needs: terraform_driftdetection_job
-    runs-on: 'ubuntu-20.04'
-    permissions:
-      actions: read
-    steps:
-      - name: Checkout
-        uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.7
-
-      - name: Keep Alive
-        uses: ./.github/actions/keep-alive/action.yaml
-        

--- a/.github/workflows/keep_alive_repository.yml
+++ b/.github/workflows/keep_alive_repository.yml
@@ -1,0 +1,38 @@
+name: Keep Alive
+
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: '0 0 * * *' # Run at 00:00 every day
+  push:
+    branches:
+      - CES-12-keepalive
+
+jobs:
+  keep_alive:
+    runs-on: 'ubuntu-20.04'
+    permissions:
+      contents: read
+      actions: write
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.7
+
+      - name: Calculate days since last commit
+        id: commit_date
+        run: |
+          LAST_COMMIT_DATE=$(git log -1 --format=%ct)
+          echo "Last commit date: $LAST_COMMIT_DATE"
+
+          CURRENT_DATE=$(date +%s)
+          echo "Current date: $CURRENT_DATE"
+
+          DIFFERENCE=$(( ($CURRENT_DATE - $LAST_COMMIT_DATE) / 86400 ))
+          echo "Days since last commit: $DIFFERENCE"
+
+          echo "days_since_commit=$DIFFERENCE" >> $GITHUB_ENV
+
+      - name: Keep Alive
+        if: steps.commit_date.outputs.days_since_commit == '59'
+        uses: ./.github/actions/keep-alive/action.yaml

--- a/.github/workflows/keep_alive_repository.yml
+++ b/.github/workflows/keep_alive_repository.yml
@@ -2,7 +2,7 @@ name: Keep Alive
 
 # This workflow is designed to keep the repository active.
 # GitHub automatically disables all actions with a cron trigger after 60 days of inactivity.
-# This action checks if there has been a commit in the last 59 days. 
+# This action checks if there has been a commit in the last 55 days. 
 # If a commit is found within this timeframe, the workflow does nothing,
 # however, if no commits have been made, it performs an empty push to keep the repository active.
 
@@ -38,6 +38,6 @@ jobs:
           echo "days_since_commit=$DIFFERENCE" >> $GITHUB_ENV
 
       - name: Keep Alive
-        # If 59 days have passed then execute the action which makes an empty push
-        if: steps.commit_date.outputs.days_since_commit >= '59'
+        # If 55 days have passed then execute the action which makes an empty push
+        if: steps.commit_date.outputs.days_since_commit >= '55'
         uses: ./.github/actions/keep-alive

--- a/.github/workflows/keep_alive_repository.yml
+++ b/.github/workflows/keep_alive_repository.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on: 'ubuntu-20.04'
     permissions:
       contents: read
-      actions: read
+      actions: write
 
     steps:
       - name: Checkout

--- a/.github/workflows/keep_alive_repository.yml
+++ b/.github/workflows/keep_alive_repository.yml
@@ -35,4 +35,4 @@ jobs:
 
       - name: Keep Alive
         if: steps.commit_date.outputs.days_since_commit == '0'
-        uses: ./.github/actions/keep-alive/action.yaml
+        uses: ./.github/actions/keep-alive

--- a/.github/workflows/keep_alive_repository.yml
+++ b/.github/workflows/keep_alive_repository.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on: 'ubuntu-20.04'
     permissions:
       contents: read
-      actions: write
+      actions: read
 
     steps:
       - name: Checkout
@@ -34,5 +34,5 @@ jobs:
           echo "days_since_commit=$DIFFERENCE" >> $GITHUB_ENV
 
       - name: Keep Alive
-        if: steps.commit_date.outputs.days_since_commit == '59'
+        if: steps.commit_date.outputs.days_since_commit == '0'
         uses: ./.github/actions/keep-alive/action.yaml

--- a/.github/workflows/keep_alive_repository.yml
+++ b/.github/workflows/keep_alive_repository.yml
@@ -1,5 +1,11 @@
 name: Keep Alive
 
+# This workflow is designed to keep the repository active.
+# GitHub automatically disables all actions with a cron trigger after 60 days of inactivity.
+# This action checks if there has been a commit in the last 59 days. 
+# If a commit is found within this timeframe, the workflow does nothing,
+# however, if no commits have been made, it performs an empty push to keep the repository active.
+
 on:
   workflow_dispatch:
   schedule:
@@ -25,11 +31,13 @@ jobs:
           CURRENT_DATE=$(date +%s)
           echo "Current date: $CURRENT_DATE"
 
+          # Calculate how many days have passed since the last commit
           DIFFERENCE=$(( ($CURRENT_DATE - $LAST_COMMIT_DATE) / 86400 ))
           echo "Days since last commit: $DIFFERENCE"
 
           echo "days_since_commit=$DIFFERENCE" >> $GITHUB_ENV
 
       - name: Keep Alive
-        if: steps.commit_date.outputs.days_since_commit == '59'
+        # If 59 days have passed then execute the action which makes an empty push
+        if: steps.commit_date.outputs.days_since_commit >= '59'
         uses: ./.github/actions/keep-alive

--- a/.github/workflows/keep_alive_repository.yml
+++ b/.github/workflows/keep_alive_repository.yml
@@ -4,9 +4,6 @@ on:
   workflow_dispatch:
   schedule:
     - cron: '0 0 * * *' # Run at 00:00 every day
-  push:
-    branches:
-      - CES-12-keepalive
 
 jobs:
   keep_alive:
@@ -34,5 +31,5 @@ jobs:
           echo "days_since_commit=$DIFFERENCE" >> $GITHUB_ENV
 
       - name: Keep Alive
-        if: steps.commit_date.outputs.days_since_commit == '0'
+        if: steps.commit_date.outputs.days_since_commit == '59'
         uses: ./.github/actions/keep-alive


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

### List of changes

<!--- Describe your changes in detail -->
Added `keep-alive` action and `keep_alive_repository` workflow

### Motivation and context

<!--- Why is this change required? What problem does it solve? -->
If there are actions in a repository that work with a trigger `schedule`, GitHub will disable them after `60` days if there have been no commits in the repo, in this way we have a workflow that checks every day if `59` days have passed, if so, it does an empty push to revitalize the repository, otherwise it does nothing.

### Type of changes

- [x] Add new resources
- [ ] Update configuration to existing resources
- [ ] Remove existing resources

### Does this introduce a change to production resources with possible user impact?

- [ ] Yes, users may be impacted applying this change
- [x] No

### Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->
