### PR TITLE
Remove provider configuration from modules

### DIFF
--- a/infra/modules/azure_app_service/main.tf
+++ b/infra/modules/azure_app_service/main.tf
@@ -7,10 +7,6 @@ terraform {
   }
 }
 
-provider "azurerm" {
-  features {}
-}
-
 module "naming_convention" {
   source = "../azure_naming_convention"
 

--- a/infra/modules/azure_app_service_exposed/main.tf
+++ b/infra/modules/azure_app_service_exposed/main.tf
@@ -7,10 +7,6 @@ terraform {
   }
 }
 
-provider "azurerm" {
-  features {}
-}
-
 module "naming_convention" {
   source = "../azure_naming_convention"
 

--- a/infra/modules/azure_event_hub/main.tf
+++ b/infra/modules/azure_event_hub/main.tf
@@ -9,12 +9,6 @@ terraform {
   required_version = "~> 1.7.5"
 }
 
-provider "azurerm" {
-  features {}
-
-  storage_use_azuread = true
-}
-
 module "naming_convention" {
   source = "../azure_naming_convention"
 

--- a/infra/modules/azure_function_app/main.tf
+++ b/infra/modules/azure_function_app/main.tf
@@ -1,7 +1,10 @@
-provider "azurerm" {
-  features {}
-
-  storage_use_azuread = true
+terraform {
+  required_providers {
+    azurerm = {
+      source  = "hashicorp/azurerm"
+      version = ">= 3.100.0"
+    }
+  }
 }
 
 module "naming_convention" {

--- a/infra/modules/azure_function_app/main.tf
+++ b/infra/modules/azure_function_app/main.tf
@@ -1,12 +1,3 @@
-terraform {
-  required_providers {
-    azurerm = {
-      source  = "hashicorp/azurerm"
-      version = ">= 3.100.0"
-    }
-  }
-}
-
 provider "azurerm" {
   features {}
 

--- a/infra/modules/azure_function_app_exposed/main.tf
+++ b/infra/modules/azure_function_app_exposed/main.tf
@@ -7,12 +7,6 @@ terraform {
   }
 }
 
-provider "azurerm" {
-  features {}
-
-  storage_use_azuread = true
-}
-
 module "naming_convention" {
   source = "../azure_naming_convention"
 

--- a/infra/modules/azure_postgres_server/main.tf
+++ b/infra/modules/azure_postgres_server/main.tf
@@ -9,12 +9,6 @@ terraform {
   required_version = "~> 1.7.5"
 }
 
-provider "azurerm" {
-  features {}
-
-  storage_use_azuread = true
-}
-
 module "naming_convention" {
   source = "../azure_naming_convention"
 


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

### List of changes
Removed explicit configuration of providers in modules

### Motivation and context
Using most of the modules with a for_each, I received the following error:
![image](https://github.com/user-attachments/assets/104e58a8-0212-42c1-b0ef-7fa791105655)

More information about the error [here](https://support.hashicorp.com/hc/en-us/articles/21807317486995-Error-Module-is-incompatible-with-count-for-each-and-depends-on)

The cleanest solution is to remove the provider definition from inner modules cause it's directly inherited from the root module.

### Type of changes

- [ ] Add new resources
- [ ] Update configuration to existing resources
- [ ] Remove existing resources

### Does this introduce a change to production resources with possible user impact?

- [ ] Yes, users may be impacted applying this change
- [ ] No

### Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->
