### PR TITLE
[CES-667] Make optional the subnet_cidr variable

### DIFF
--- a/.changeset/thin-meals-accept.md
+++ b/.changeset/thin-meals-accept.md
@@ -1,0 +1,6 @@
+---
+"azure_function_app": patch
+"azure_app_service": patch
+---
+
+Variable subnet_cidr is no longer required when a value for subnet_id is provided

--- a/infra/modules/azure_app_service/README.md
+++ b/infra/modules/azure_app_service/README.md
@@ -44,7 +44,7 @@
 | <a name="input_slot_app_settings"></a> [slot\_app\_settings](#input\_slot\_app\_settings) | Staging slot application settings | `map(string)` | `{}` | no |
 | <a name="input_stack"></a> [stack](#input\_stack) | n/a | `string` | `"node"` | no |
 | <a name="input_sticky_app_setting_names"></a> [sticky\_app\_setting\_names](#input\_sticky\_app\_setting\_names) | (Optional) A list of application setting names that are not swapped between slots | `list(string)` | `[]` | no |
-| <a name="input_subnet_cidr"></a> [subnet\_cidr](#input\_subnet\_cidr) | CIDR block to use for the subnet the Function App uses for outbound connectivity | `string` | n/a | yes |
+| <a name="input_subnet_cidr"></a> [subnet\_cidr](#input\_subnet\_cidr) | (Optional) CIDR block to use for the subnet the AppService uses for outbound connectivity. Mandatory if subnet\_id is not set | `string` | `null` | no |
 | <a name="input_subnet_id"></a> [subnet\_id](#input\_subnet\_id) | (Optional) Set the subnet id where you want to host the Function App | `string` | `null` | no |
 | <a name="input_subnet_pep_id"></a> [subnet\_pep\_id](#input\_subnet\_pep\_id) | Id of the subnet which holds private endpoints | `string` | n/a | yes |
 | <a name="input_subnet_service_endpoints"></a> [subnet\_service\_endpoints](#input\_subnet\_service\_endpoints) | (Optional) Enable service endpoints for the underlying subnet. This variable should be set only if function dependencies do not use private endpoints | <pre>object({<br/>    cosmos  = optional(bool, false)<br/>    storage = optional(bool, false)<br/>    web     = optional(bool, false)<br/>  })</pre> | `null` | no |

--- a/infra/modules/azure_app_service/tests/appservice.tftest.hcl
+++ b/infra/modules/azure_app_service/tests/appservice.tftest.hcl
@@ -82,6 +82,11 @@ run "app_service_is_correct_plan" {
     condition     = azurerm_linux_web_app.this.site_config[0].always_on == true
     error_message = "The App Service should have Always On enabled"
   }
+
+  assert {
+    condition     = length(azurerm_subnet.this) == 1
+    error_message = "Subnet should be created"
+  }
 }
 
 run "app_service_custom_subnet" {
@@ -109,7 +114,6 @@ run "app_service_custom_subnet" {
 
     subnet_pep_id                        = run.setup_tests.pep_id
     subnet_id                            = run.setup_tests.pep_id
-    subnet_cidr                          = "10.20.50.0/24"
     private_dns_zone_resource_group_name = "dx-d-itn-network-rg-01"
 
     app_settings      = {}

--- a/infra/modules/azure_app_service/variables.tf
+++ b/infra/modules/azure_app_service/variables.tf
@@ -104,7 +104,13 @@ variable "sticky_app_setting_names" {
 
 variable "subnet_cidr" {
   type        = string
-  description = "CIDR block to use for the subnet the Function App uses for outbound connectivity"
+  default     = null
+  description = "(Optional) CIDR block to use for the subnet the AppService uses for outbound connectivity. Mandatory if subnet_id is not set"
+
+  validation {
+    condition = (var.subnet_id != null) != (var.subnet_cidr != null)
+    error_message = "Please specify the subnet_cidr or the subnet_id, not both"
+  }
 }
 
 variable "subnet_pep_id" {

--- a/infra/modules/azure_app_service/variables.tf
+++ b/infra/modules/azure_app_service/variables.tf
@@ -108,7 +108,7 @@ variable "subnet_cidr" {
   description = "(Optional) CIDR block to use for the subnet the AppService uses for outbound connectivity. Mandatory if subnet_id is not set"
 
   validation {
-    condition = (var.subnet_id != null) != (var.subnet_cidr != null)
+    condition     = (var.subnet_id != null) != (var.subnet_cidr != null)
     error_message = "Please specify the subnet_cidr or the subnet_id, not both"
   }
 }

--- a/infra/modules/azure_function_app/README.md
+++ b/infra/modules/azure_function_app/README.md
@@ -62,7 +62,7 @@
 | <a name="input_slot_app_settings"></a> [slot\_app\_settings](#input\_slot\_app\_settings) | Staging slot application settings | `map(string)` | `{}` | no |
 | <a name="input_stack"></a> [stack](#input\_stack) | n/a | `string` | `"node"` | no |
 | <a name="input_sticky_app_setting_names"></a> [sticky\_app\_setting\_names](#input\_sticky\_app\_setting\_names) | (Optional) A list of application setting names that are not swapped between slots | `list(string)` | `[]` | no |
-| <a name="input_subnet_cidr"></a> [subnet\_cidr](#input\_subnet\_cidr) | CIDR block to use for the subnet the Function App uses for outbound connectivity | `string` | n/a | yes |
+| <a name="input_subnet_cidr"></a> [subnet\_cidr](#input\_subnet\_cidr) | (Optional) CIDR block to use for the subnet the Function App uses for outbound connectivity. Mandatory if subnet\_id is not set | `string` | `null` | no |
 | <a name="input_subnet_id"></a> [subnet\_id](#input\_subnet\_id) | (Optional) Set the subnet id where you want to host the Function App | `string` | `null` | no |
 | <a name="input_subnet_pep_id"></a> [subnet\_pep\_id](#input\_subnet\_pep\_id) | Id of the subnet which holds private endpoints | `string` | n/a | yes |
 | <a name="input_subnet_service_endpoints"></a> [subnet\_service\_endpoints](#input\_subnet\_service\_endpoints) | (Optional) Enable service endpoints for the underlying subnet. This variable should be set only if function dependencies do not use private endpoints | <pre>object({<br/>    cosmos  = optional(bool, false)<br/>    storage = optional(bool, false)<br/>    web     = optional(bool, false)<br/>  })</pre> | `null` | no |

--- a/infra/modules/azure_function_app/tests/functionapp.tftest.hcl
+++ b/infra/modules/azure_function_app/tests/functionapp.tftest.hcl
@@ -34,15 +34,7 @@ run "function_app_is_correct_plan" {
       instance_number = "01"
     }
 
-    tags = {
-      CostCenter  = "TS700 - ENGINEERING"
-      CreatedBy   = "Terraform"
-      Environment = "Dev"
-      Owner       = "DevEx"
-      Source      = "https://github.com/pagopa/dx/blob/main/infra/modules/azure_function_app/tests"
-      Test        = "true"
-      TestName    = "Create Function app for test"
-    }
+    tags = {}
 
     resource_group_name = run.setup_tests.resource_group_name
     tier                = "m"
@@ -93,6 +85,11 @@ run "function_app_is_correct_plan" {
     condition     = azurerm_private_endpoint.st_blob.subnet_id == run.setup_tests.pep_id
     error_message = "The Private Endpoint must be in the correct subnet"
   }
+
+  assert {
+    condition     = length(azurerm_subnet.this) == 1
+    error_message = "Subnet should be created"
+  }
 }
 
 run "function_app_custom_subnet" {
@@ -119,7 +116,6 @@ run "function_app_custom_subnet" {
     }
 
     subnet_pep_id                        = run.setup_tests.pep_id
-    subnet_cidr                          = "10.50.80.0/24"
     subnet_id                            = run.setup_tests.pep_id
     private_dns_zone_resource_group_name = "dx-d-itn-network-rg-01"
 
@@ -127,7 +123,6 @@ run "function_app_custom_subnet" {
     slot_app_settings = {}
 
     health_check_path = "/health"
-
   }
 
   assert {

--- a/infra/modules/azure_function_app/variables.tf
+++ b/infra/modules/azure_function_app/variables.tf
@@ -131,7 +131,13 @@ variable "sticky_app_setting_names" {
 
 variable "subnet_cidr" {
   type        = string
-  description = "CIDR block to use for the subnet the Function App uses for outbound connectivity"
+  default     = null
+  description = "(Optional) CIDR block to use for the subnet the Function App uses for outbound connectivity. Mandatory if subnet_id is not set"
+
+  validation {
+    condition = (var.subnet_id != null) != (var.subnet_cidr != null)
+    error_message = "Please specify the subnet_cidr or the subnet_id, not both"
+  }
 }
 
 variable "subnet_pep_id" {

--- a/infra/modules/azure_function_app/variables.tf
+++ b/infra/modules/azure_function_app/variables.tf
@@ -135,7 +135,7 @@ variable "subnet_cidr" {
   description = "(Optional) CIDR block to use for the subnet the Function App uses for outbound connectivity. Mandatory if subnet_id is not set"
 
   validation {
-    condition = (var.subnet_id != null) != (var.subnet_cidr != null)
+    condition     = (var.subnet_id != null) != (var.subnet_cidr != null)
     error_message = "Please specify the subnet_cidr or the subnet_id, not both"
   }
 }


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

### List of changes

<!--- Describe your changes in detail -->
In AppService and FunctionApp modules, the variable `subnet_cidr` is no longer required when a value for `subnet_id` is provided

### Motivation and context

<!--- Why is this change required? What problem does it solve? -->
Variable `subnet_cidr` is not used when a value for `subnet_id` is provided

### Type of changes

- [ ] Add new resources
- [X] Update configuration to existing resources
- [ ] Remove existing resources

### Does this introduce a change to production resources with possible user impact?

- [ ] Yes, users may be impacted applying this change
- [X] No

### Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->
