### PR TITLE
[CES-607] Add support to custom startup command in AppService modules

### DIFF
--- a/.changeset/popular-bears-draw.md
+++ b/.changeset/popular-bears-draw.md
@@ -1,0 +1,9 @@
+---
+"azure_app_service_exposed": major
+"azure_app_service": major
+---
+
+Two breaking changes introduced in this version:
+
+- PM2 is now the default entrypoint in NodeJs apps (still overridable)
+- Allows startup command override on Java apps

--- a/infra/modules/azure_app_service/README.md
+++ b/infra/modules/azure_app_service/README.md
@@ -43,7 +43,7 @@
 | <a name="input_resource_group_name"></a> [resource\_group\_name](#input\_resource\_group\_name) | Resource group to deploy resources to | `string` | n/a | yes |
 | <a name="input_slot_app_settings"></a> [slot\_app\_settings](#input\_slot\_app\_settings) | Staging slot application settings | `map(string)` | `{}` | no |
 | <a name="input_stack"></a> [stack](#input\_stack) | n/a | `string` | `"node"` | no |
-| <a name="input_startup_command"></a> [startup\_command](#input\_startup\_command) | (Optional) The PM2 file used as PM2 process entry point | `string` | `""` | no |
+| <a name="input_startup_command"></a> [startup\_command](#input\_startup\_command) | (Optional) Override AppService startup command. If using node, the default value uses PM2 | `string` | `""` | no |
 | <a name="input_sticky_app_setting_names"></a> [sticky\_app\_setting\_names](#input\_sticky\_app\_setting\_names) | (Optional) A list of application setting names that are not swapped between slots | `list(string)` | `[]` | no |
 | <a name="input_subnet_cidr"></a> [subnet\_cidr](#input\_subnet\_cidr) | CIDR block to use for the subnet the Function App uses for outbound connectivity | `string` | n/a | yes |
 | <a name="input_subnet_pep_id"></a> [subnet\_pep\_id](#input\_subnet\_pep\_id) | Id of the subnet which holds private endpoints | `string` | n/a | yes |

--- a/infra/modules/azure_app_service/README.md
+++ b/infra/modules/azure_app_service/README.md
@@ -39,6 +39,7 @@
 | <a name="input_health_check_path"></a> [health\_check\_path](#input\_health\_check\_path) | Endpoint where health probe is exposed | `string` | n/a | yes |
 | <a name="input_java_version"></a> [java\_version](#input\_java\_version) | Java version to use | `string` | `17` | no |
 | <a name="input_node_version"></a> [node\_version](#input\_node\_version) | Node version to use | `number` | `20` | no |
+| <a name="input_pm2_startup_file_name"></a> [pm2\_startup\_file\_name](#input\_pm2\_startup\_file\_name) | (Optional) Use this variable to enable PM2. The specified file is used as PM2 process entry point | `string` | `null` | no |
 | <a name="input_private_dns_zone_resource_group_name"></a> [private\_dns\_zone\_resource\_group\_name](#input\_private\_dns\_zone\_resource\_group\_name) | (Optional) The name of the resource group holding private DNS zone to use for private endpoints. Default is Virtual Network resource group | `string` | `null` | no |
 | <a name="input_resource_group_name"></a> [resource\_group\_name](#input\_resource\_group\_name) | Resource group to deploy resources to | `string` | n/a | yes |
 | <a name="input_slot_app_settings"></a> [slot\_app\_settings](#input\_slot\_app\_settings) | Staging slot application settings | `map(string)` | `{}` | no |

--- a/infra/modules/azure_app_service/README.md
+++ b/infra/modules/azure_app_service/README.md
@@ -39,11 +39,11 @@
 | <a name="input_health_check_path"></a> [health\_check\_path](#input\_health\_check\_path) | Endpoint where health probe is exposed | `string` | n/a | yes |
 | <a name="input_java_version"></a> [java\_version](#input\_java\_version) | Java version to use | `string` | `17` | no |
 | <a name="input_node_version"></a> [node\_version](#input\_node\_version) | Node version to use | `number` | `20` | no |
-| <a name="input_pm2_startup_file_name"></a> [pm2\_startup\_file\_name](#input\_pm2\_startup\_file\_name) | (Optional) Use this variable to enable PM2. The specified file is used as PM2 process entry point | `string` | `null` | no |
 | <a name="input_private_dns_zone_resource_group_name"></a> [private\_dns\_zone\_resource\_group\_name](#input\_private\_dns\_zone\_resource\_group\_name) | (Optional) The name of the resource group holding private DNS zone to use for private endpoints. Default is Virtual Network resource group | `string` | `null` | no |
 | <a name="input_resource_group_name"></a> [resource\_group\_name](#input\_resource\_group\_name) | Resource group to deploy resources to | `string` | n/a | yes |
 | <a name="input_slot_app_settings"></a> [slot\_app\_settings](#input\_slot\_app\_settings) | Staging slot application settings | `map(string)` | `{}` | no |
 | <a name="input_stack"></a> [stack](#input\_stack) | n/a | `string` | `"node"` | no |
+| <a name="input_startup_command"></a> [startup\_command](#input\_startup\_command) | (Optional) The PM2 file used as PM2 process entry point | `string` | `""` | no |
 | <a name="input_sticky_app_setting_names"></a> [sticky\_app\_setting\_names](#input\_sticky\_app\_setting\_names) | (Optional) A list of application setting names that are not swapped between slots | `list(string)` | `[]` | no |
 | <a name="input_subnet_cidr"></a> [subnet\_cidr](#input\_subnet\_cidr) | CIDR block to use for the subnet the Function App uses for outbound connectivity | `string` | n/a | yes |
 | <a name="input_subnet_pep_id"></a> [subnet\_pep\_id](#input\_subnet\_pep\_id) | Id of the subnet which holds private endpoints | `string` | n/a | yes |

--- a/infra/modules/azure_app_service/app_service.tf
+++ b/infra/modules/azure_app_service/app_service.tf
@@ -21,6 +21,8 @@ resource "azurerm_linux_web_app" "this" {
     health_check_eviction_time_in_min = 2
     ip_restriction_default_action     = "Deny"
 
+    app_command_line = local.app_service.command_line
+
     application_stack {
       node_version        = var.stack == "node" ? "${var.node_version}-lts" : null
       java_version        = var.stack == "java" ? var.java_version : null

--- a/infra/modules/azure_app_service/app_service.tf
+++ b/infra/modules/azure_app_service/app_service.tf
@@ -21,7 +21,7 @@ resource "azurerm_linux_web_app" "this" {
     health_check_eviction_time_in_min = 2
     ip_restriction_default_action     = "Deny"
 
-    app_command_line = local.app_service.command_line
+    app_command_line = local.app_service.startup_command
 
     application_stack {
       node_version        = var.stack == "node" ? "${var.node_version}-lts" : null

--- a/infra/modules/azure_app_service/app_service_slot.tf
+++ b/infra/modules/azure_app_service/app_service_slot.tf
@@ -21,7 +21,7 @@ resource "azurerm_linux_web_app_slot" "this" {
     health_check_eviction_time_in_min = 2
     ip_restriction_default_action     = "Deny"
 
-    app_command_line = local.app_service.command_line
+    app_command_line = local.app_service.startup_command
 
     application_stack {
       node_version        = var.stack == "node" ? "${var.node_version}-lts" : null

--- a/infra/modules/azure_app_service/app_service_slot.tf
+++ b/infra/modules/azure_app_service/app_service_slot.tf
@@ -21,6 +21,8 @@ resource "azurerm_linux_web_app_slot" "this" {
     health_check_eviction_time_in_min = 2
     ip_restriction_default_action     = "Deny"
 
+    app_command_line = local.app_service.command_line
+
     application_stack {
       node_version        = var.stack == "node" ? "${var.node_version}-lts" : null
       java_version        = var.stack == "java" ? var.java_version : null

--- a/infra/modules/azure_app_service/locals.tf
+++ b/infra/modules/azure_app_service/locals.tf
@@ -16,7 +16,10 @@ locals {
     sku_name               = local.sku_name_mapping[local.tier]
     zone_balancing_enabled = local.tier != "s"
     is_slot_enabled        = local.tier == "s" ? 0 : 1
-    command_line           = var.pm2_startup_file_name == null ? null : "pm2 start ${var.pm2_startup_file_name} -i max --no-daemon"
+    startup_command = (var.stack == "node"
+      ? (var.startup_command == "" ? "pm2 start index.js -i max --no-daemon" : var.startup_command)
+      : (var.stack == "java" && var.startup_command == "" ? null : var.startup_command)
+    )
   }
 
   app_service_slot = {

--- a/infra/modules/azure_app_service/locals.tf
+++ b/infra/modules/azure_app_service/locals.tf
@@ -16,6 +16,7 @@ locals {
     sku_name               = local.sku_name_mapping[local.tier]
     zone_balancing_enabled = local.tier != "s"
     is_slot_enabled        = local.tier == "s" ? 0 : 1
+    command_line           = var.pm2_startup_file_name == null ? null : "pm2 start ${var.pm2_startup_file_name} -i max --no-daemon"
   }
 
   app_service_slot = {

--- a/infra/modules/azure_app_service/tests/appservice.tftest.hcl
+++ b/infra/modules/azure_app_service/tests/appservice.tftest.hcl
@@ -33,15 +33,7 @@ run "app_service_is_correct_plan" {
       instance_number = "01"
     }
 
-    tags = {
-      CostCenter  = "TS700 - ENGINEERING"
-      CreatedBy   = "Terraform"
-      Environment = "Dev"
-      Owner       = "DevEx"
-      Source      = "https://github.com/pagopa/dx/blob/main/infra/modules/azure_app_service/tests"
-      Test        = "true"
-      TestName    = "Create app service for test"
-    }
+    tags = {}
 
     resource_group_name = run.setup_tests.resource_group_name
     tier                = "m"
@@ -59,7 +51,6 @@ run "app_service_is_correct_plan" {
     slot_app_settings = {}
 
     health_check_path = "/health"
-
   }
 
   # Checks some assertions
@@ -81,5 +72,286 @@ run "app_service_is_correct_plan" {
   assert {
     condition     = azurerm_linux_web_app.this.site_config[0].always_on == true
     error_message = "The App Service should have Always On enabled"
+  }
+}
+
+run "app_service_node_default_startup_command" {
+  command = plan
+
+  plan_options {
+    target = [
+      azurerm_linux_web_app.this,
+      azurerm_linux_web_app_slot.this,
+    ]
+  }
+
+  variables {
+    environment = {
+      prefix          = "dx"
+      env_short       = "d"
+      location        = "italynorth"
+      domain          = "modules"
+      app_name        = "test"
+      instance_number = "01"
+    }
+
+    tags = {}
+
+    resource_group_name = run.setup_tests.resource_group_name
+    tier                = "m"
+
+    virtual_network = {
+      name                = run.setup_tests.vnet.name
+      resource_group_name = run.setup_tests.vnet.resource_group_name
+    }
+
+    subnet_pep_id                        = run.setup_tests.pep_id
+    subnet_cidr                          = "10.20.50.0/24"
+    private_dns_zone_resource_group_name = "dx-d-itn-network-rg-01"
+
+    app_settings      = {}
+    slot_app_settings = {}
+
+    health_check_path = "/health"
+  }
+
+  assert {
+    condition     = azurerm_linux_web_app.this.site_config[0].application_stack[0].node_version != null
+    error_message = "Node version is null"
+  }
+
+  assert {
+    condition     = azurerm_linux_web_app_slot.this[0].site_config[0].application_stack[0].node_version != null
+    error_message = "Node version is null on staging slot"
+  }
+
+  assert {
+    condition     = strcontains(azurerm_linux_web_app.this.site_config[0].app_command_line, "pm2 start")
+    error_message = "PM2 is not set as default for Node.js"
+  }
+
+  assert {
+    condition     = strcontains(azurerm_linux_web_app_slot.this[0].site_config[0].app_command_line, "pm2 start")
+    error_message = "PM2 is not set as default for Node.js on staging slot"
+  }
+}
+
+run "app_service_node_custom_startup_command" {
+  command = plan
+
+  plan_options {
+    target = [
+      azurerm_linux_web_app.this,
+        azurerm_linux_web_app_slot.this,
+    ]
+  }
+
+  variables {
+    environment = {
+      prefix          = "dx"
+      env_short       = "d"
+      location        = "italynorth"
+      domain          = "modules"
+      app_name        = "test"
+      instance_number = "01"
+    }
+
+    tags = {}
+
+    resource_group_name = run.setup_tests.resource_group_name
+    tier                = "m"
+
+    virtual_network = {
+      name                = run.setup_tests.vnet.name
+      resource_group_name = run.setup_tests.vnet.resource_group_name
+    }
+
+    subnet_pep_id                        = run.setup_tests.pep_id
+    subnet_cidr                          = "10.20.50.0/24"
+    private_dns_zone_resource_group_name = "dx-d-itn-network-rg-01"
+
+    app_settings      = {}
+    slot_app_settings = {}
+
+    health_check_path = "/health"
+
+    startup_command = "custom command"
+  }
+
+  assert {
+    condition     = azurerm_linux_web_app.this.site_config[0].application_stack[0].node_version != null
+    error_message = "Node version is null"
+  }
+
+  assert {
+    condition     = azurerm_linux_web_app.this.site_config[0].app_command_line == "custom command"
+    error_message = "Startup command override doesn't work on Node.js stack"
+  }
+}
+
+run "app_service_java_default_startup_command" {
+  command = plan
+
+  plan_options {
+    target = [
+      azurerm_linux_web_app.this,
+        azurerm_linux_web_app_slot.this,
+    ]
+  }
+
+  variables {
+    environment = {
+      prefix          = "dx"
+      env_short       = "d"
+      location        = "italynorth"
+      domain          = "modules"
+      app_name        = "test"
+      instance_number = "01"
+    }
+
+    tags = {}
+
+    resource_group_name = run.setup_tests.resource_group_name
+    tier                = "m"
+
+    virtual_network = {
+      name                = run.setup_tests.vnet.name
+      resource_group_name = run.setup_tests.vnet.resource_group_name
+    }
+
+    subnet_pep_id                        = run.setup_tests.pep_id
+    subnet_cidr                          = "10.20.50.0/24"
+    private_dns_zone_resource_group_name = "dx-d-itn-network-rg-01"
+
+    app_settings      = {}
+    slot_app_settings = {}
+
+    health_check_path = "/health"
+
+    stack = "java"
+  }
+
+  assert {
+    condition     = azurerm_linux_web_app.this.site_config[0].application_stack[0].java_version != null
+    error_message = "Java version is null"
+  }
+
+  assert {
+    condition     = azurerm_linux_web_app_slot.this[0].site_config[0].application_stack[0].java_version != null
+    error_message = "Java version is null on staging slot"
+  }
+
+  assert {
+    condition     = azurerm_linux_web_app.this.site_config[0].application_stack[0].java_server != null
+    error_message = "Java server is null"
+  }
+
+  assert {
+    condition     = azurerm_linux_web_app_slot.this[0].site_config[0].application_stack[0].java_server != null
+    error_message = "Java server is null on staging slot"
+  }
+
+  assert {
+    condition     = azurerm_linux_web_app.this.site_config[0].application_stack[0].java_server_version != null
+    error_message = "Java server version is null"
+  }
+
+  assert {
+    condition     = azurerm_linux_web_app_slot.this[0].site_config[0].application_stack[0].java_server_version != null
+    error_message = "Java server version is null on staging slot"
+  }
+
+  assert {
+    condition     = azurerm_linux_web_app.this.site_config[0].app_command_line == null
+    error_message = "Default startup command value is not null on Java stack"
+  }
+
+  assert {
+    condition     = azurerm_linux_web_app_slot.this[0].site_config[0].app_command_line == null
+    error_message = "Default startup command value is not null on Java stack on staging slot"
+  }
+}
+
+run "app_service_java_custom_startup_command" {
+  command = plan
+
+  plan_options {
+    target = [
+      azurerm_linux_web_app.this,
+        azurerm_linux_web_app_slot.this,
+    ]
+  }
+
+  variables {
+    environment = {
+      prefix          = "dx"
+      env_short       = "d"
+      location        = "italynorth"
+      domain          = "modules"
+      app_name        = "test"
+      instance_number = "01"
+    }
+
+    tags = {}
+
+    resource_group_name = run.setup_tests.resource_group_name
+    tier                = "m"
+
+    virtual_network = {
+      name                = run.setup_tests.vnet.name
+      resource_group_name = run.setup_tests.vnet.resource_group_name
+    }
+
+    subnet_pep_id                        = run.setup_tests.pep_id
+    subnet_cidr                          = "10.20.50.0/24"
+    private_dns_zone_resource_group_name = "dx-d-itn-network-rg-01"
+
+    app_settings      = {}
+    slot_app_settings = {}
+
+    health_check_path = "/health"
+
+    stack           = "java"
+    startup_command = "custom command"
+  }
+
+  assert {
+    condition     = azurerm_linux_web_app.this.site_config[0].application_stack[0].java_version != null
+    error_message = "Java version is null"
+  }
+
+  assert {
+    condition     = azurerm_linux_web_app_slot.this[0].site_config[0].application_stack[0].java_version != null
+    error_message = "Java version is null on staging slot"
+  }
+
+  assert {
+    condition     = azurerm_linux_web_app.this.site_config[0].application_stack[0].java_server != null
+    error_message = "Java server is null"
+  }
+
+  assert {
+    condition     = azurerm_linux_web_app_slot.this[0].site_config[0].application_stack[0].java_server != null
+    error_message = "Java server is null on staging slot"
+  }
+
+  assert {
+    condition     = azurerm_linux_web_app.this.site_config[0].application_stack[0].java_server_version != null
+    error_message = "Java server version is null"
+  }
+
+  assert {
+    condition     = azurerm_linux_web_app_slot.this[0].site_config[0].application_stack[0].java_server_version != null
+    error_message = "Java server version is null on staging slot"
+  }
+
+  assert {
+    condition     = azurerm_linux_web_app.this.site_config[0].app_command_line != null
+    error_message = "Startup command override doesn't work on Java stack"
+  }
+
+  assert {
+    condition     = azurerm_linux_web_app_slot.this[0].site_config[0].app_command_line != null
+    error_message = "Startup command override doesn't work on Java stack on staging slot"
   }
 }

--- a/infra/modules/azure_app_service/variables.tf
+++ b/infra/modules/azure_app_service/variables.tf
@@ -76,7 +76,7 @@ variable "java_version" {
 variable "startup_command" {
   type        = string
   default     = ""
-  description = "(Optional) The PM2 file used as PM2 process entry point"
+  description = "(Optional) Override AppService startup command. If using node, the default value uses PM2"
 }
 
 variable "application_insights_sampling_percentage" {

--- a/infra/modules/azure_app_service/variables.tf
+++ b/infra/modules/azure_app_service/variables.tf
@@ -129,3 +129,9 @@ variable "subnet_service_endpoints" {
   description = "(Optional) Enable service endpoints for the underlying subnet. This variable should be set only if function dependencies do not use private endpoints"
   default     = null
 }
+
+variable "pm2_startup_file_name" {
+  type        = string
+  default     = null
+  description = "(Optional) Use this variable to enable PM2. The specified file is used as PM2 process entry point"
+}

--- a/infra/modules/azure_app_service/variables.tf
+++ b/infra/modules/azure_app_service/variables.tf
@@ -73,6 +73,12 @@ variable "java_version" {
   description = "Java version to use"
 }
 
+variable "startup_command" {
+  type        = string
+  default     = ""
+  description = "(Optional) The PM2 file used as PM2 process entry point"
+}
+
 variable "application_insights_sampling_percentage" {
   type        = number
   default     = 5
@@ -128,10 +134,4 @@ variable "subnet_service_endpoints" {
   })
   description = "(Optional) Enable service endpoints for the underlying subnet. This variable should be set only if function dependencies do not use private endpoints"
   default     = null
-}
-
-variable "startup_command" {
-  type        = string
-  default     = ""
-  description = "(Optional) The PM2 file used as PM2 process entry point"
 }

--- a/infra/modules/azure_app_service/variables.tf
+++ b/infra/modules/azure_app_service/variables.tf
@@ -130,8 +130,8 @@ variable "subnet_service_endpoints" {
   default     = null
 }
 
-variable "pm2_startup_file_name" {
+variable "startup_command" {
   type        = string
-  default     = null
-  description = "(Optional) Use this variable to enable PM2. The specified file is used as PM2 process entry point"
+  default     = ""
+  description = "(Optional) The PM2 file used as PM2 process entry point"
 }

--- a/infra/modules/azure_app_service_exposed/README.md
+++ b/infra/modules/azure_app_service_exposed/README.md
@@ -36,6 +36,7 @@ This module is used to create an Azure App Service, allowing it to be configured
 | <a name="input_health_check_path"></a> [health\_check\_path](#input\_health\_check\_path) | Endpoint where health probe is exposed | `string` | n/a | yes |
 | <a name="input_java_version"></a> [java\_version](#input\_java\_version) | Java version to use | `string` | `17` | no |
 | <a name="input_node_version"></a> [node\_version](#input\_node\_version) | Node version to use | `number` | `20` | no |
+| <a name="input_pm2_startup_file_name"></a> [pm2\_startup\_file\_name](#input\_pm2\_startup\_file\_name) | (Optional) Use this variable to enable PM2. The specified file is used as PM2 process entry point | `string` | `null` | no |
 | <a name="input_resource_group_name"></a> [resource\_group\_name](#input\_resource\_group\_name) | Resource group to deploy resources to | `string` | n/a | yes |
 | <a name="input_slot_app_settings"></a> [slot\_app\_settings](#input\_slot\_app\_settings) | Staging slot application settings | `map(string)` | `{}` | no |
 | <a name="input_stack"></a> [stack](#input\_stack) | n/a | `string` | `"node"` | no |

--- a/infra/modules/azure_app_service_exposed/README.md
+++ b/infra/modules/azure_app_service_exposed/README.md
@@ -39,7 +39,7 @@ This module is used to create an Azure App Service, allowing it to be configured
 | <a name="input_resource_group_name"></a> [resource\_group\_name](#input\_resource\_group\_name) | Resource group to deploy resources to | `string` | n/a | yes |
 | <a name="input_slot_app_settings"></a> [slot\_app\_settings](#input\_slot\_app\_settings) | Staging slot application settings | `map(string)` | `{}` | no |
 | <a name="input_stack"></a> [stack](#input\_stack) | n/a | `string` | `"node"` | no |
-| <a name="input_startup_command"></a> [startup\_command](#input\_startup\_command) | (Optional) The PM2 file used as PM2 process entry point | `string` | `""` | no |
+| <a name="input_startup_command"></a> [startup\_command](#input\_startup\_command) | (Optional) Override AppService startup command. If using node, the default value uses PM2 | `string` | `""` | no |
 | <a name="input_sticky_app_setting_names"></a> [sticky\_app\_setting\_names](#input\_sticky\_app\_setting\_names) | (Optional) A list of application setting names that are not swapped between slots | `list(string)` | `[]` | no |
 | <a name="input_tags"></a> [tags](#input\_tags) | Resources tags | `map(any)` | n/a | yes |
 | <a name="input_tier"></a> [tier](#input\_tier) | Resource tiers depending on workload. Allowed values are 'xs', 's', 'm', 'l', 'xl'. Legacy values 'premium', 'standard', 'test' are also supported for backward compatibility. | `string` | `"l"` | no |

--- a/infra/modules/azure_app_service_exposed/README.md
+++ b/infra/modules/azure_app_service_exposed/README.md
@@ -40,6 +40,7 @@ This module is used to create an Azure App Service, allowing it to be configured
 | <a name="input_resource_group_name"></a> [resource\_group\_name](#input\_resource\_group\_name) | Resource group to deploy resources to | `string` | n/a | yes |
 | <a name="input_slot_app_settings"></a> [slot\_app\_settings](#input\_slot\_app\_settings) | Staging slot application settings | `map(string)` | `{}` | no |
 | <a name="input_stack"></a> [stack](#input\_stack) | n/a | `string` | `"node"` | no |
+| <a name="input_startup_command"></a> [startup\_command](#input\_startup\_command) | (Optional) The PM2 file used as PM2 process entry point | `string` | `""` | no |
 | <a name="input_sticky_app_setting_names"></a> [sticky\_app\_setting\_names](#input\_sticky\_app\_setting\_names) | (Optional) A list of application setting names that are not swapped between slots | `list(string)` | `[]` | no |
 | <a name="input_tags"></a> [tags](#input\_tags) | Resources tags | `map(any)` | n/a | yes |
 | <a name="input_tier"></a> [tier](#input\_tier) | Resource tiers depending on workload. Allowed values are 'xs', 's', 'm', 'l', 'xl'. Legacy values 'premium', 'standard', 'test' are also supported for backward compatibility. | `string` | `"l"` | no |

--- a/infra/modules/azure_app_service_exposed/README.md
+++ b/infra/modules/azure_app_service_exposed/README.md
@@ -36,7 +36,6 @@ This module is used to create an Azure App Service, allowing it to be configured
 | <a name="input_health_check_path"></a> [health\_check\_path](#input\_health\_check\_path) | Endpoint where health probe is exposed | `string` | n/a | yes |
 | <a name="input_java_version"></a> [java\_version](#input\_java\_version) | Java version to use | `string` | `17` | no |
 | <a name="input_node_version"></a> [node\_version](#input\_node\_version) | Node version to use | `number` | `20` | no |
-| <a name="input_pm2_startup_file_name"></a> [pm2\_startup\_file\_name](#input\_pm2\_startup\_file\_name) | (Optional) Use this variable to enable PM2. The specified file is used as PM2 process entry point | `string` | `null` | no |
 | <a name="input_resource_group_name"></a> [resource\_group\_name](#input\_resource\_group\_name) | Resource group to deploy resources to | `string` | n/a | yes |
 | <a name="input_slot_app_settings"></a> [slot\_app\_settings](#input\_slot\_app\_settings) | Staging slot application settings | `map(string)` | `{}` | no |
 | <a name="input_stack"></a> [stack](#input\_stack) | n/a | `string` | `"node"` | no |

--- a/infra/modules/azure_app_service_exposed/app_service.tf
+++ b/infra/modules/azure_app_service_exposed/app_service.tf
@@ -19,7 +19,7 @@ resource "azurerm_linux_web_app" "this" {
     health_check_path                 = var.health_check_path
     health_check_eviction_time_in_min = 2
 
-    app_command_line = local.app_service.command_line
+    app_command_line = local.app_service.startup_command
 
     application_stack {
       node_version        = var.stack == "node" ? "${var.node_version}-lts" : null

--- a/infra/modules/azure_app_service_exposed/app_service.tf
+++ b/infra/modules/azure_app_service_exposed/app_service.tf
@@ -19,6 +19,8 @@ resource "azurerm_linux_web_app" "this" {
     health_check_path                 = var.health_check_path
     health_check_eviction_time_in_min = 2
 
+    app_command_line = local.app_service.command_line
+
     application_stack {
       node_version        = var.stack == "node" ? "${var.node_version}-lts" : null
       java_version        = var.stack == "java" ? var.java_version : null

--- a/infra/modules/azure_app_service_exposed/app_service_slot.tf
+++ b/infra/modules/azure_app_service_exposed/app_service_slot.tf
@@ -19,6 +19,8 @@ resource "azurerm_linux_web_app_slot" "this" {
     health_check_path                 = var.health_check_path
     health_check_eviction_time_in_min = 2
 
+    app_command_line = local.app_service.command_line
+
     application_stack {
       node_version        = var.stack == "node" ? "${var.node_version}-lts" : null
       java_version        = var.stack == "java" ? var.java_version : null

--- a/infra/modules/azure_app_service_exposed/app_service_slot.tf
+++ b/infra/modules/azure_app_service_exposed/app_service_slot.tf
@@ -19,7 +19,7 @@ resource "azurerm_linux_web_app_slot" "this" {
     health_check_path                 = var.health_check_path
     health_check_eviction_time_in_min = 2
 
-    app_command_line = local.app_service.command_line
+    app_command_line = local.app_service.startup_command
 
     application_stack {
       node_version        = var.stack == "node" ? "${var.node_version}-lts" : null

--- a/infra/modules/azure_app_service_exposed/locals.tf
+++ b/infra/modules/azure_app_service_exposed/locals.tf
@@ -9,6 +9,7 @@ locals {
     zone_balancing_enabled = local.tier != "s" && local.tier != "xs"
     is_slot_enabled        = local.tier == "s" || local.tier == "xs" ? 0 : 1
     always_on              = local.tier == "xs" ? false : true
+    command_line           = var.pm2_startup_file_name == null ? null : "pm2 start ${var.pm2_startup_file_name} -i max --no-daemon"
   }
 
   application_insights = {

--- a/infra/modules/azure_app_service_exposed/locals.tf
+++ b/infra/modules/azure_app_service_exposed/locals.tf
@@ -9,7 +9,10 @@ locals {
     zone_balancing_enabled = local.tier != "s" && local.tier != "xs"
     is_slot_enabled        = local.tier == "s" || local.tier == "xs" ? 0 : 1
     always_on              = local.tier == "xs" ? false : true
-    command_line           = var.pm2_startup_file_name == null ? null : "pm2 start ${var.pm2_startup_file_name} -i max --no-daemon"
+    startup_command = (var.stack == "node"
+      ? (var.startup_command == "" ? "pm2 start index.js -i max --no-daemon" : var.startup_command)
+      : (var.stack == "java" && var.startup_command == "" ? null : var.startup_command)
+    )
   }
 
   application_insights = {

--- a/infra/modules/azure_app_service_exposed/tests/appservice.tftest.hcl
+++ b/infra/modules/azure_app_service_exposed/tests/appservice.tftest.hcl
@@ -79,3 +79,248 @@ run "app_service_is_correct_plan" {
     error_message = "The App Service should have Always On enabled"
   }
 }
+
+run "app_service_node_default_startup_command" {
+  command = plan
+
+  plan_options {
+    target = [
+      azurerm_linux_web_app.this,
+      azurerm_linux_web_app_slot.this,
+    ]
+  }
+
+  variables {
+    environment = {
+      prefix          = "dx"
+      env_short       = "d"
+      location        = "italynorth"
+      domain          = "modules"
+      app_name        = "test"
+      instance_number = "01"
+    }
+
+    tags = {}
+
+    resource_group_name = run.setup_tests.resource_group_name
+    tier                = "m"
+
+    app_settings      = {}
+    slot_app_settings = {}
+
+    health_check_path = "/health"
+  }
+
+  assert {
+    condition     = azurerm_linux_web_app.this.site_config[0].application_stack[0].node_version != null
+    error_message = "Node version is null"
+  }
+
+  assert {
+    condition     = azurerm_linux_web_app_slot.this[0].site_config[0].application_stack[0].node_version != null
+    error_message = "Node version is null on staging slot"
+  }
+
+  assert {
+    condition     = strcontains(azurerm_linux_web_app.this.site_config[0].app_command_line, "pm2 start")
+    error_message = "PM2 is not set as default for Node.js"
+  }
+
+  assert {
+    condition     = strcontains(azurerm_linux_web_app_slot.this[0].site_config[0].app_command_line, "pm2 start")
+    error_message = "PM2 is not set as default for Node.js on staging slot"
+  }
+}
+
+run "app_service_node_custom_startup_command" {
+  command = plan
+
+  plan_options {
+    target = [
+      azurerm_linux_web_app.this,
+        azurerm_linux_web_app_slot.this,
+    ]
+  }
+
+  variables {
+    environment = {
+      prefix          = "dx"
+      env_short       = "d"
+      location        = "italynorth"
+      domain          = "modules"
+      app_name        = "test"
+      instance_number = "01"
+    }
+
+    tags = {}
+
+    resource_group_name = run.setup_tests.resource_group_name
+    tier                = "m"
+
+    app_settings      = {}
+    slot_app_settings = {}
+
+    health_check_path = "/health"
+
+    startup_command = "custom command"
+  }
+
+  assert {
+    condition     = azurerm_linux_web_app.this.site_config[0].application_stack[0].node_version != null
+    error_message = "Node version is null"
+  }
+
+  assert {
+    condition     = azurerm_linux_web_app.this.site_config[0].app_command_line == "custom command"
+    error_message = "Startup command override doesn't work on Node.js stack"
+  }
+}
+
+run "app_service_java_default_startup_command" {
+  command = plan
+
+  plan_options {
+    target = [
+      azurerm_linux_web_app.this,
+        azurerm_linux_web_app_slot.this,
+    ]
+  }
+
+  variables {
+    environment = {
+      prefix          = "dx"
+      env_short       = "d"
+      location        = "italynorth"
+      domain          = "modules"
+      app_name        = "test"
+      instance_number = "01"
+    }
+
+    tags = {}
+
+    resource_group_name = run.setup_tests.resource_group_name
+    tier                = "m"
+
+    app_settings      = {}
+    slot_app_settings = {}
+
+    health_check_path = "/health"
+
+    stack = "java"
+  }
+
+  assert {
+    condition     = azurerm_linux_web_app.this.site_config[0].application_stack[0].java_version != null
+    error_message = "Java version is null"
+  }
+
+  assert {
+    condition     = azurerm_linux_web_app_slot.this[0].site_config[0].application_stack[0].java_version != null
+    error_message = "Java version is null on staging slot"
+  }
+
+  assert {
+    condition     = azurerm_linux_web_app.this.site_config[0].application_stack[0].java_server != null
+    error_message = "Java server is null"
+  }
+
+  assert {
+    condition     = azurerm_linux_web_app_slot.this[0].site_config[0].application_stack[0].java_server != null
+    error_message = "Java server is null on staging slot"
+  }
+
+  assert {
+    condition     = azurerm_linux_web_app.this.site_config[0].application_stack[0].java_server_version != null
+    error_message = "Java server version is null"
+  }
+
+  assert {
+    condition     = azurerm_linux_web_app_slot.this[0].site_config[0].application_stack[0].java_server_version != null
+    error_message = "Java server version is null on staging slot"
+  }
+
+  assert {
+    condition     = azurerm_linux_web_app.this.site_config[0].app_command_line == null
+    error_message = "Default startup command value is not null on Java stack"
+  }
+
+  assert {
+    condition     = azurerm_linux_web_app_slot.this[0].site_config[0].app_command_line == null
+    error_message = "Default startup command value is not null on Java stack on staging slot"
+  }
+}
+
+run "app_service_java_custom_startup_command" {
+  command = plan
+
+  plan_options {
+    target = [
+      azurerm_linux_web_app.this,
+        azurerm_linux_web_app_slot.this,
+    ]
+  }
+
+  variables {
+    environment = {
+      prefix          = "dx"
+      env_short       = "d"
+      location        = "italynorth"
+      domain          = "modules"
+      app_name        = "test"
+      instance_number = "01"
+    }
+
+    tags = {}
+
+    resource_group_name = run.setup_tests.resource_group_name
+    tier                = "m"
+
+    app_settings      = {}
+    slot_app_settings = {}
+
+    health_check_path = "/health"
+
+    stack           = "java"
+    startup_command = "custom command"
+  }
+
+  assert {
+    condition     = azurerm_linux_web_app.this.site_config[0].application_stack[0].java_version != null
+    error_message = "Java version is null"
+  }
+
+  assert {
+    condition     = azurerm_linux_web_app_slot.this[0].site_config[0].application_stack[0].java_version != null
+    error_message = "Java version is null on staging slot"
+  }
+
+  assert {
+    condition     = azurerm_linux_web_app.this.site_config[0].application_stack[0].java_server != null
+    error_message = "Java server is null"
+  }
+
+  assert {
+    condition     = azurerm_linux_web_app_slot.this[0].site_config[0].application_stack[0].java_server != null
+    error_message = "Java server is null on staging slot"
+  }
+
+  assert {
+    condition     = azurerm_linux_web_app.this.site_config[0].application_stack[0].java_server_version != null
+    error_message = "Java server version is null"
+  }
+
+  assert {
+    condition     = azurerm_linux_web_app_slot.this[0].site_config[0].application_stack[0].java_server_version != null
+    error_message = "Java server version is null on staging slot"
+  }
+
+  assert {
+    condition     = azurerm_linux_web_app.this.site_config[0].app_command_line != null
+    error_message = "Startup command override doesn't work on Java stack"
+  }
+
+  assert {
+    condition     = azurerm_linux_web_app_slot.this[0].site_config[0].app_command_line != null
+    error_message = "Startup command override doesn't work on Java stack on staging slot"
+  }
+}

--- a/infra/modules/azure_app_service_exposed/variables.tf
+++ b/infra/modules/azure_app_service_exposed/variables.tf
@@ -76,6 +76,12 @@ variable "java_version" {
   description = "Java version to use"
 }
 
+variable "startup_command" {
+  type        = string
+  default     = ""
+  description = "(Optional) The PM2 file used as PM2 process entry point"
+}
+
 variable "application_insights_sampling_percentage" {
   type        = number
   default     = 5
@@ -97,16 +103,4 @@ variable "sticky_app_setting_names" {
   type        = list(string)
   description = "(Optional) A list of application setting names that are not swapped between slots"
   default     = []
-}
-
-variable "pm2_startup_file_name" {
-  type        = string
-  default     = null
-  description = "(Optional) Use this variable to enable PM2. The specified file is used as PM2 process entry point"
-}
-
-variable "startup_command" {
-  type        = string
-  default     = ""
-  description = "(Optional) The PM2 file used as PM2 process entry point"
 }

--- a/infra/modules/azure_app_service_exposed/variables.tf
+++ b/infra/modules/azure_app_service_exposed/variables.tf
@@ -79,7 +79,7 @@ variable "java_version" {
 variable "startup_command" {
   type        = string
   default     = ""
-  description = "(Optional) The PM2 file used as PM2 process entry point"
+  description = "(Optional) Override AppService startup command. If using node, the default value uses PM2"
 }
 
 variable "application_insights_sampling_percentage" {

--- a/infra/modules/azure_app_service_exposed/variables.tf
+++ b/infra/modules/azure_app_service_exposed/variables.tf
@@ -104,3 +104,9 @@ variable "pm2_startup_file_name" {
   default     = null
   description = "(Optional) Use this variable to enable PM2. The specified file is used as PM2 process entry point"
 }
+
+variable "startup_command" {
+  type        = string
+  default     = ""
+  description = "(Optional) The PM2 file used as PM2 process entry point"
+}

--- a/infra/modules/azure_app_service_exposed/variables.tf
+++ b/infra/modules/azure_app_service_exposed/variables.tf
@@ -98,3 +98,9 @@ variable "sticky_app_setting_names" {
   description = "(Optional) A list of application setting names that are not swapped between slots"
   default     = []
 }
+
+variable "pm2_startup_file_name" {
+  type        = string
+  default     = null
+  description = "(Optional) Use this variable to enable PM2. The specified file is used as PM2 process entry point"
+}

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pagopa/dx",
-  "packageManager": "yarn@4.4.0",
+  "packageManager": "yarn@4.6.0",
   "workspaces": [
     "packages/**",
     "website",


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

### List of changes

<!--- Describe your changes in detail -->

Override app startup command if PM2 entry point file is provided in AppService modules

### Motivation and context

<!--- Why is this change required? What problem does it solve? -->

More teams are using PM2 to exploit full hardware capacity

### Type of changes

- [ ] Add new resources
- [X] Update configuration to existing resources
- [ ] Remove existing resources

### Does this introduce a change to production resources with possible user impact?

- [ ] Yes, users may be impacted applying this change
- [X] No

### Other information

depends on #204