### PR TITLE
Add override_github_environment to infra_drift_detection workflow template

### DIFF
--- a/.github/workflows/infra_drift_detection.yml
+++ b/.github/workflows/infra_drift_detection.yml
@@ -18,6 +18,11 @@ on:
         type: boolean
         required: false
         default: false
+      override_github_environment:
+          description: Set a value if GitHub Environment name is different than the TF environment folder
+          type: string
+          required: false
+          default: ''
 
 env:
   ARM_SUBSCRIPTION_ID: ${{ secrets.ARM_SUBSCRIPTION_ID }}
@@ -32,7 +37,7 @@ jobs:
   terraform_driftdetection_job:
     name: Terraform Drift Detection
     runs-on: ${{ inputs.use_private_agent == true && 'self-hosted' || 'ubuntu-latest' }}
-    environment: ${{ inputs.environment }}-ci
+    environment: ${{ inputs.override_github_environment == '' && inputs.environment || inputs.override_github_environment}}-ci
     concurrency:
       group: ${{ github.workflow }}-ci
       cancel-in-progress: true


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

### List of changes

<!--- Describe your changes in detail -->
Add override_github_environment to infra_drift_detection workflow template

### Motivation and context

<!--- Why is this change required? What problem does it solve? -->
In the latest proposed repository setup configuration, environment names about infrastructure pipelines were moved from `prod-ci` to `infra-prod-ci`

### Type of changes

- [ ] Add new resources
- [X] Update configuration to existing resources
- [ ] Remove existing resources

### Does this introduce a change to production resources with possible user impact?

- [ ] Yes, users may be impacted applying this change
- [X] No

### Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->
