### PR TITLE
[CES-690] Dynamically get terraform version from file in static analysis workflow

### DIFF
--- a/.github/actions/get-terraform-version/action.yaml
+++ b/.github/actions/get-terraform-version/action.yaml
@@ -1,0 +1,37 @@
+name: Get Terraform Version
+description: Retrieve the Terraform version from the `.terraform-version` file or return a default version.
+inputs:
+  default_version:
+    description: "Default Terraform version to use if the `.terraform-version` file is not found."
+    required: false
+    default: "1.10.4"
+outputs:
+  terraform_version:
+    description: "The Terraform version retrieved or the default."
+runs:
+  using: "composite"
+  steps:
+    - name: Get Terraform Version
+      shell: bash
+      run: |
+        # Default version provided via input
+        DEFAULT_VERSION="${{ inputs.default_version }}"
+        
+        # Check for the .terraform-version file
+        if [ -f ".terraform-version" ]; then
+            TERRAFORM_VERSION=$(cat .terraform-version)
+            
+            # Validate the version format
+            if [[ "$TERRAFORM_VERSION" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+                echo "Terraform version found in .terraform-version file: $TERRAFORM_VERSION"
+            else
+                echo "Error: Invalid Terraform version format: $TERRAFORM_VERSION"
+                exit 1
+            fi
+        else
+            TERRAFORM_VERSION="$DEFAULT_VERSION"
+            echo "No .terraform-version file found. Defaulting to $TERRAFORM_VERSION"
+        fi
+        
+        # Output the Terraform version
+        echo "terraform_version=$TERRAFORM_VERSION" >> $GITHUB_OUTPUT

--- a/.github/workflows/get_terraform_version.yaml
+++ b/.github/workflows/get_terraform_version.yaml
@@ -3,7 +3,7 @@ on:
     outputs:
       terraform_version:
         value: ${{ jobs.get-terraform-version.outputs.terraform_version }}
-        description: "List of all modules in the format [\"name1\", \"name2\"]"
+        description: "The terraform version retrieved from the .terraform-version file. If missing, it returns a default recommended version."
 jobs:
   get-terraform-version:
     runs-on: ubuntu-latest

--- a/.github/workflows/get_terraform_version.yaml
+++ b/.github/workflows/get_terraform_version.yaml
@@ -1,0 +1,27 @@
+on:
+  workflow_call:
+    outputs:
+      terraform_version:
+        value: ${{ jobs.get-terraform-version.outputs.terraform_version }}
+        description: "List of all modules in the format [\"name1\", \"name2\"]"
+jobs:
+  get-terraform-version:
+    runs-on: ubuntu-latest
+    name: Get terraform version
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v3
+
+      - name: Determine Terraform version
+        id: get-terraform-version
+        run: |
+          if [ -f ".terraform-version" ]; then
+              TERRAFORM_VERSION=$(cat .terraform-version)
+              echo "Terraform version found in .terraform-version file: $TERRAFORM_VERSION"
+          else
+              TERRAFORM_VERSION="1.10.4"
+              echo "No .terraform-version file found. Defaulting to $TERRAFORM_VERSION"
+          fi
+          echo "terraform_version=$TERRAFORM_VERSION" >> $GITHUB_OUTPUT
+    outputs:
+      terraform_version: ${{ steps.get-terraform-version.outputs.terraform_version }}

--- a/.github/workflows/get_terraform_version.yaml
+++ b/.github/workflows/get_terraform_version.yaml
@@ -17,6 +17,10 @@ jobs:
         run: |
           if [ -f ".terraform-version" ]; then
               TERRAFORM_VERSION=$(cat .terraform-version)
+              if ! [[ "$TERRAFORM_VERSION" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+                echo "Error: Invalid Terraform version format: $TERRAFORM_VERSION"
+                exit 1
+              fi
               echo "Terraform version found in .terraform-version file: $TERRAFORM_VERSION"
           else
               TERRAFORM_VERSION="1.10.4"

--- a/.github/workflows/get_terraform_version.yaml
+++ b/.github/workflows/get_terraform_version.yaml
@@ -10,7 +10,7 @@ jobs:
     name: Get terraform version
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
 
       - name: Determine Terraform version
         id: get-terraform-version

--- a/.github/workflows/static_analysis.yaml
+++ b/.github/workflows/static_analysis.yaml
@@ -1,7 +1,3 @@
-# This pipeline assumes the presence of a .pre-commit-config.yaml file at
-# the top level of the repository, which contains Terraform validation tasks.
-# For more details, refer to the pre-commit configuration file:
-# https://github.com/pagopa/dx/blob/main/.pre-commit-config.yaml.
 name: Static Analysis - TF Validation
 
 on:
@@ -11,7 +7,6 @@ on:
         description: Terraform version to use
         type: string
         required: false
-        default: "1.7.5"
       pre_commit_tf_tag:
         description: |
           Pre-commit Terraform TAG to use,
@@ -35,11 +30,16 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  get-terraform-version:
+    uses: ./.github/workflows/get_terraform_version.yaml
+    name: Get terraform version from .terraform-version file
+
   tf_analysis:
     name: Terraform Validation
     runs-on: ubuntu-latest
+    needs: [ get-terraform-version ]
     env:
-      TERRAFORM_VERSION: ${{ inputs.terraform_version }}
+      TERRAFORM_VERSION: ${{ inputs.terraform_version || needs.get-terraform-version.outputs.terraform_version }}
     container:
       image: ghcr.io/antonbabenko/pre-commit-terraform:${{ inputs.pre_commit_tf_tag }}
     defaults:
@@ -47,14 +47,12 @@ jobs:
         shell: bash
 
     steps:
-
       - name: Checkout
         uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
         with:
           fetch-depth: 0
           ref: ${{ github.sha }}
 
-      # https://github.com/antonbabenko/pre-commit-terraform#github-actions
       - name: Git config
         run: |
           set -eu
@@ -65,7 +63,6 @@ jobs:
       - name: Fix Alpine Container Image
         run: |
           apk --no-cache add tar
-          # check python modules installed versions
           python -m pip freeze --local
 
       - name: Run pre-commit on Modified Files

--- a/.github/workflows/static_analysis.yaml
+++ b/.github/workflows/static_analysis.yaml
@@ -1,15 +1,10 @@
-# This pipeline assumes the presence of a .pre-commit-config.yaml file at
-# the top level of the repository, which contains Terraform validation tasks.
-# For more details, refer to the pre-commit configuration file:
-# https://github.com/pagopa/dx/blob/main/.pre-commit-config.yaml.
-
 name: Static Analysis - TF Validation
 
 on:
   workflow_call:
     inputs:
       terraform_version:
-        description: Terraform version to use. If not set it is automatically retrieved from .terraform-version file.
+        description: Terraform version to use. If not set, it is automatically retrieved from .terraform-version file.
         type: string
         required: false
       pre_commit_tf_tag:
@@ -21,7 +16,7 @@ on:
         required: false
         default: "v1.94.1@sha256:638e8892cb2647240c175064254c2fda80214597275c81a360a878dc80323076"
       enable_modified_files_detection:
-        description: If true the pipeline will run pre-commit on modified files only
+        description: If true, the pipeline will run pre-commit on modified files only.
         type: boolean
         required: false
         default: false
@@ -36,8 +31,16 @@ concurrency:
 
 jobs:
   get-terraform-version:
-    uses: ./.github/workflows/get_terraform_version.yaml
-    name: Get terraform version from .terraform-version file
+    name: Get Terraform Version
+    runs-on: ubuntu-latest
+    outputs:
+      terraform_version: ${{ steps.get-version.outputs.terraform_version }}
+    steps:
+      - name: Get terraform version from .terraform-version file
+        id: get-version
+        uses: ./.github/actions/get-terraform-version
+        with:
+          default_version: "1.10.4"
 
   tf_analysis:
     name: Terraform Validation

--- a/.github/workflows/static_analysis.yaml
+++ b/.github/workflows/static_analysis.yaml
@@ -36,6 +36,9 @@ jobs:
     outputs:
       terraform_version: ${{ steps.get-version.outputs.terraform_version }}
     steps:
+      - name: Checkout
+        uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.7
+
       - name: Get terraform version from .terraform-version file
         id: get-version
         uses: ./.github/actions/get-terraform-version

--- a/.github/workflows/static_analysis.yaml
+++ b/.github/workflows/static_analysis.yaml
@@ -4,7 +4,7 @@ on:
   workflow_call:
     inputs:
       terraform_version:
-        description: Terraform version to use
+        description: Terraform version to use. If not set it is automatically retrieved from .terraform-version file.
         type: string
         required: false
       pre_commit_tf_tag:

--- a/.github/workflows/static_analysis.yaml
+++ b/.github/workflows/static_analysis.yaml
@@ -24,6 +24,10 @@ on:
         description: If set, it runs only the specified pre-commit hook check. Otherwise, all checks are run.
         type: string
         required: false
+      verbose:
+        description: If enabled, it prints the verbose logging of pre-commit checks
+        type: boolean
+        required: false
 
 concurrency:
   group: tf-static-analysis-${{ github.head_ref }}
@@ -78,6 +82,8 @@ jobs:
 
       - name: Run pre-commit on Modified Files
         if: ${{ github.event_name == 'pull_request' && inputs.enable_modified_files_detection }}
+        env:
+          PRE_COMMIT_VERBOSE: ${{ inputs.verbose && '1' || '0' }}
         run: |
           set -eu
 
@@ -95,6 +101,8 @@ jobs:
       - name: Run pre-commit
         if: ${{ github.event_name != 'pull_request' || !inputs.enable_modified_files_detection }}
         id: pre_commit
+        env:
+          PRE_COMMIT_VERBOSE: ${{ inputs.verbose && '1' || '0' }}
         run: |
           set -eu
 

--- a/.github/workflows/static_analysis.yaml
+++ b/.github/workflows/static_analysis.yaml
@@ -45,7 +45,7 @@ jobs:
 
       - name: Get terraform version from .terraform-version file
         id: get-version
-        uses: ./.github/actions/get-terraform-version
+        uses: pagopa/dx/.github/actions/get-terraform-version@get-terraform-version-in-static-analysis
         with:
           default_version: "1.10.4"
 

--- a/.github/workflows/static_analysis.yaml
+++ b/.github/workflows/static_analysis.yaml
@@ -1,3 +1,8 @@
+# This pipeline assumes the presence of a .pre-commit-config.yaml file at
+# the top level of the repository, which contains Terraform validation tasks.
+# For more details, refer to the pre-commit configuration file:
+# https://github.com/pagopa/dx/blob/main/.pre-commit-config.yaml.
+
 name: Static Analysis - TF Validation
 
 on:

--- a/.github/workflows/static_analysis.yaml
+++ b/.github/workflows/static_analysis.yaml
@@ -45,7 +45,7 @@ jobs:
 
       - name: Get terraform version from .terraform-version file
         id: get-version
-        uses: pagopa/dx/.github/actions/get-terraform-version@get-terraform-version-in-static-analysis
+        uses: pagopa/dx/.github/actions/get-terraform-version@main
         with:
           default_version: "1.10.4"
 

--- a/.github/workflows/static_analysis_dx.yaml
+++ b/.github/workflows/static_analysis_dx.yaml
@@ -11,16 +11,10 @@ on:
       - .trivyignore
 
 jobs:
-  get-terraform-version:
-    uses: ./.github/workflows/get_terraform_version.yaml
-    name: Get terraform version from .terraform-version file
-
   tf_analysis:
     uses: ./.github/workflows/static_analysis.yaml
-    needs: [ get-terraform-version ]
     name: Terraform Validation
     secrets: inherit
     with:
-      terraform_version: needs.get-terraform-version.outputs.terraform_version
       pre_commit_tf_tag: "v1.96.2@sha256:01f870b7689b5a09c1a370914fcddcac42c4b6478c9d369e1d2590dd0a66ffd0"
       enable_modified_files_detection: true

--- a/.github/workflows/static_analysis_dx.yaml
+++ b/.github/workflows/static_analysis_dx.yaml
@@ -11,11 +11,16 @@ on:
       - .trivyignore
 
 jobs:
+  get-terraform-version:
+    uses: ./.github/workflows/get_terraform_version.yaml
+    name: Get terraform version from .terraform-version file
+
   tf_analysis:
     uses: ./.github/workflows/static_analysis.yaml
+    needs: [ get-terraform-version ]
     name: Terraform Validation
     secrets: inherit
     with:
-      terraform_version: "1.7.5"
+      terraform_version: needs.get-terraform-version.outputs.terraform_version
       pre_commit_tf_tag: "v1.96.2@sha256:01f870b7689b5a09c1a370914fcddcac42c4b6478c9d369e1d2590dd0a66ffd0"
       enable_modified_files_detection: true

--- a/infra/github-runner/dev/tfmodules.lock.json
+++ b/infra/github-runner/dev/tfmodules.lock.json
@@ -1,3 +1,3 @@
 {
-  "container_app_job_selfhosted_runner.naming_convention": "807e8fafaf3cda8d1df7cc5c624715555ff150e87a8df0becc7e5cab3e54f855"
+  "container_app_job_selfhosted_runner.naming_convention": "cebed82c7742c150fbcb4c363670d8078bee27ebd7cb37a37c01cd3803670c64"
 }


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

### List of changes
- Added reusable workflow to retrieve the terraform version from the .terraform-version file
- Include the new workflow in static analysis to optionally retrieve the terraform version
- Added possibility to print verbose logs of pre-commit runs
<!--- Describe your changes in detail -->

### Motivation and context
All repositories include the .terraform-version file. This PR aims to avoid the need of updating the terraform version in cicd pipelines by automatically retrieving the version from the file.
<!--- Why is this change required? What problem does it solve? -->

### Type of changes

- [ ] Add new resources
- [X] Update configuration to existing resources
- [ ] Remove existing resources

### Does this introduce a change to production resources with possible user impact?

- [ ] Yes, users may be impacted applying this change
- [X] No

### Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->
