### PR TITLE
Remove pull request template for clarity and efficiency

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,27 +1,3 @@
-<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
-<!--- Even if we are all from our internal team, we may not be on the same page. -->
-<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
-<!--- This will improve our projects in the long run! Thanks. -->
-
-### List of changes
-
-<!--- Describe your changes in detail -->
-
 ### Motivation and context
 
-<!--- Why is this change required? What problem does it solve? -->
-
-### Type of changes
-
-- [ ] Add new resources
-- [ ] Update configuration to existing resources
-- [ ] Remove existing resources
-
-### Does this introduce a change to production resources with possible user impact?
-
-- [ ] Yes, users may be impacted applying this change
-- [ ] No
-
-### Other information
-
-<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->
+<!-- Why is this change required? What problem does it solve? -->

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,3 +1,0 @@
-### Motivation and context
-
-<!-- Why is this change required? What problem does it solve? -->


### PR DESCRIPTION
Remove the pull request template to streamline contribution guidelines and enhance clarity for contributors.