### PR TITLE
[CES-676] Avoid buffering Terraform output

### DIFF
--- a/.github/workflows/infra_apply.yaml
+++ b/.github/workflows/infra_apply.yaml
@@ -133,7 +133,7 @@ jobs:
             -lock-timeout=3000s \
             -out=tfplan-${{ github.sha }} \
             -input=false \
-            | grep -v "hidden-link:"
+            | grep --line-buffered -v "hidden-link:"
 
       - name: "Upload Terraform Plan as Artifact"
         uses: actions/upload-artifact@694cdabd8bdb0f10b2cea11669e1bf5453eed0a6 # v4.2.0
@@ -201,4 +201,4 @@ jobs:
             -auto-approve \
             -input=false \
             tfplan-${{ github.sha }} \
-            | grep -v "hidden-link:"
+            | grep -v --line-buffered "hidden-link:"

--- a/.github/workflows/infra_drift_detection.yml
+++ b/.github/workflows/infra_drift_detection.yml
@@ -117,7 +117,7 @@ jobs:
         working-directory: ${{ steps.directory.outputs.dir }}
         run: |
           set -uo pipefail
-          terraform plan -no-color -detailed-exitcode -out=plan.tfplan | grep -v "hidden-link:"
+          terraform plan -no-color -detailed-exitcode -out=plan.tfplan | grep --line-buffered -v "hidden-link:"
 
           EXIT_CODE=${PIPESTATUS[0]}
           if [ "$EXIT_CODE" -eq 1 ]; then

--- a/.github/workflows/infra_plan.yaml
+++ b/.github/workflows/infra_plan.yaml
@@ -129,7 +129,7 @@ jobs:
         id: plan
         working-directory: ${{ steps.directory.outputs.dir }}
         run: |
-          stdbuf -oL terraform plan -lock-timeout=3000s -no-color 2>&1 | grep --line-buffered -v "hidden-link:"  | tee plan_output.txt
+          terraform plan -lock-timeout=3000s -no-color 2>&1 | grep --line-buffered -v "hidden-link:"  | tee >(cat) plan_output.txt
 
           OUTPUT=$(grep -Ev "Refreshing state|state lock|Reading|Read" plan_output.txt | tail -c 60000)
 

--- a/.github/workflows/infra_plan.yaml
+++ b/.github/workflows/infra_plan.yaml
@@ -129,7 +129,7 @@ jobs:
         id: plan
         working-directory: ${{ steps.directory.outputs.dir }}
         run: |
-          terraform plan -lock-timeout=3000s -no-color 2>&1 | grep -v "hidden-link:"  | tee plan_output.txt
+          terraform plan -lock-timeout=3000s -no-color 2>&1 | grep --line-buffered -v "hidden-link:"  | tee plan_output.txt
 
           OUTPUT=$(grep -Ev "Refreshing state|state lock|Reading|Read" plan_output.txt | tail -c 60000)
 

--- a/.github/workflows/infra_plan.yaml
+++ b/.github/workflows/infra_plan.yaml
@@ -129,7 +129,7 @@ jobs:
         id: plan
         working-directory: ${{ steps.directory.outputs.dir }}
         run: |
-          terraform plan -lock-timeout=3000s -no-color 2>&1 | grep --line-buffered -v "hidden-link:"  | tee plan_output.txt
+          stdbuf -oL terraform plan -lock-timeout=3000s -no-color 2>&1 | grep --line-buffered -v "hidden-link:"  | tee plan_output.txt
 
           OUTPUT=$(grep -Ev "Refreshing state|state lock|Reading|Read" plan_output.txt | tail -c 60000)
 

--- a/.github/workflows/infra_plan.yaml
+++ b/.github/workflows/infra_plan.yaml
@@ -121,6 +121,9 @@ jobs:
         run: |
           terraform init
 
+      - name: Install expect
+        run: sudo apt-get update && sudo apt-get install -y expect
+
       # Run Terraform Plan
       # The plan output is saved in a file and then processed to remove unnecessary lines
       # The step never fails but the result is checked in the next step
@@ -129,7 +132,7 @@ jobs:
         id: plan
         working-directory: ${{ steps.directory.outputs.dir }}
         run: |
-          stdbuf -oL -eL terraform plan -lock-timeout=3000s -no-color 2>&1 | stdbuf -oL -eL grep --line-buffered -v "hidden-link:"  | tee plan_output.txt
+          unbuffer terraform plan -lock-timeout=3000s -no-color 2>&1 | grep --line-buffered -v "hidden-link:"  | tee plan_output.txt
 
           OUTPUT=$(grep -Ev "Refreshing state|state lock|Reading|Read" plan_output.txt | tail -c 60000)
 

--- a/.github/workflows/infra_plan.yaml
+++ b/.github/workflows/infra_plan.yaml
@@ -121,9 +121,6 @@ jobs:
         run: |
           terraform init
 
-      - name: Install expect
-        run: sudo apt-get update && sudo apt-get install -y expect
-
       # Run Terraform Plan
       # The plan output is saved in a file and then processed to remove unnecessary lines
       # The step never fails but the result is checked in the next step
@@ -132,7 +129,7 @@ jobs:
         id: plan
         working-directory: ${{ steps.directory.outputs.dir }}
         run: |
-          unbuffer terraform plan -lock-timeout=3000s -no-color 2>&1 | grep --line-buffered -v "hidden-link:"  | tee plan_output.txt
+          terraform plan -lock-timeout=3000s -no-color 2>&1 | grep --line-buffered -v "hidden-link:"  | tee plan_output.txt
 
           OUTPUT=$(grep -Ev "Refreshing state|state lock|Reading|Read" plan_output.txt | tail -c 60000)
 

--- a/.github/workflows/infra_plan.yaml
+++ b/.github/workflows/infra_plan.yaml
@@ -129,7 +129,7 @@ jobs:
         id: plan
         working-directory: ${{ steps.directory.outputs.dir }}
         run: |
-          terraform plan -lock-timeout=3000s -no-color 2>&1 | grep --line-buffered -v "hidden-link:"  | tee >(cat) plan_output.txt
+          stdbuf -oL -eL terraform plan -lock-timeout=3000s -no-color 2>&1 | stdbuf -oL -eL grep --line-buffered -v "hidden-link:"  | tee plan_output.txt
 
           OUTPUT=$(grep -Ev "Refreshing state|state lock|Reading|Read" plan_output.txt | tail -c 60000)
 


### PR DESCRIPTION
### List of changes

During Terraform plan and apply avoid buffering
in order to print output in realtime and not only
when the Terraform command exit.

### Motivation and context

This change let's users watch Terraform plan/apply
output without waiting for the end of the command.

### Type of changes

- [ ] Add new resources
- [X] Update configuration to existing resources
- [ ] Remove existing resources

### Does this introduce a change to production resources with possible user impact?

- [X] Yes, users may be impacted applying this change
- [ ] No

