### PR TITLE
Force `node_modules` in `function_app_deploy.yaml`

### DIFF
--- a/.github/workflows/function_app_deploy.yaml
+++ b/.github/workflows/function_app_deploy.yaml
@@ -48,6 +48,9 @@ concurrency:
 
 env:
   BUNDLE_NAME: bundle
+  # we fall back to node-moules, even in case pnp is configured, in order to avoid bundling dependendencies
+  YARN_NODE_LINKER: node-modules
+  YARN_NM_HOISTING_LIMITS: workspaces
 
 jobs:
 


### PR DESCRIPTION
Lagacy projects that uses this workflow needs `node-modules` as package resolution algorithm. This change will force this mechanism even if the root project adopts Plug'n'Play.