### PR TITLE
[DEVEX-175] Fix infra deployment pipeline result status in case of failure

### DIFF
--- a/.github/workflows/infra_apply.yaml
+++ b/.github/workflows/infra_apply.yaml
@@ -109,6 +109,8 @@ jobs:
       - name: Terraform Plan
         working-directory: ${{ steps.directory.outputs.dir }}
         run: |
+          set -o pipefail
+
           terraform plan \
             -lock-timeout=3000s \
             -out=tfplan-${{ github.sha }} \


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

### List of changes

<!--- Describe your changes in detail -->

Add `set -o pipefail` flag to the bash script that runs the `terraform apply` command

### Motivation and context

<!--- Why is this change required? What problem does it solve? -->

Regression, pipeline were green (passed) rather than red (failed)

### Type of changes

- [ ] Add new resources
- [X] Update configuration to existing resources
- [ ] Remove existing resources

### Does this introduce a change to production resources with possible user impact?

- [ ] Yes, users may be impacted applying this change
- [ ] No

### Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->
