### PR TITLE
fix: add modules script now uses dashes

### DIFF
--- a/.github/workflows/push_modules_to_subrepo.yml
+++ b/.github/workflows/push_modules_to_subrepo.yml
@@ -52,6 +52,7 @@ jobs:
     needs: [get-modified-modules, get-all-modules]
     if: always()
     strategy:
+      fail-fast: false
       matrix:
         module: ${{ fromJSON(needs.get-all-modules.outputs.modules || needs.get-modified-modules.outputs.modules) }}
     steps:

--- a/infra/modules/azure_core_infra/package.json
+++ b/infra/modules/azure_core_infra/package.json
@@ -1,6 +1,6 @@
 {
   "name": "azure_core_infra",
-  "version": "0.0.0",
+  "version": "0.0.1",
   "private": true,
   "provider": "azurerm"
 }

--- a/infra/scripts/add-module.sh
+++ b/infra/scripts/add-module.sh
@@ -27,7 +27,8 @@ if [ -z "$MODULE_NAME" ]; then
 fi
 
 DX_PREFIX="dx"
-SUBREPO_NAME="terraform-$PROVIDER-${DX_PREFIX}_${MODULE_NAME}"
+SUBREPO_NAME="terraform-$PROVIDER-${DX_PREFIX}-${MODULE_NAME}"
+SUBREPO_NAME=${SUBREPO_NAME//_/\-}
 MODULE_DIR="infra/modules/$MODULE_NAME"
 
 # Check if the module directory already exists


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

### List of changes

<!--- Describe your changes in detail -->
- add modules script now uses dashes in subrepo names
- the action that push modules to subrepos, now won't stop if one of them fails
- added azure_core_infra package.json

### Motivation and context

<!--- Why is this change required? What problem does it solve? -->

### Type of changes

- [ ] Add new resources
- [ ] Update configuration to existing resources
- [ ] Remove existing resources

### Does this introduce a change to production resources with possible user impact?

- [ ] Yes, users may be impacted applying this change
- [ ] No

### Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->
