### PR TITLE
[CES-692] Allow static analysis to run in specific folder

### DIFF
--- a/.github/workflows/static_analysis.yaml
+++ b/.github/workflows/static_analysis.yaml
@@ -24,6 +24,10 @@ on:
         description: If set, it runs only the specified pre-commit hook check. Otherwise, all checks are run.
         type: string
         required: false
+      folder:
+        description: If set, it runs the pre-commit on a single folder. Otherwise, it is run on all files.
+        type: string
+        required: false
       verbose:
         description: If enabled, it prints the verbose logging of pre-commit checks
         type: boolean
@@ -79,9 +83,25 @@ jobs:
         run: |
           apk --no-cache add tar
           python -m pip freeze --local
+        
+      - name: Run pre-commit on specific folders
+        if: ${{ inputs.folder != '' }}
+        id: pre_commit_specific_folders
+        env: 
+          PRE_COMMIT_VERBOSE: ${{ inputs.verbose && '1' || '0' }}
+        run: |
+          set -eu
+
+          echo "Start pre-commit on specific folder ${{ inputs.folder }}"
+
+          find "${{ inputs.folder }}" -type f | xargs pre-commit run \
+            --color=always \
+            ${{ inputs.check_to_run }} \
+            --files
 
       - name: Run pre-commit on Modified Files
-        if: ${{ github.event_name == 'pull_request' && inputs.enable_modified_files_detection }}
+        if: ${{ inputs.folder == '' && github.event_name == 'pull_request' && inputs.enable_modified_files_detection }}
+        id: pre_commit_modified_files
         env:
           PRE_COMMIT_VERBOSE: ${{ inputs.verbose && '1' || '0' }}
         run: |
@@ -99,7 +119,7 @@ jobs:
             ${{ inputs.check_to_run }}
 
       - name: Run pre-commit
-        if: ${{ github.event_name != 'pull_request' || !inputs.enable_modified_files_detection }}
+        if: ${{ inputs.folder == '' && (!github.event_name == 'pull_request' || !inputs.enable_modified_files_detection) }}
         id: pre_commit
         env:
           PRE_COMMIT_VERBOSE: ${{ inputs.verbose && '1' || '0' }}


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

### List of changes

<!--- Describe your changes in detail -->
Allow the possibility to run pre-commit checks only on a specific folder

### Motivation and context

<!--- Why is this change required? What problem does it solve? -->
This option is useful in a couple of cases:
- Repositories with multiple terraform configurations (e.g. io-infra)
- Running the check of modules locks exclusively on the terraform configuration for which the plan/apply workflow is running

### Type of changes

- [ ] Add new resources
- [ ] Update configuration to existing resources
- [ ] Remove existing resources

### Does this introduce a change to production resources with possible user impact?

- [ ] Yes, users may be impacted applying this change
- [X] No

### Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->
