### PR TITLE
[CES-706] In Azure Github Env Bootstrap module Infra CD identity can manage IAM roles

### DIFF
--- a/.changeset/yellow-eyes-hide.md
+++ b/.changeset/yellow-eyes-hide.md
@@ -1,0 +1,5 @@
+---
+"azure_github_environment_bootstrap": patch
+---
+
+Add `Role Based Access Control Administrator` role at subscription scope to Infra CD identity

--- a/infra/modules/azure_github_environment_bootstrap/README.md
+++ b/infra/modules/azure_github_environment_bootstrap/README.md
@@ -51,6 +51,7 @@
 | [azurerm_role_assignment.infra_cd_rg_st_blob_contributor](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/role_assignment) | resource |
 | [azurerm_role_assignment.infra_cd_rg_user_access_admin](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/role_assignment) | resource |
 | [azurerm_role_assignment.infra_cd_st_tf_blob_contributor](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/role_assignment) | resource |
+| [azurerm_role_assignment.infra_cd_subscription_rbac_admin](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/role_assignment) | resource |
 | [azurerm_role_assignment.infra_cd_subscription_reader](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/role_assignment) | resource |
 | [azurerm_role_assignment.infra_cd_vnet_network_contributor](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/role_assignment) | resource |
 | [azurerm_role_assignment.infra_ci_rg_cosmos_contributor](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/role_assignment) | resource |

--- a/infra/modules/azure_github_environment_bootstrap/id_infra_cd_iam.tf
+++ b/infra/modules/azure_github_environment_bootstrap/id_infra_cd_iam.tf
@@ -6,6 +6,13 @@ resource "azurerm_role_assignment" "infra_cd_subscription_reader" {
   description          = "Allow ${var.repository.name} Infra CD identity to read resources at subscription scope"
 }
 
+resource "azurerm_role_assignment" "infra_cd_subscription_rbac_admin" {
+  scope                = var.subscription_id
+  role_definition_name = "Role Based Access Control Administrator"
+  principal_id         = azurerm_user_assigned_identity.infra_cd.principal_id
+  description          = "Allow ${var.repository.name} Infra CD identity to manage IAM roles at subscription scope"
+}
+
 # Resource Group
 resource "azurerm_role_assignment" "infra_cd_rg_contributor" {
   scope                = azurerm_resource_group.main.id

--- a/infra/modules/azure_github_environment_bootstrap/tests/mono_repo.tftest.hcl
+++ b/infra/modules/azure_github_environment_bootstrap/tests/mono_repo.tftest.hcl
@@ -351,6 +351,7 @@ run "validate_github_id_infra" {
       azurerm_role_assignment.infra_ci_rg_ext_pagopa_dns_reader,
       azurerm_key_vault_access_policy.infra_ci_kv_common,
       azurerm_role_assignment.infra_cd_subscription_reader,
+      azurerm_role_assignment.infra_cd_subscription_rbac_admin,
       azurerm_role_assignment.infra_cd_rg_contributor,
       azurerm_role_assignment.infra_cd_vnet_network_contributor,
       azurerm_role_assignment.infra_cd_apim_service_contributor,
@@ -498,6 +499,11 @@ run "validate_github_id_infra" {
   assert {
     condition     = azurerm_role_assignment.infra_cd_subscription_reader != null
     error_message = "The Infra CD managed identity can't read resources at subscription scope"
+  }
+
+  assert {
+    condition     = azurerm_role_assignment.infra_cd_subscription_rbac_admin != null
+    error_message = "The Infra CD managed identity can't manage IAM roles at subscription scope"
   }
 
   assert {


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

### List of changes

<!--- Describe your changes in detail -->
Add `Role Based Access Control Administrator` role at subscription scope to Infra CD identity in `azure_github_environment_bootstrap`

### Motivation and context

<!--- Why is this change required? What problem does it solve? -->
This change is due when a team has more than one resource group. In this scenario, in fact, it is necessary that the GitHub pipeline can assign permissions to the new resource

### Type of changes

- [ ] Add new resources
- [X] Update configuration to existing resources
- [ ] Remove existing resources

### Does this introduce a change to production resources with possible user impact?

- [ ] Yes, users may be impacted applying this change
- [X] No

### Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->
