### PR TITLE
Disable Defender for Storage Accounts located in Italy North

### DIFF
--- a/infra/modules/azure_storage_account/alerts.tf
+++ b/infra/modules/azure_storage_account/alerts.tf
@@ -3,7 +3,7 @@
 # -----------------------------------------------
 
 resource "azurerm_monitor_metric_alert" "storage_account_health_check" {
-  count               = local.tier_features.advanced_threat_protection ? 1 : 0
+  count               = local.tier_features.alerts ? 1 : 0
   name                = "[${azurerm_storage_account.this.name}] Low Availability"
   resource_group_name = var.resource_group_name
   scopes              = [azurerm_storage_account.this.id]

--- a/infra/modules/azure_storage_account/locals.tf
+++ b/infra/modules/azure_storage_account/locals.tf
@@ -9,7 +9,7 @@ locals {
 
     l = {
       alerts                     = true
-      advanced_threat_protection = true
+      advanced_threat_protection = var.environment.location != "italynorth"
       account_tier               = "Standard"
       replication_type           = "ZRS"
     }


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

### List of changes

<!--- Describe your changes in detail -->

Do not create `azurerm_security_center_storage_defender` if the Storage Account is located in Italy North

### Motivation and context

<!--- Why is this change required? What problem does it solve? -->

Region does not support that provider

### Type of changes

- [ ] Add new resources
- [x] Update configuration to existing resources
- [ ] Remove existing resources

### Does this introduce a change to production resources with possible user impact?

- [ ] Yes, users may be impacted applying this change
- [ ] No

### Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->
