### PR TITLE
[DEVEX-184] Fix infra deployment pipeline result status in case of failure

### DIFF
--- a/.github/workflows/infra_apply.yaml
+++ b/.github/workflows/infra_apply.yaml
@@ -176,6 +176,8 @@ jobs:
       - name: Terraform Apply
         working-directory: ${{ needs.tf_plan.outputs.working_dir }}
         run: |
+          set -o pipefail
+
           terraform apply \
             -lock-timeout=3000s \
             -auto-approve \

--- a/.github/workflows/infra_plan.yaml
+++ b/.github/workflows/infra_plan.yaml
@@ -114,7 +114,7 @@ jobs:
           terraform plan -lock-timeout=3000s -no-color 2>&1 | grep -v "hidden-link:"  | tee plan_output.txt
 
           OUTPUT=$(grep -Ev "Refreshing state|state lock|Reading|Read" plan_output.txt | tail -c 60000)
-          
+
           printf "%s" "$OUTPUT" > plan_output_multiline.txt
 
           if grep -q "::error::Terraform exited with code" plan_output.txt; then
@@ -158,14 +158,14 @@ jobs:
                 comment_id: botComment.id
               })
             }
-            
+
             await github.rest.issues.createComment({
               owner: context.repo.owner,
               repo: context.repo.repo,
               body: commentBody,
               issue_number: context.issue.number
             })
-            
+
 
       # Fail the workflow if the Terraform plan failed
       - name: Check Terraform Plan Result


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

### List of changes

<!--- Describe your changes in detail -->
Add set -o pipefail flag to the bash script that runs the terraform apply command

### Motivation and context

<!--- Why is this change required? What problem does it solve? -->
Regression, pipeline were green (passed) rather than red (failed)

### Type of changes

- [ ] Add new resources
- [X] Update configuration to existing resources
- [ ] Remove existing resources

### Does this introduce a change to production resources with possible user impact?

- [ ] Yes, users may be impacted applying this change
- [ ] No

### Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->
