### PR TITLE
Update defaults in docs_website_publish.yaml

### DIFF
--- a/.github/workflows/docs_website_publish.yaml
+++ b/.github/workflows/docs_website_publish.yaml
@@ -11,9 +11,9 @@ on:
 # env:
 #   WORKING_DIR: ./website
 
-# defaults:
-#   run:
-#     working-directory: ./website
+defaults:
+  run:
+    working-directory: ./website
 
 jobs:
   build:


### PR DESCRIPTION
This pull request updates the defaults in the `docs_website_publish.yaml` file. The `defaults` section has been modified to include the `run` section with the `working-directory` set to `./website`.