### PR TITLE
Remove hardcoded version from workflow

### DIFF
--- a/.github/workflows/web_app_deploy.yaml
+++ b/.github/workflows/web_app_deploy.yaml
@@ -47,7 +47,7 @@ jobs:
         name: Checkout
 
       - name: Prune
-        run: npx turbo prune --scope ${{ env.WORKSPACE }}
+        run: npx turbo@2 prune --scope ${{ env.WORKSPACE }}
 
       - name: Enable Corepack
         run: corepack enable

--- a/.github/workflows/web_app_deploy.yaml
+++ b/.github/workflows/web_app_deploy.yaml
@@ -49,6 +49,9 @@ jobs:
       - name: Prune
         run: npx turbo prune --scope ${{ env.WORKSPACE }}
 
+      - name: Enable Corepack
+        run: corepack enable
+
       - name: Setup Node.js
         uses: actions/setup-node@60edb5dd545a775178f52524783378180af0d1f8 # v4.0.2
         with:

--- a/.github/workflows/web_app_deploy.yaml
+++ b/.github/workflows/web_app_deploy.yaml
@@ -47,7 +47,7 @@ jobs:
         name: Checkout
 
       - name: Prune
-        run: npx turbo@1.13.3 prune --scope ${{ env.WORKSPACE }}
+        run: npx turbo prune --scope ${{ env.WORKSPACE }}
 
       - name: Setup Node.js
         uses: actions/setup-node@60edb5dd545a775178f52524783378180af0d1f8 # v4.0.2


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

### List of changes

<!--- Describe your changes in detail -->
- Enable `corepack`
- Use `turbo` on major version 2

### Motivation and context

<!--- Why is this change required? What problem does it solve? -->
We want to use the latest `turbo` version in our workflows.

### Type of changes

- [ ] Add new resources
- [ ] Update configuration to existing resources
- [ ] Remove existing resources

### Does this introduce a change to production resources with possible user impact?

- [x] Yes, users may be impacted applying this change
- [ ] No

It can impact those projects that are pointing to `main` when referencing the updated workflow.

### Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->

There is a PR that shows how to migrate from `turbo` 1 to version 2.
Reference: https://github.com/pagopa/trial-system/pull/267

### Migration guide
First, check the [official documentation](https://turbo.build/repo/docs/crafting-your-repository/upgrading) for any doubts.

- Run `yarn dlx @turbo/codemod migrate` or `npx @turbo/codemod migrate` (official tool that should help to migrate. Follow the wizard)
   - This will update the `turbo.json` file and try to install the latest version of `turbo`
     - In case of errors, you can manually update the `turbo.json` file [following these steps](https://turbo.build/repo/docs/reference/turbo-codemod#turborepo-2x)
     - In case it wasn't possible to install `turbo`, try to do it manually:
       - `yarn add -D turbo`
     - Now you should be ready to use the latest version of `turbo`
 - Eventually, update the workflow pointing to a specific SHA
