### PR TITLE
[CES-767] Upgrade Postgres SKUs to v5

### DIFF
--- a/.changeset/khaki-waves-prove.md
+++ b/.changeset/khaki-waves-prove.md
@@ -1,5 +1,5 @@
 ---
-"azure_postgres_server": minor
+"azure_postgres_server": major
 ---
 
 L tier now uses GP_Standard_D4ds_v5 as SKU, and M tier uses GP_Standard_D2ds_v5

--- a/.changeset/khaki-waves-prove.md
+++ b/.changeset/khaki-waves-prove.md
@@ -2,4 +2,4 @@
 "azure_postgres_server": minor
 ---
 
-L tier now uses GP_Standard_D4ds_v5 as SKU
+L tier now uses GP_Standard_D4ds_v5 as SKU, and M tier uses GP_Standard_D2ds_v5

--- a/.changeset/khaki-waves-prove.md
+++ b/.changeset/khaki-waves-prove.md
@@ -1,0 +1,5 @@
+---
+"azure_postgres_server": minor
+---
+
+L tier now uses GP_Standard_D4ds_v5 as SKU

--- a/infra/modules/azure_postgres_server/locals.tf
+++ b/infra/modules/azure_postgres_server/locals.tf
@@ -5,8 +5,8 @@ locals {
     sku_name = lookup(
       {
         "s" = "B_Standard_B1ms",
-        "m" = "GP_Standard_D2s_v3",
-        "l" = "GP_Standard_D2ds_v5"
+        "m" = "GP_Standard_D2ds_v5",
+        "l" = "GP_Standard_D4ds_v5"
       },
       var.tier,
       "GP_Standard_D2ds_v5" # Default

--- a/infra/modules/azure_postgres_server/tests/postgres.tftest.hcl
+++ b/infra/modules/azure_postgres_server/tests/postgres.tftest.hcl
@@ -59,8 +59,8 @@ run "postgres_is_correct_plan" {
 
   # Checks some assertions
   assert {
-    condition     = azurerm_postgresql_flexible_server.this.sku_name == "GP_Standard_D2ds_v5"
-    error_message = "The PostgreSQL Flexible Server must use the correct SKU (GP_Standard_D2ds_v5)"
+    condition     = azurerm_postgresql_flexible_server.this.sku_name == "GP_Standard_D4ds_v5"
+    error_message = "The PostgreSQL Flexible Server must use the correct SKU (GP_Standard_D4ds_v5)"
   }
 
   assert {


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

### List of changes

<!--- Describe your changes in detail -->
Tier L now uses `GP_Standard_D4ds_v5` and tier M moved to `GP_Standard_D2ds_v5`

### Motivation and context

<!--- Why is this change required? What problem does it solve? -->
PagoPA owns reservations only for v5

### Type of changes

- [ ] Add new resources
- [X] Update configuration to existing resources
- [ ] Remove existing resources

### Does this introduce a change to production resources with possible user impact?

- [ ] Yes, users may be impacted applying this change
- [ ] No

### Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->
