### PR TITLE
Set up custom warm-up in webapps modules

### DIFF
--- a/.changeset/chatty-lobsters-arrive.md
+++ b/.changeset/chatty-lobsters-arrive.md
@@ -1,0 +1,8 @@
+---
+"azure_function_app_exposed": patch
+"azure_app_service_exposed": patch
+"azure_function_app": patch
+"azure_app_service": patch
+---
+
+Set up custom warm-up for swap and restart

--- a/infra/modules/azure_app_service/app_service.tf
+++ b/infra/modules/azure_app_service/app_service.tf
@@ -37,6 +37,10 @@ resource "azurerm_linux_web_app" "this" {
       WEBSITE_RUN_FROM_PACKAGE = 1
       # https://docs.microsoft.com/en-us/azure/virtual-network/what-is-ip-address-168-63-129-16
       WEBSITE_DNS_SERVER = "168.63.129.16"
+      # https://learn.microsoft.com/en-us/azure/app-service/deploy-staging-slots?tabs=portal#specify-custom-warm-up
+      WEBSITE_SWAP_WARMUP_PING_PATH     = var.health_check_path
+      WEBSITE_SWAP_WARMUP_PING_STATUSES = "200,204"
+      WEBSITE_WARMUP_PATH               = var.health_check_path
     },
     var.app_settings,
     local.application_insights.enable ? {

--- a/infra/modules/azure_app_service/app_service_slot.tf
+++ b/infra/modules/azure_app_service/app_service_slot.tf
@@ -37,6 +37,10 @@ resource "azurerm_linux_web_app_slot" "this" {
       WEBSITE_RUN_FROM_PACKAGE = 1
       # https://docs.microsoft.com/en-us/azure/virtual-network/what-is-ip-address-168-63-129-16
       WEBSITE_DNS_SERVER = "168.63.129.16"
+      # https://learn.microsoft.com/en-us/azure/app-service/deploy-staging-slots?tabs=portal#specify-custom-warm-up
+      WEBSITE_SWAP_WARMUP_PING_PATH     = var.health_check_path
+      WEBSITE_SWAP_WARMUP_PING_STATUSES = "200,204"
+      WEBSITE_WARMUP_PATH               = var.health_check_path
     },
     var.slot_app_settings,
     local.application_insights.enable ? {

--- a/infra/modules/azure_app_service_exposed/app_service.tf
+++ b/infra/modules/azure_app_service_exposed/app_service.tf
@@ -35,6 +35,10 @@ resource "azurerm_linux_web_app" "this" {
       WEBSITE_RUN_FROM_PACKAGE = 1
       # https://docs.microsoft.com/en-us/azure/virtual-network/what-is-ip-address-168-63-129-16
       WEBSITE_DNS_SERVER = "168.63.129.16"
+      # https://learn.microsoft.com/en-us/azure/app-service/deploy-staging-slots?tabs=portal#specify-custom-warm-up
+      WEBSITE_SWAP_WARMUP_PING_PATH     = var.health_check_path
+      WEBSITE_SWAP_WARMUP_PING_STATUSES = "200,204"
+      WEBSITE_WARMUP_PATH               = var.health_check_path
     },
     var.app_settings,
     local.application_insights.enable ? {

--- a/infra/modules/azure_app_service_exposed/app_service_slot.tf
+++ b/infra/modules/azure_app_service_exposed/app_service_slot.tf
@@ -35,6 +35,10 @@ resource "azurerm_linux_web_app_slot" "this" {
       WEBSITE_RUN_FROM_PACKAGE = 1
       # https://docs.microsoft.com/en-us/azure/virtual-network/what-is-ip-address-168-63-129-16
       WEBSITE_DNS_SERVER = "168.63.129.16"
+      # https://learn.microsoft.com/en-us/azure/app-service/deploy-staging-slots?tabs=portal#specify-custom-warm-up
+      WEBSITE_SWAP_WARMUP_PING_PATH     = var.health_check_path
+      WEBSITE_SWAP_WARMUP_PING_STATUSES = "200,204"
+      WEBSITE_WARMUP_PATH               = var.health_check_path
     },
     var.slot_app_settings,
     local.application_insights.enable ? {

--- a/infra/modules/azure_function_app/function_app.tf
+++ b/infra/modules/azure_function_app/function_app.tf
@@ -45,6 +45,10 @@ resource "azurerm_linux_function_app" "this" {
       SLOT_TASK_HUBNAME = "ProductionTaskHub",
       # https://learn.microsoft.com/en-us/azure/azure-functions/functions-app-settings#functions_worker_process_count
       FUNCTIONS_WORKER_PROCESS_COUNT = local.function_app.worker_process_count,
+      # https://learn.microsoft.com/en-us/azure/app-service/deploy-staging-slots?tabs=portal#specify-custom-warm-up
+      WEBSITE_SWAP_WARMUP_PING_PATH     = var.health_check_path
+      WEBSITE_SWAP_WARMUP_PING_STATUSES = "200,204"
+      WEBSITE_WARMUP_PATH               = var.health_check_path
     },
     # https://learn.microsoft.com/en-us/azure/azure-functions/errors-diagnostics/diagnostic-events/azfd0004#options-for-addressing-collisions
     length(local.function_app.name) > 32 && !(contains(keys(var.app_settings), "AzureFunctionsWebHost__hostid")) ? { AzureFunctionsWebHost__hostid = "production" } : {},

--- a/infra/modules/azure_function_app/function_app_slot.tf
+++ b/infra/modules/azure_function_app/function_app_slot.tf
@@ -44,6 +44,10 @@ resource "azurerm_linux_function_app_slot" "this" {
       SLOT_TASK_HUBNAME = "StagingTaskHub",
       # https://learn.microsoft.com/en-us/azure/azure-functions/functions-app-settings#functions_worker_process_count
       FUNCTIONS_WORKER_PROCESS_COUNT = local.function_app.worker_process_count,
+      # https://learn.microsoft.com/en-us/azure/app-service/deploy-staging-slots?tabs=portal#specify-custom-warm-up
+      WEBSITE_SWAP_WARMUP_PING_PATH     = var.health_check_path
+      WEBSITE_SWAP_WARMUP_PING_STATUSES = "200,204"
+      WEBSITE_WARMUP_PATH               = var.health_check_path
     },
     local.application_insights.enable ? {
       # https://docs.microsoft.com/en-us/azure/azure-monitor/app/sampling

--- a/infra/modules/azure_function_app_exposed/function_app.tf
+++ b/infra/modules/azure_function_app_exposed/function_app.tf
@@ -41,6 +41,10 @@ resource "azurerm_linux_function_app" "this" {
       SLOT_TASK_HUBNAME = "ProductionTaskHub",
       # https://learn.microsoft.com/en-us/azure/azure-functions/functions-app-settings#functions_worker_process_count
       FUNCTIONS_WORKER_PROCESS_COUNT = local.function_app.worker_process_count,
+      # https://learn.microsoft.com/en-us/azure/app-service/deploy-staging-slots?tabs=portal#specify-custom-warm-up
+      WEBSITE_SWAP_WARMUP_PING_PATH     = var.health_check_path
+      WEBSITE_SWAP_WARMUP_PING_STATUSES = "200,204"
+      WEBSITE_WARMUP_PATH               = var.health_check_path
     },
     # https://learn.microsoft.com/en-us/azure/azure-functions/errors-diagnostics/diagnostic-events/azfd0004#options-for-addressing-collisions
     length(local.function_app.name) > 32 && !(contains(keys(var.app_settings), "AzureFunctionsWebHost__hostid")) ? { AzureFunctionsWebHost__hostid = "production" } : {},

--- a/infra/modules/azure_function_app_exposed/function_app_slot.tf
+++ b/infra/modules/azure_function_app_exposed/function_app_slot.tf
@@ -40,6 +40,10 @@ resource "azurerm_linux_function_app_slot" "this" {
       SLOT_TASK_HUBNAME = "StagingTaskHub",
       # https://learn.microsoft.com/en-us/azure/azure-functions/functions-app-settings#functions_worker_process_count
       FUNCTIONS_WORKER_PROCESS_COUNT = local.function_app.worker_process_count,
+      # https://learn.microsoft.com/en-us/azure/app-service/deploy-staging-slots?tabs=portal#specify-custom-warm-up
+      WEBSITE_SWAP_WARMUP_PING_PATH     = var.health_check_path
+      WEBSITE_SWAP_WARMUP_PING_STATUSES = "200,204"
+      WEBSITE_WARMUP_PATH               = var.health_check_path
     },
     local.application_insights.enable ? {
       # https://docs.microsoft.com/en-us/azure/azure-monitor/app/sampling


### PR DESCRIPTION
Set `var.health_check_path` as custom warm-up path to constraint the swap operation only when the source slots is healthy.