### PR TITLE
[DEVEX-221] - Avoid checking modules hashes when no modules are used

### DIFF
--- a/.github/workflows/infra_plan.yaml
+++ b/.github/workflows/infra_plan.yaml
@@ -113,10 +113,16 @@ jobs:
           REGISTRY_URL="registry.terraform.io"
           HASHES_FILE="tfmodules.lock.json"
 
-          # Check if modules metadata exists
+          # Check if modules directory exists, exit if not
+          if [ ! -d "$MODULES_DIR" ]; then
+              echo "No modules directory found. Skipping module check."
+              exit 0
+          fi
+
+          # Check if modules metadata exists, exit if not
           if [ ! -f "$MODULES_METADATA" ]; then
-              echo "Error: Modules metadata file $MODULES_METADATA not found. Did you run 'terraform init'?"
-              exit 1
+              echo "No modules metadata file found. Skipping module check."
+              exit 0
           fi
 
           # Check for modules sourced from the Terraform registry


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

### List of changes
Avoid checking modules hashes when no modules are used in the terraform configuration

<!--- Describe your changes in detail -->

### Motivation and context
The infra review workflow fails at step `Check terraform registry modules hashes` when no modules are used in the terraform configuration
<!--- Why is this change required? What problem does it solve? -->

### Type of changes

- [ ] Add new resources
- [X] Update configuration to existing resources
- [ ] Remove existing resources

### Does this introduce a change to production resources with possible user impact?

- [ ] Yes, users may be impacted applying this change
- [X] No

### Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->
