### PR TITLE
fix: dx-pagopa-bot must be added as writer to subrepos

### DIFF
--- a/infra/scripts/add-module.sh
+++ b/infra/scripts/add-module.sh
@@ -78,6 +78,9 @@ if [ -n "$ORG_NAME" ]; then
     echo "GitHub repository created successfully: https://github.com/$ORG_NAME/$SUBREPO_NAME"
     echo "Please, ask the DevEx members to edit the dx-pagopa-bot PAT adding the new repository"
     
+    # Add dx-pagopa-bot as a collaborator with write permissions
+    gh api -X PUT /repos/$ORG_NAME/$SUBREPO_NAME/collaborators/dx-pagopa-bot -f permission=push
+
     # Initialize Git in the module directory and push to the new repository
     cd "$MODULE_DIR"
     git init


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

### List of changes

<!--- Describe your changes in detail -->
The dx-pagopa-bot is automatically granted writer permissions to the new subrepo when created

### Motivation and context

<!--- Why is this change required? What problem does it solve? -->

### Type of changes

- [ ] Add new resources
- [ ] Update configuration to existing resources
- [ ] Remove existing resources

### Does this introduce a change to production resources with possible user impact?

- [ ] Yes, users may be impacted applying this change
- [ ] No

### Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->
