### PR TITLE
[CES-491] - Queue reader needs two roles

### DIFF
--- a/.changeset/stupid-frogs-hope.md
+++ b/.changeset/stupid-frogs-hope.md
@@ -1,0 +1,5 @@
+---
+"azure_role_assignments": minor
+---
+
+Storage account queues readers now have two azure roles assigned

--- a/infra/modules/azure_role_assignments/modules/storage_account/locals.tf
+++ b/infra/modules/azure_role_assignments/modules/storage_account/locals.tf
@@ -14,7 +14,7 @@ locals {
   table_assignments = { for assignment in var.storage_table : "${assignment.storage_account_name}|${assignment.table_name}|${assignment.role}" => assignment }
 
   queues            = distinct([for queue in var.storage_queue : { storage_account_name = queue.storage_account_name, resource_group_name = queue.resource_group_name, queue_name = queue.queue_name } if queue.queue_name != "*"])
-  queue_assignments = merge([ for key, item in var.storage_queue : { for role_name in local.role_definition_name.queue[lower(item.role)] : "${item.storage_account_name}|${item.queue_name}|${item.role}|${role_name}" => merge(item, { role_definition_name = role_name }) } ]...)
+  queue_assignments = merge([for key, item in var.storage_queue : { for role_name in local.role_definition_name.queue[lower(item.role)] : "${item.storage_account_name}|${item.queue_name}|${item.role}|${role_name}" => merge(item, { role_definition_name = role_name }) }]...)
 
   role_definition_name = {
     blob = {

--- a/infra/modules/azure_role_assignments/modules/storage_account/locals.tf
+++ b/infra/modules/azure_role_assignments/modules/storage_account/locals.tf
@@ -14,7 +14,7 @@ locals {
   table_assignments = { for assignment in var.storage_table : "${assignment.storage_account_name}|${assignment.table_name}|${assignment.role}" => assignment }
 
   queues            = distinct([for queue in var.storage_queue : { storage_account_name = queue.storage_account_name, resource_group_name = queue.resource_group_name, queue_name = queue.queue_name } if queue.queue_name != "*"])
-  queue_assignments = { for assignment in var.storage_queue : "${assignment.storage_account_name}|${assignment.queue_name}|${assignment.role}" => assignment }
+  queue_assignments = merge([ for key, item in var.storage_queue : { for role_name in local.role_definition_name.queue[lower(item.role)] : "${item.storage_account_name}|${item.queue_name}|${item.role}|${role_name}" => merge(item, { role_definition_name = role_name }) } ]...)
 
   role_definition_name = {
     blob = {
@@ -30,9 +30,9 @@ locals {
     }
 
     queue = {
-      reader = "Storage Queue Data Message Processor",
-      writer = "Storage Queue Data Message Sender",
-      owner  = "Storage Queue Data Contributor"
+      reader = ["Storage Queue Data Message Processor", "Storage Queue Data Reader"],
+      writer = ["Storage Queue Data Message Sender"],
+      owner  = ["Storage Queue Data Contributor"]
     }
   }
 }

--- a/infra/modules/azure_role_assignments/modules/storage_account/main.tf
+++ b/infra/modules/azure_role_assignments/modules/storage_account/main.tf
@@ -14,7 +14,7 @@ resource "azurerm_role_assignment" "table" {
 
 resource "azurerm_role_assignment" "queue" {
   for_each             = local.queue_assignments
-  role_definition_name = local.role_definition_name.queue[lower(each.value.role)]
+  role_definition_name = each.value.role_definition_name
   scope                = each.value.queue_name == "*" ? data.azurerm_storage_account.this["${each.value.resource_group_name}|${each.value.storage_account_name}"].id : data.azurerm_storage_queue.this["${each.value.storage_account_name}|${each.value.queue_name}"].resource_manager_id
   principal_id         = var.principal_id
 }


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

### List of changes
Added possibility for role assignments on storage account queues to assign more than one role

<!--- Describe your changes in detail -->

### Motivation and context
The receiver of storage accounts queue messages needs two roles
<!--- Why is this change required? What problem does it solve? -->

### Type of changes

- [ ] Add new resources
- [ ] Update configuration to existing resources
- [ ] Remove existing resources

### Does this introduce a change to production resources with possible user impact?

- [ ] Yes, users may be impacted applying this change
- [ ] No

### Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->
