### PR TITLE
[PE-881] Output PEP's recordsets for App Services

### DIFF
--- a/.changeset/tame-seals-shop.md
+++ b/.changeset/tame-seals-shop.md
@@ -1,0 +1,5 @@
+---
+"azure_app_service": patch
+---
+
+Adding to outputs the recordsets pointing to app services' private endpoint

--- a/infra/modules/azure_app_service/outputs.tf
+++ b/infra/modules/azure_app_service/outputs.tf
@@ -17,14 +17,14 @@ output "app_service" {
       name         = azurerm_linux_web_app.this.name
       principal_id = azurerm_linux_web_app.this.identity[0].principal_id
       pep = {
-        record_sets = azurerm_private_endpoint.app_service_sites.private_dns_zone_configs.record_sets
+        record_sets = azurerm_private_endpoint.app_service_sites.private_dns_zone_configs[0].record_sets
       }
       slot = {
         id           = try(azurerm_linux_web_app_slot.this[0].id, null)
         name         = try(azurerm_linux_web_app_slot.this[0].name, null)
         principal_id = try(azurerm_linux_web_app_slot.this[0].identity[0].principal_id, null)
         pep = {
-          record_sets = try(azurerm_private_endpoint.staging_app_service_sites[0].private_dns_zone_configs.record_sets, null)
+          record_sets = try(azurerm_private_endpoint.staging_app_service_sites[0].private_dns_zone_configs[0].record_sets, null)
         }
       }
     }

--- a/infra/modules/azure_app_service/outputs.tf
+++ b/infra/modules/azure_app_service/outputs.tf
@@ -16,10 +16,16 @@ output "app_service" {
       id           = azurerm_linux_web_app.this.id
       name         = azurerm_linux_web_app.this.name
       principal_id = azurerm_linux_web_app.this.identity[0].principal_id
+      pep          = {
+        record_sets = azurerm_private_endpoint.app_service_sites.private_dns_zone_configs.record_sets
+      }
       slot = {
         id           = try(azurerm_linux_web_app_slot.this[0].id, null)
         name         = try(azurerm_linux_web_app_slot.this[0].name, null)
         principal_id = try(azurerm_linux_web_app_slot.this[0].identity[0].principal_id, null)
+        pep = {
+          record_sets  = try(azurerm_private_endpoint.staging_app_service_sites[0].private_dns_zone_configs.record_sets, null)
+        }
       }
     }
   }

--- a/infra/modules/azure_app_service/outputs.tf
+++ b/infra/modules/azure_app_service/outputs.tf
@@ -16,7 +16,7 @@ output "app_service" {
       id           = azurerm_linux_web_app.this.id
       name         = azurerm_linux_web_app.this.name
       principal_id = azurerm_linux_web_app.this.identity[0].principal_id
-      pep          = {
+      pep = {
         record_sets = azurerm_private_endpoint.app_service_sites.private_dns_zone_configs.record_sets
       }
       slot = {
@@ -24,7 +24,7 @@ output "app_service" {
         name         = try(azurerm_linux_web_app_slot.this[0].name, null)
         principal_id = try(azurerm_linux_web_app_slot.this[0].identity[0].principal_id, null)
         pep = {
-          record_sets  = try(azurerm_private_endpoint.staging_app_service_sites[0].private_dns_zone_configs.record_sets, null)
+          record_sets = try(azurerm_private_endpoint.staging_app_service_sites[0].private_dns_zone_configs.record_sets, null)
         }
       }
     }

--- a/infra/modules/azure_app_service/outputs.tf
+++ b/infra/modules/azure_app_service/outputs.tf
@@ -13,19 +13,15 @@ output "app_service" {
       name = try(azurerm_service_plan.this[0].name, null)
     }
     app_service = {
-      id           = azurerm_linux_web_app.this.id
-      name         = azurerm_linux_web_app.this.name
-      principal_id = azurerm_linux_web_app.this.identity[0].principal_id
-      pep = {
-        record_sets = azurerm_private_endpoint.app_service_sites.private_dns_zone_configs[0].record_sets
-      }
+      id              = azurerm_linux_web_app.this.id
+      name            = azurerm_linux_web_app.this.name
+      principal_id    = azurerm_linux_web_app.this.identity[0].principal_id
+      pep_record_sets = azurerm_private_endpoint.app_service_sites.private_dns_zone_configs[0].record_sets
       slot = {
-        id           = try(azurerm_linux_web_app_slot.this[0].id, null)
-        name         = try(azurerm_linux_web_app_slot.this[0].name, null)
-        principal_id = try(azurerm_linux_web_app_slot.this[0].identity[0].principal_id, null)
-        pep = {
-          record_sets = try(azurerm_private_endpoint.staging_app_service_sites[0].private_dns_zone_configs[0].record_sets, null)
-        }
+        id              = try(azurerm_linux_web_app_slot.this[0].id, null)
+        name            = try(azurerm_linux_web_app_slot.this[0].name, null)
+        principal_id    = try(azurerm_linux_web_app_slot.this[0].identity[0].principal_id, null)
+        pep_record_sets = try(azurerm_private_endpoint.staging_app_service_sites[0].private_dns_zone_configs[0].record_sets, null)
       }
     }
   }


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

### List of changes

<!--- Describe your changes in detail -->
Output PEP's recordsets for App Services

### Motivation and context

<!--- Why is this change required? What problem does it solve? -->
In order to enable private reachability of an app service located in a peered vnet, this information is needed. In fact, the dns records pointing to the pep must also be created in the peered vnet's private dns zone.
### Type of changes

- [ ] Add new resources
- [X] Update configuration to existing resources
- [ ] Remove existing resources

### Does this introduce a change to production resources with possible user impact?

- [ ] Yes, users may be impacted applying this change
- [X] No

### Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->
