### PR TITLE
Allow plan and apply workflows concurrent executions for different base paths

### DIFF
--- a/.github/workflows/infra_apply.yaml
+++ b/.github/workflows/infra_apply.yaml
@@ -42,7 +42,7 @@ env:
   ARM_STORAGE_USE_AZUREAD: true
 
 concurrency:
-  group: ${{ github.workflow }}-${{ inputs.environment }}-cd
+  group: ${{ github.workflow }}-${{ inputs.environment }}-${{ inputs.base_path }}-cd
   cancel-in-progress: false
 
 jobs:

--- a/.github/workflows/infra_plan.yaml
+++ b/.github/workflows/infra_plan.yaml
@@ -50,7 +50,7 @@ jobs:
     runs-on: ${{ inputs.use_labels && inputs.use_private_agent && (inputs.override_labels != '' && inputs.override_labels || inputs.environment) || inputs.use_private_agent && 'self-hosted' || 'ubuntu-latest' }}
     environment: ${{ inputs.override_github_environment == '' && inputs.environment || inputs.override_github_environment}}-ci
     concurrency:
-      group: ${{ github.workflow }}-${{ inputs.environment }}-ci
+      group: ${{ github.workflow }}-${{ inputs.environment }}-${{ inputs.base_path }}-ci
       cancel-in-progress: false
     permissions:
       id-token: write


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

### List of changes

<!--- Describe your changes in detail -->
Added base path in the concurrency group of plan and apply workflows

### Motivation and context

<!--- Why is this change required? What problem does it solve? -->
Monorepos containing multiple terraform configurations can't run plan or apply workflows concurrently although the base path is different

This happens when a PR modified multiple terraform configurations in the same repository
Example [here](https://github.com/pagopa/io-infra/pull/1374)

### Type of changes

- [ ] Add new resources
- [ ] Update configuration to existing resources
- [ ] Remove existing resources

### Does this introduce a change to production resources with possible user impact?

- [ ] Yes, users may be impacted applying this change
- [ ] No

### Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->
