### PR TITLE
[CES-707] Fix Infra Test trigger to run as CI workflow

### DIFF
--- a/.github/workflows/infra_test.yaml
+++ b/.github/workflows/infra_test.yaml
@@ -2,7 +2,8 @@ name: Test Terraform modules plan
 
 on:
   workflow_dispatch:
-  push:
+  pull_request:
+    types: [opened, synchronize]
     branches:
       - main
     paths:


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

### List of changes

<!--- Describe your changes in detail -->
Replace `push` trigger with `pull_request` in `infra_test.yaml` workflow

### Motivation and context

<!--- Why is this change required? What problem does it solve? -->
Tests must run in CI, not CD

### Type of changes

- [ ] Add new resources
- [X] Update configuration to existing resources
- [ ] Remove existing resources

### Does this introduce a change to production resources with possible user impact?

- [ ] Yes, users may be impacted applying this change
- [X] No

### Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->
