### PR TITLE
[CES-679] Make AI integration optional

### DIFF
--- a/.changeset/curly-rockets-give.md
+++ b/.changeset/curly-rockets-give.md
@@ -1,0 +1,5 @@
+---
+"azure_function_app": patch
+---
+
+Make AI integration optional

--- a/infra/modules/azure_function_app/variables.tf
+++ b/infra/modules/azure_function_app/variables.tf
@@ -45,7 +45,7 @@ variable "application_insights_connection_string" {
   description = "(Optional) Application Insights connection string"
 
   validation {
-    condition     = ((var.application_insights_connection_string != null) != (var.application_insights_key != null)) || (var.application_insights_connection_string == null && var.application_insights_key == null)
+    condition     = var.application_insights_connection_string == null || var.application_insights_key == null
     error_message = "Please provide either Application Insights connection string or instrumentation key, or neither. Using a connection string is preferable as instrumentation key will be deprecated on March 31, 2025. Do not use both."
   }
 }

--- a/infra/modules/azure_function_app/variables.tf
+++ b/infra/modules/azure_function_app/variables.tf
@@ -45,7 +45,7 @@ variable "application_insights_connection_string" {
   description = "(Optional) Application Insights connection string"
 
   validation {
-    condition     = (var.application_insights_connection_string != null || var.application_insights_key != null) || (var.application_insights_connection_string == null && var.application_insights_key == null)
+    condition     = ((var.application_insights_connection_string != null) != (var.application_insights_key != null)) || (var.application_insights_connection_string == null && var.application_insights_key == null)
     error_message = "Please provide either Application Insights connection string or instrumentation key, or neither. Using a connection string is preferable as instrumentation key will be deprecated on March 31, 2025. Do not use both."
   }
 }

--- a/infra/modules/azure_function_app/variables.tf
+++ b/infra/modules/azure_function_app/variables.tf
@@ -45,8 +45,8 @@ variable "application_insights_connection_string" {
   description = "(Optional) Application Insights connection string"
 
   validation {
-    condition     = (var.application_insights_connection_string != null) != (var.application_insights_key != null)
-    error_message = "Please provide Application Insights connection string if you are not using instrumentation key. Using a connection string is preferrable as instrumentation key will be deprecated on March 31, 2025. Do not use both."
+    condition     = (var.application_insights_connection_string != null || var.application_insights_key != null) || (var.application_insights_connection_string == null && var.application_insights_key == null)
+    error_message = "Please provide either Application Insights connection string or instrumentation key, or neither. Using a connection string is preferable as instrumentation key will be deprecated on March 31, 2025. Do not use both."
   }
 }
 


### PR DESCRIPTION
### List of changes

Change the validation on AI variables to allow module users to create functions without integrating with Application Insights.

### Motivation and context

There was a breaking change that made default AI 
integration mandatory:

https://github.com/pagopa/dx/pull/224

which breaks existing function apps and even the example in this repo:

https://github.com/pagopa/dx/blob/main/infra/modules/azure_function_app/examples/complete/main.tf#L24

### Type of changes

- [ ] Add new resources
- [X] Update configuration to existing resources
- [ ] Remove existing resources

### Does this introduce a change to production resources with possible user impact?

- [X] No
