### PR TITLE
[CES-715] Remove roles from Entra ID groups on Terraform Storage Account in azure github bootstrap module

### DIFF
--- a/.changeset/wicked-gifts-deliver.md
+++ b/.changeset/wicked-gifts-deliver.md
@@ -1,0 +1,5 @@
+---
+"azure_github_environment_bootstrap": patch
+---
+
+Remove roles from Entra ID groups on Terraform Storage Account

--- a/infra/modules/azure_github_environment_bootstrap/README.md
+++ b/infra/modules/azure_github_environment_bootstrap/README.md
@@ -32,15 +32,12 @@
 | [azurerm_role_assignment.admins_group_rg](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/role_assignment) | resource |
 | [azurerm_role_assignment.admins_group_rg_kv_admin](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/role_assignment) | resource |
 | [azurerm_role_assignment.admins_group_rg_kv_data](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/role_assignment) | resource |
-| [azurerm_role_assignment.admins_group_st_tf](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/role_assignment) | resource |
 | [azurerm_role_assignment.app_cd_rg_contributor](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/role_assignment) | resource |
 | [azurerm_role_assignment.app_cd_subscription_reader](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/role_assignment) | resource |
 | [azurerm_role_assignment.app_cd_tf_rg_blob_contributor](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/role_assignment) | resource |
 | [azurerm_role_assignment.devs_group_rg](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/role_assignment) | resource |
 | [azurerm_role_assignment.devs_group_tf_rg_kv_secr](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/role_assignment) | resource |
-| [azurerm_role_assignment.devs_group_tf_st](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/role_assignment) | resource |
 | [azurerm_role_assignment.externals_group_rg](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/role_assignment) | resource |
-| [azurerm_role_assignment.externals_group_tf_rg](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/role_assignment) | resource |
 | [azurerm_role_assignment.infra_cd_apim_service_contributor](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/role_assignment) | resource |
 | [azurerm_role_assignment.infra_cd_rg_contributor](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/role_assignment) | resource |
 | [azurerm_role_assignment.infra_cd_rg_ext_network_contributor](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/role_assignment) | resource |

--- a/infra/modules/azure_github_environment_bootstrap/ad_admin_iam.tf
+++ b/infra/modules/azure_github_environment_bootstrap/ad_admin_iam.tf
@@ -8,13 +8,6 @@ resource "azurerm_role_assignment" "admins_group_rg" {
   description          = "Allow ${var.repository.name} AD Admin group the complete ownership at monorepository resource group scope"
 }
 
-# Storage Account - Terraform state file
-resource "azurerm_role_assignment" "admins_group_st_tf" {
-  scope                = local.tf_storage_account.id
-  role_definition_name = "Storage Blob Data Contributor"
-  principal_id         = var.entraid_groups.admins_object_id
-  description          = "Allow ${var.repository.name} AD Admin group to apply changes to the Terraform state file Storage Account scope"
-}
 
 # Key Vault
 resource "azurerm_role_assignment" "admins_group_rg_kv_data" {

--- a/infra/modules/azure_github_environment_bootstrap/ad_devs_iam.tf
+++ b/infra/modules/azure_github_environment_bootstrap/ad_devs_iam.tf
@@ -6,14 +6,6 @@ resource "azurerm_role_assignment" "devs_group_rg" {
   description          = "Allow ${var.repository.name} AD Dev group to apply changes at monorepository resource group scope"
 }
 
-# Storage Account - Terraform state file
-resource "azurerm_role_assignment" "devs_group_tf_st" {
-  scope                = local.tf_storage_account.id
-  role_definition_name = "Storage Blob Data Contributor"
-  principal_id         = var.entraid_groups.devs_object_id
-  description          = "Allow ${var.repository.name} AD Dev group to apply changes to the Terraform state file Storage Account scope"
-}
-
 # Key Vault
 resource "azurerm_role_assignment" "devs_group_tf_rg_kv_secr" {
   scope                = azurerm_resource_group.main.id

--- a/infra/modules/azure_github_environment_bootstrap/ad_ext_iam.tf
+++ b/infra/modules/azure_github_environment_bootstrap/ad_ext_iam.tf
@@ -7,13 +7,3 @@ resource "azurerm_role_assignment" "externals_group_rg" {
   principal_id         = var.entraid_groups.externals_object_id
   description          = "Allow ${var.repository.name} AD external group to read resources at resource group scope"
 }
-
-# Storage Account - Terraform state file
-resource "azurerm_role_assignment" "externals_group_tf_rg" {
-  count = var.entraid_groups.externals_object_id == null ? 0 : 1
-
-  scope                = local.tf_storage_account.id
-  role_definition_name = "Storage Blob Data Reader"
-  principal_id         = var.entraid_groups.externals_object_id
-  description          = "Allow ${var.repository.name} AD external group to read blobs at the Terraform state file Storage Account scope"
-}

--- a/infra/modules/azure_github_environment_bootstrap/tests/mono_repo.tftest.hcl
+++ b/infra/modules/azure_github_environment_bootstrap/tests/mono_repo.tftest.hcl
@@ -572,14 +572,11 @@ run "validate_rbac_entraid" {
   plan_options {
     target = [
       azurerm_role_assignment.admins_group_rg,
-      azurerm_role_assignment.admins_group_st_tf,
       azurerm_role_assignment.admins_group_rg_kv_data,
       azurerm_role_assignment.admins_group_rg_kv_admin,
       azurerm_role_assignment.devs_group_rg,
-      azurerm_role_assignment.devs_group_tf_st,
       azurerm_role_assignment.devs_group_tf_rg_kv_secr,
       azurerm_role_assignment.externals_group_rg,
-      azurerm_role_assignment.externals_group_tf_rg,
     ]
   }
 
@@ -637,20 +634,9 @@ run "validate_rbac_entraid" {
   }
 
   assert {
-    condition     = azurerm_role_assignment.admins_group_st_tf != null
-    error_message = "The Admins group should have role assignments for Terraform state storage"
-  }
-
-  assert {
     condition     = azurerm_role_assignment.devs_group_rg != null
     error_message = "The Developers group should have role assignments at resource group scope"
   }
-
-  assert {
-    condition     = azurerm_role_assignment.devs_group_tf_st != null
-    error_message = "The Developers group should have role assignments for Terraform state storage"
-  }
-
 
   assert {
     condition     = azurerm_role_assignment.devs_group_tf_rg_kv_secr != null
@@ -660,11 +646,6 @@ run "validate_rbac_entraid" {
   assert {
     condition     = azurerm_role_assignment.externals_group_rg != null
     error_message = "The Externals group should have role assignments at resource group scope"
-  }
-
-  assert {
-    condition     = azurerm_role_assignment.externals_group_tf_rg != null
-    error_message = "The Externals group should have role assignments for Terraform resource group"
   }
 }
 


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

### List of changes

<!--- Describe your changes in detail -->
Remove roles from Entra ID groups on Terraform Storage Account in azure github bootstrap module

### Motivation and context

<!--- Why is this change required? What problem does it solve? -->
Since the storage account with Terraform state is managed in io-infra with related permissions on Entra ID groups, it is no longer necessary to assign roles within the azure github bootstrap module

### Type of changes

- [ ] Add new resources
- [x] Update configuration to existing resources
- [ ] Remove existing resources

### Does this introduce a change to production resources with possible user impact?

- [ ] Yes, users may be impacted applying this change
- [x] No

### Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->
