### PR TITLE
[DEVEX-137] Imported alerts in Azure Functions App module

### DIFF
--- a/infra/modules/azure_function_app/README.md
+++ b/infra/modules/azure_function_app/README.md
@@ -12,7 +12,7 @@
 
 | Name | Version |
 |------|---------|
-| <a name="provider_azurerm"></a> [azurerm](#provider\_azurerm) | 3.107.0 |
+| <a name="provider_azurerm"></a> [azurerm](#provider\_azurerm) | 3.114.0 |
 
 ## Modules
 
@@ -26,6 +26,8 @@
 |------|------|
 | [azurerm_linux_function_app.this](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/linux_function_app) | resource |
 | [azurerm_linux_function_app_slot.this](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/linux_function_app_slot) | resource |
+| [azurerm_monitor_metric_alert.function_app_health_check](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/monitor_metric_alert) | resource |
+| [azurerm_monitor_metric_alert.storage_account_health_check](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/monitor_metric_alert) | resource |
 | [azurerm_private_endpoint.function_sites](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/private_endpoint) | resource |
 | [azurerm_private_endpoint.st_blob](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/private_endpoint) | resource |
 | [azurerm_private_endpoint.st_file](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/private_endpoint) | resource |
@@ -52,6 +54,7 @@
 
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
+| <a name="input_alert_config"></a> [alert\_config](#input\_alert\_config) | Set the Action Group Id to invoke when the Function App alert triggers and related webhook | <pre>object({<br>    action_group_id    = string<br>    webhook_properties = map(string)<br>  })</pre> | n/a | yes |
 | <a name="input_app_service_plan_id"></a> [app\_service\_plan\_id](#input\_app\_service\_plan\_id) | (Optional) Set the AppService Id where you want to host the Function App | `string` | `null` | no |
 | <a name="input_app_settings"></a> [app\_settings](#input\_app\_settings) | Application settings | `map(string)` | n/a | yes |
 | <a name="input_application_insights_connection_string"></a> [application\_insights\_connection\_string](#input\_application\_insights\_connection\_string) | (Optional) Application Insights connection string | `string` | `null` | no |

--- a/infra/modules/azure_function_app/README.md
+++ b/infra/modules/azure_function_app/README.md
@@ -54,7 +54,7 @@
 
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
-| <a name="input_alert_config"></a> [alert\_config](#input\_alert\_config) | Set the Action Group Id to invoke when the Function App alert triggers and related webhook | <pre>object({<br>    action_group_id    = string<br>    webhook_properties = map(string)<br>  })</pre> | `null` | no |
+| <a name="input_action_group_id"></a> [action\_group\_id](#input\_action\_group\_id) | Set the Action Group Id to invoke when the Function App alert triggers | `string` | `null` | no |
 | <a name="input_app_service_plan_id"></a> [app\_service\_plan\_id](#input\_app\_service\_plan\_id) | (Optional) Set the AppService Id where you want to host the Function App | `string` | `null` | no |
 | <a name="input_app_settings"></a> [app\_settings](#input\_app\_settings) | Application settings | `map(string)` | n/a | yes |
 | <a name="input_application_insights_connection_string"></a> [application\_insights\_connection\_string](#input\_application\_insights\_connection\_string) | (Optional) Application Insights connection string | `string` | `null` | no |

--- a/infra/modules/azure_function_app/README.md
+++ b/infra/modules/azure_function_app/README.md
@@ -54,7 +54,7 @@
 
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
-| <a name="input_alert_config"></a> [alert\_config](#input\_alert\_config) | Set the Action Group Id to invoke when the Function App alert triggers and related webhook | <pre>object({<br>    action_group_id    = string<br>    webhook_properties = map(string)<br>  })</pre> | n/a | yes |
+| <a name="input_alert_config"></a> [alert\_config](#input\_alert\_config) | Set the Action Group Id to invoke when the Function App alert triggers and related webhook | <pre>object({<br>    action_group_id    = string<br>    webhook_properties = map(string)<br>  })</pre> | `null` | no |
 | <a name="input_app_service_plan_id"></a> [app\_service\_plan\_id](#input\_app\_service\_plan\_id) | (Optional) Set the AppService Id where you want to host the Function App | `string` | `null` | no |
 | <a name="input_app_settings"></a> [app\_settings](#input\_app\_settings) | Application settings | `map(string)` | n/a | yes |
 | <a name="input_application_insights_connection_string"></a> [application\_insights\_connection\_string](#input\_application\_insights\_connection\_string) | (Optional) Application Insights connection string | `string` | `null` | no |

--- a/infra/modules/azure_function_app/alerts.tf
+++ b/infra/modules/azure_function_app/alerts.tf
@@ -52,9 +52,12 @@ resource "azurerm_monitor_metric_alert" "storage_account_health_check" {
     skip_metric_validation = false
   }
 
-  action {
-    action_group_id    = var.alert_config.action_group_id
-    webhook_properties = var.alert_config.webhook_properties
+  dynamic "action" {
+    for_each = var.alert_config == null ? [] : ["dummy"]
+    content {
+      action_group_id    = var.alert_config.action_group_id
+      webhook_properties = var.alert_config.webhook_properties
+    }
   }
 
   tags = var.tags

--- a/infra/modules/azure_function_app/alerts.tf
+++ b/infra/modules/azure_function_app/alerts.tf
@@ -19,10 +19,9 @@ resource "azurerm_monitor_metric_alert" "function_app_health_check" {
   }
 
   dynamic "action" {
-    for_each = var.alert_config == null ? [] : ["dummy"]
+    for_each = var.action_group_id == null ? [] : ["dummy"]
     content {
-      action_group_id    = var.alert_config.action_group_id
-      webhook_properties = var.alert_config.webhook_properties
+      action_group_id = var.action_group_id
     }
   }
 
@@ -53,10 +52,9 @@ resource "azurerm_monitor_metric_alert" "storage_account_health_check" {
   }
 
   dynamic "action" {
-    for_each = var.alert_config == null ? [] : ["dummy"]
+    for_each = var.action_group_id == null ? [] : ["dummy"]
     content {
-      action_group_id    = var.alert_config.action_group_id
-      webhook_properties = var.alert_config.webhook_properties
+      action_group_id = var.action_group_id
     }
   }
 

--- a/infra/modules/azure_function_app/alerts.tf
+++ b/infra/modules/azure_function_app/alerts.tf
@@ -1,0 +1,61 @@
+resource "azurerm_monitor_metric_alert" "function_app_health_check" {
+  count = var.tier == "test" ? 0 : 1
+
+  name                = local.function_app.alert
+  resource_group_name = var.resource_group_name
+  scopes              = [azurerm_linux_function_app.this.id]
+  description         = "Function availability is under threshold level. Runbook: -"
+  severity            = 1
+  frequency           = "PT5M"
+  auto_mitigate       = false
+  enabled             = true
+
+  criteria {
+    metric_namespace = "Microsoft.Web/sites"
+    metric_name      = "HealthCheckStatus"
+    aggregation      = "Average"
+    operator         = "LessThan"
+    threshold        = 50
+  }
+
+  dynamic "action" {
+    for_each = var.alert_config == null ? [] : ["dummy"]
+    content {
+      action_group_id    = var.alert_config.action_group_id
+      webhook_properties = var.alert_config.webhook_properties
+    }
+  }
+
+  tags = var.tags
+}
+
+resource "azurerm_monitor_metric_alert" "storage_account_health_check" {
+  count = var.tier == "test" ? 0 : 1
+
+  name                = local.storage_account.alert
+  resource_group_name = var.resource_group_name
+  scopes              = [azurerm_storage_account.this.id]
+  description         = "The average availability is less than 99.8%. Runbook: not needed."
+  severity            = 0
+  window_size         = "PT5M"
+  frequency           = "PT5M"
+  auto_mitigate       = false
+
+  # Metric info
+  # https://learn.microsoft.com/en-us/azure/azure-monitor/essentials/metrics-supported#microsoftstoragestorageaccounts
+  criteria {
+    metric_namespace       = "Microsoft.Storage/storageAccounts"
+    metric_name            = "Availability"
+    aggregation            = "Average"
+    operator               = "LessThan"
+    threshold              = 99.8
+    skip_metric_validation = false
+  }
+
+  action {
+    action_group_id    = var.alert_config.action_group_id
+    webhook_properties = var.alert_config.webhook_properties
+  }
+
+  tags = var.tags
+}

--- a/infra/modules/azure_function_app/locals.tf
+++ b/infra/modules/azure_function_app/locals.tf
@@ -1,7 +1,8 @@
 locals {
-  location_short = var.environment.location == "italynorth" ? "itn" : var.environment.location == "westeurope" ? "weu" : var.environment.location == "germanywestcentral" ? "gwc" : "neu"
-  project        = "${var.environment.prefix}-${var.environment.env_short}-${local.location_short}"
-  domain         = var.environment.domain == null ? "-" : "-${var.environment.domain}-"
+  location_short  = var.environment.location == "italynorth" ? "itn" : var.environment.location == "westeurope" ? "weu" : var.environment.location == "germanywestcentral" ? "gwc" : "neu"
+  project         = "${var.environment.prefix}-${var.environment.env_short}-${local.location_short}"
+  domain          = var.environment.domain == null ? "-" : "-${var.environment.domain}-"
+  app_name_prefix = "${local.project}${local.domain}${var.environment.app_name}"
 
   subnet = {
     enable_service_endpoints = var.subnet_service_endpoints != null ? concat(
@@ -9,22 +10,22 @@ locals {
       var.subnet_service_endpoints.web ? ["Microsoft.Web"] : [],
       var.subnet_service_endpoints.storage ? ["Microsoft.Storage"] : [],
     ) : []
-    name = "${local.project}${local.domain}${var.environment.app_name}-func-snet-${var.environment.instance_number}"
+    name = "${local.app_name_prefix}-func-snet-${var.environment.instance_number}"
   }
 
   app_service_plan = {
     enable = var.app_service_plan_id == null
-    name   = "${local.project}${local.domain}${var.environment.app_name}-asp-${var.environment.instance_number}"
+    name   = "${local.app_name_prefix}-asp-${var.environment.instance_number}"
   }
 
   function_app = {
-    name                   = "${local.project}${local.domain}${var.environment.app_name}-func-${var.environment.instance_number}"
+    name                   = "${local.app_name_prefix}-func-${var.environment.instance_number}"
     sku_name               = var.tier == "test" ? "B1" : var.tier == "standard" ? "P0v3" : "P1v3"
     zone_balancing_enabled = var.tier != "test"
     is_slot_enabled        = var.tier == "test" ? 0 : 1
-    pep_sites              = "${local.project}${local.domain}${var.environment.app_name}-func-pep-${var.environment.instance_number}"
-    pep_sites_staging      = "${local.project}${local.domain}${var.environment.app_name}-staging-func-pep-${var.environment.instance_number}"
-    alert                  = "${local.project}${local.domain}${var.environment.app_name}-func-${var.environment.instance_number}] Health Check Failed"
+    pep_sites              = "${local.app_name_prefix}-func-pep-${var.environment.instance_number}"
+    pep_sites_staging      = "${local.app_name_prefix}-staging-func-pep-${var.environment.instance_number}"
+    alert                  = "${local.app_name_prefix}-func-${var.environment.instance_number}] Health Check Failed"
   }
 
   function_app_slot = {
@@ -38,9 +39,9 @@ locals {
   storage_account = {
     replication_type = var.tier == "test" ? "LRS" : "ZRS"
     name             = replace("${local.project}${replace(local.domain, "-", "")}${var.environment.app_name}stfn${var.environment.instance_number}", "-", "")
-    pep_blob_name    = "${local.project}${local.domain}${var.environment.app_name}-blob-pep-${var.environment.instance_number}"
-    pep_file_name    = "${local.project}${local.domain}${var.environment.app_name}-file-pep-${var.environment.instance_number}"
-    pep_queue_name   = "${local.project}${local.domain}${var.environment.app_name}-queue-pep-${var.environment.instance_number}"
+    pep_blob_name    = "${local.app_name_prefix}-blob-pep-${var.environment.instance_number}"
+    pep_file_name    = "${local.app_name_prefix}-file-pep-${var.environment.instance_number}"
+    pep_queue_name   = "${local.app_name_prefix}-queue-pep-${var.environment.instance_number}"
     alert            = "[${replace("${local.project}${replace(local.domain, "-", "")}${var.environment.app_name}stfn${var.environment.instance_number}", "-", "")}] Low Availability"
   }
 

--- a/infra/modules/azure_function_app/locals.tf
+++ b/infra/modules/azure_function_app/locals.tf
@@ -24,6 +24,7 @@ locals {
     is_slot_enabled        = var.tier == "test" ? 0 : 1
     pep_sites              = "${local.project}${local.domain}${var.environment.app_name}-func-pep-${var.environment.instance_number}"
     pep_sites_staging      = "${local.project}${local.domain}${var.environment.app_name}-staging-func-pep-${var.environment.instance_number}"
+    alert                  = "${local.project}${local.domain}${var.environment.app_name}-func-${var.environment.instance_number}] Health Check Failed"
   }
 
   function_app_slot = {
@@ -40,6 +41,7 @@ locals {
     pep_blob_name    = "${local.project}${local.domain}${var.environment.app_name}-blob-pep-${var.environment.instance_number}"
     pep_file_name    = "${local.project}${local.domain}${var.environment.app_name}-file-pep-${var.environment.instance_number}"
     pep_queue_name   = "${local.project}${local.domain}${var.environment.app_name}-queue-pep-${var.environment.instance_number}"
+    alert            = "[${replace("${local.project}${replace(local.domain, "-", "")}${var.environment.app_name}stfn${var.environment.instance_number}", "-", "")}] Low Availability"
   }
 
   private_dns_zone = {

--- a/infra/modules/azure_function_app/variables.tf
+++ b/infra/modules/azure_function_app/variables.tf
@@ -155,3 +155,11 @@ variable "subnet_service_endpoints" {
   description = "(Optional) Enable service endpoints for the underlying subnet. This variable should be set only if function dependencies do not use private endpoints"
   default     = null
 }
+
+variable "alert_config" {
+  type = object({
+    action_group_id    = string
+    webhook_properties = map(string)
+  })
+  description = "Set the Action Group Id to invoke when the Function App alert triggers and related webhook"
+}

--- a/infra/modules/azure_function_app/variables.tf
+++ b/infra/modules/azure_function_app/variables.tf
@@ -162,4 +162,5 @@ variable "alert_config" {
     webhook_properties = map(string)
   })
   description = "Set the Action Group Id to invoke when the Function App alert triggers and related webhook"
+  default     = null
 }

--- a/infra/modules/azure_function_app/variables.tf
+++ b/infra/modules/azure_function_app/variables.tf
@@ -156,11 +156,8 @@ variable "subnet_service_endpoints" {
   default     = null
 }
 
-variable "alert_config" {
-  type = object({
-    action_group_id    = string
-    webhook_properties = map(string)
-  })
-  description = "Set the Action Group Id to invoke when the Function App alert triggers and related webhook"
+variable "action_group_id" {
+  type        = string
+  description = "Set the Action Group Id to invoke when the Function App alert triggers"
   default     = null
 }


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

### List of changes

<!--- Describe your changes in detail -->

Add availability alert on Function App and Storage Account components in Azure Function App module.

This PR adds an optional variable `alert_config`, which brings the `action_group_id` to notify when the alert triggers. Alerts are created only in `premium` and `standard` tiers.

To avoid breaking changes, developers should manually add the `alert_config` indicating their `action_group_id`, otherwise the alert is created without actions. We can also change the approach introducing this small breaking change, but I don't think it is the right choice as informing developers about it should be enough (same code of legacy module). Instead, we can alter the default behaviour in the next weeks with a minor blast radius as many of them will have already implemented it.

### Motivation and context

<!--- Why is this change required? What problem does it solve? -->

Production resources should be monitored. Moreover, these alerts were already included in the legacy modules

### Type of changes

- [ ] Add new resources
- [X] Update configuration to existing resources
- [ ] Remove existing resources

### Does this introduce a change to production resources with possible user impact?

- [ ] Yes, users may be impacted applying this change
- [ ] No

### Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->
