### PR TITLE
fix: fix pessimistic constraint on azure role assignment module

### DIFF
--- a/infra/modules/azure_app_service/README.md
+++ b/infra/modules/azure_app_service/README.md
@@ -12,7 +12,7 @@
 
 | Name | Version |
 |------|---------|
-| <a name="provider_azurerm"></a> [azurerm](#provider\_azurerm) | 3.113.0 |
+| <a name="provider_azurerm"></a> [azurerm](#provider\_azurerm) | 3.107.0 |
 
 ## Modules
 

--- a/infra/modules/azure_app_service_exposed/README.md
+++ b/infra/modules/azure_app_service_exposed/README.md
@@ -14,7 +14,7 @@ This module is used to create an Azure App Service, allowing it to be configured
 
 | Name | Version |
 |------|---------|
-| <a name="provider_azurerm"></a> [azurerm](#provider\_azurerm) | 3.113.0 |
+| <a name="provider_azurerm"></a> [azurerm](#provider\_azurerm) | 3.111.0 |
 
 ## Modules
 

--- a/infra/modules/azure_app_service_plan_autoscaler/README.md
+++ b/infra/modules/azure_app_service_plan_autoscaler/README.md
@@ -12,7 +12,7 @@
 
 | Name | Version |
 |------|---------|
-| <a name="provider_azurerm"></a> [azurerm](#provider\_azurerm) | 3.113.0 |
+| <a name="provider_azurerm"></a> [azurerm](#provider\_azurerm) | 3.110.0 |
 
 ## Modules
 

--- a/infra/modules/azure_federated_identity_with_github/README.md
+++ b/infra/modules/azure_federated_identity_with_github/README.md
@@ -12,7 +12,7 @@
 
 | Name | Version |
 |------|---------|
-| <a name="provider_azurerm"></a> [azurerm](#provider\_azurerm) | 3.114.0 |
+| <a name="provider_azurerm"></a> [azurerm](#provider\_azurerm) | 3.97.1 |
 
 ## Modules
 

--- a/infra/modules/azure_function_app/README.md
+++ b/infra/modules/azure_function_app/README.md
@@ -12,7 +12,7 @@
 
 | Name | Version |
 |------|---------|
-| <a name="provider_azurerm"></a> [azurerm](#provider\_azurerm) | 3.113.0 |
+| <a name="provider_azurerm"></a> [azurerm](#provider\_azurerm) | 3.107.0 |
 
 ## Modules
 

--- a/infra/modules/azure_role_assignments/README.md
+++ b/infra/modules/azure_role_assignments/README.md
@@ -3,7 +3,7 @@
 
 | Name | Version |
 |------|---------|
-| <a name="requirement_azurerm"></a> [azurerm](#requirement\_azurerm) | ~> 3.106.0 |
+| <a name="requirement_azurerm"></a> [azurerm](#requirement\_azurerm) | ~> 3.106 |
 
 ## Providers
 

--- a/infra/modules/azure_role_assignments/providers.tf
+++ b/infra/modules/azure_role_assignments/providers.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     azurerm = {
       source  = "hashicorp/azurerm"
-      version = "~> 3.106.0"
+      version = "~> 3.106"
     }
   }
 }

--- a/infra/modules/github_selfhosted_runner_on_container_app_jobs/README.md
+++ b/infra/modules/github_selfhosted_runner_on_container_app_jobs/README.md
@@ -12,7 +12,7 @@
 
 | Name | Version |
 |------|---------|
-| <a name="provider_azurerm"></a> [azurerm](#provider\_azurerm) | 3.114.0 |
+| <a name="provider_azurerm"></a> [azurerm](#provider\_azurerm) | 3.97.1 |
 
 ## Modules
 


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

### List of changes

<!--- Describe your changes in detail -->
Reduced pessimistic constraint being to strict on azure role assignment module

### Motivation and context

<!--- Why is this change required? What problem does it solve? -->
The constraint was forcing to use 3.106.* azure provider versions

### Type of changes

- [ ] Add new resources
- [ ] Update configuration to existing resources
- [ ] Remove existing resources

### Does this introduce a change to production resources with possible user impact?

- [ ] Yes, users may be impacted applying this change
- [ ] No

### Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->
