### PR TITLE
[CES-865] Fix get-modified-modules always returning an empty list

### DIFF
--- a/.github/workflows/get_modified_modules.yaml
+++ b/.github/workflows/get_modified_modules.yaml
@@ -1,5 +1,11 @@
 on:
   workflow_call:
+    inputs:
+      from_ref:
+        required: true
+        type: string
+        description: "The starting commit for computing the diff against the PR destination branch"
+
     outputs:
       modules:
         value: ${{ jobs.get-modified-modules.outputs.modules }}
@@ -18,7 +24,7 @@ jobs:
       - name: Get modified modules
         id: get-modules
         run: |
-          folders_list=$(git diff --name-only ${{ github.event.before }} ${{ github.sha }} infra/modules | xargs -r dirname | sed 's#^infra\/modules/\([^/]*\).*#\1#' | uniq | jq -R -c . | jq -s -c .)
+          folders_list=$(git diff --name-only ${{ inputs.from_ref }} ${{ github.sha }} infra/modules | xargs -r dirname | sed 's#^infra\/modules/\([^/]*\).*#\1#' | uniq | jq -R -c . | jq -s -c .)
           echo Modules changed: $folders_list
           echo "modules=$folders_list" >> $GITHUB_OUTPUT
 

--- a/.github/workflows/get_modified_modules.yaml
+++ b/.github/workflows/get_modified_modules.yaml
@@ -18,7 +18,7 @@ jobs:
       - name: Get modified modules
         id: get-modules
         run: |
-          folders_list=$(git diff --name-only origin/main ${{ github.sha }} infra/modules | xargs -r dirname | sed 's#^infra\/modules/\([^/]*\).*#\1#' | uniq | jq -R -c . | jq -s -c .)
+          folders_list=$(git diff --name-only ${{ github.event.before }} ${{ github.sha }} infra/modules | xargs -r dirname | sed 's#^infra\/modules/\([^/]*\).*#\1#' | uniq | jq -R -c . | jq -s -c .)
           echo Modules changed: $folders_list
           echo "modules=$folders_list" >> $GITHUB_OUTPUT
 

--- a/.github/workflows/push_modules_to_subrepo.yml
+++ b/.github/workflows/push_modules_to_subrepo.yml
@@ -17,6 +17,8 @@ jobs:
     uses: ./.github/workflows/get_modified_modules.yaml
     name: Get Modified Modules
     if: ${{ github.event_name != 'workflow_dispatch' }}
+    with:
+      from_ref: ${{ github.event.before }}
 
   get-all-modules:
     uses: ./.github/workflows/get_all_modules.yaml


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

### List of changes

<!--- Describe your changes in detail -->
Passing the starting commit of the diff via input to the get-modified-modules workflow
### Motivation and context

<!--- Why is this change required? What problem does it solve? -->
The workflow was always returning an empty list of modules although they actually changed.

### Type of changes

- [ ] Add new resources
- [ ] Update configuration to existing resources
- [ ] Remove existing resources

### Does this introduce a change to production resources with possible user impact?

- [ ] Yes, users may be impacted applying this change
- [ ] No

### Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->
