### PR TITLE
Create APIM logger when AI is enabled

### DIFF
--- a/.changeset/few-singers-know.md
+++ b/.changeset/few-singers-know.md
@@ -1,0 +1,5 @@
+---
+"azure_api_management": patch
+---
+
+Create APIM logger when AI is enabled

--- a/infra/modules/azure_api_management/monitor.tf
+++ b/infra/modules/azure_api_management/monitor.tf
@@ -1,5 +1,5 @@
 resource "azurerm_api_management_logger" "this" {
-  count = var.application_insights.enabled && var.tier != "s" ? 1 : 0
+  count = var.application_insights.enabled ? 1 : 0
 
   name                = "${local.apim.name}-logger"
   api_management_name = azurerm_api_management.this.name
@@ -11,7 +11,6 @@ resource "azurerm_api_management_logger" "this" {
       connection_string = var.application_insights.connection_string
     }
   }
-
 }
 
 resource "azurerm_monitor_metric_alert" "this" {

--- a/infra/modules/azure_api_management/tests/apim.tftest.hcl
+++ b/infra/modules/azure_api_management/tests/apim.tftest.hcl
@@ -57,13 +57,17 @@ run "apim_is_correct_plan" {
 
     subnet_id                     = run.setup_tests.subnet_id
     virtual_network_type_internal = true
-
   }
 
   # Checks some assertions
   assert {
     condition     = azurerm_api_management.this.sku_name == "Premium_1"
     error_message = "The APIM SKU is incorrect, have to be Premium_1"
+  }
+
+  assert {
+    condition     = length(azurerm_api_management_logger.this) == 0
+    error_message = "The APIM logegr should not exist"
   }
 }
 

--- a/infra/modules/azure_api_management/tests/apim.tftest.hcl
+++ b/infra/modules/azure_api_management/tests/apim.tftest.hcl
@@ -158,7 +158,7 @@ run "apim_tier_s_create_logger" {
 
     application_insights = {
       enabled = true
-      instrumentation_key = "anInstrumentationKey"
+      connection_string = "aConnectionString"
     }
 
     subnet_id                     = run.setup_tests.subnet_id

--- a/infra/modules/azure_api_management/tests/apim.tftest.hcl
+++ b/infra/modules/azure_api_management/tests/apim.tftest.hcl
@@ -55,6 +55,11 @@ run "apim_is_correct_plan" {
       resource_group_name = run.setup_tests.vnet.resource_group_name
     }
 
+    application_insights = {
+      enabled           = true
+      connection_string = "aConnectionString"
+    }
+
     subnet_id                     = run.setup_tests.subnet_id
     virtual_network_type_internal = true
   }
@@ -66,8 +71,8 @@ run "apim_is_correct_plan" {
   }
 
   assert {
-    condition     = length(azurerm_api_management_logger.this) == 0
-    error_message = "The APIM logger should not exist"
+    condition     = length(azurerm_api_management_logger.this) > 0
+    error_message = "The APIM logger does not exist"
   }
 }
 
@@ -119,55 +124,4 @@ run "apim_ai_enabled_without_connection_string" {
     # Specify the exact variable that should fail validation
     var.application_insights.connection_string,
   ]
-}
-
-run "apim_tier_s_create_logger" {
-  command = plan
-
-  variables {
-    environment = {
-      prefix          = "dx"
-      env_short       = "d"
-      location        = "italynorth"
-      domain          = "modules"
-      app_name        = "test"
-      instance_number = "01"
-    }
-
-    tags = {
-      CostCenter     = "TS000 - Tecnologia e Servizi"
-      CreatedBy      = "Terraform"
-      Environment    = "Dev"
-      Owner          = "DevEx"
-      Source         = "https://github.com/pagopa/dx/blob/main/infra/modules/azure_api_management/tests"
-      ManagementTeam = "Developer Experience"
-      Test           = "true"
-      TestName       = "Create APIM for test"
-    }
-
-    resource_group_name = run.setup_tests.resource_group_name
-    tier                = "s"
-
-    publisher_email = "example@pagopa.it"
-    publisher_name  = "Example Publisher"
-
-    virtual_network = {
-      name                = run.setup_tests.vnet.name
-      resource_group_name = run.setup_tests.vnet.resource_group_name
-    }
-
-    application_insights = {
-      enabled = true
-      connection_string = "aConnectionString"
-    }
-
-    subnet_id                     = run.setup_tests.subnet_id
-    virtual_network_type_internal = true
-  }
-
-  # Checks some assertions
-  assert {
-    condition     = length(azurerm_api_management_logger.this) > 0
-    error_message = "The APIM logegr does not exist"
-  }
 }

--- a/infra/modules/azure_api_management/tests/apim.tftest.hcl
+++ b/infra/modules/azure_api_management/tests/apim.tftest.hcl
@@ -67,7 +67,7 @@ run "apim_is_correct_plan" {
 
   assert {
     condition     = length(azurerm_api_management_logger.this) == 0
-    error_message = "The APIM logegr should not exist"
+    error_message = "The APIM logger should not exist"
   }
 }
 

--- a/infra/modules/azure_api_management/tests/apim.tftest.hcl
+++ b/infra/modules/azure_api_management/tests/apim.tftest.hcl
@@ -120,3 +120,54 @@ run "apim_ai_enabled_without_connection_string" {
     var.application_insights.connection_string,
   ]
 }
+
+run "apim_tier_s_create_logger" {
+  command = plan
+
+  variables {
+    environment = {
+      prefix          = "dx"
+      env_short       = "d"
+      location        = "italynorth"
+      domain          = "modules"
+      app_name        = "test"
+      instance_number = "01"
+    }
+
+    tags = {
+      CostCenter     = "TS000 - Tecnologia e Servizi"
+      CreatedBy      = "Terraform"
+      Environment    = "Dev"
+      Owner          = "DevEx"
+      Source         = "https://github.com/pagopa/dx/blob/main/infra/modules/azure_api_management/tests"
+      ManagementTeam = "Developer Experience"
+      Test           = "true"
+      TestName       = "Create APIM for test"
+    }
+
+    resource_group_name = run.setup_tests.resource_group_name
+    tier                = "s"
+
+    publisher_email = "example@pagopa.it"
+    publisher_name  = "Example Publisher"
+
+    virtual_network = {
+      name                = run.setup_tests.vnet.name
+      resource_group_name = run.setup_tests.vnet.resource_group_name
+    }
+
+    application_insights = {
+      enabled = true
+      instrumentation_key = "anInstrumentationKey"
+    }
+
+    subnet_id                     = run.setup_tests.subnet_id
+    virtual_network_type_internal = true
+  }
+
+  # Checks some assertions
+  assert {
+    condition     = length(azurerm_api_management_logger.this) > 0
+    error_message = "The APIM logegr does not exist"
+  }
+}


### PR DESCRIPTION
When tier is set to `s`, but AI is enabled, the plan fails because it assumes the APIM logger exists.
With this change, when AI is enabled, then the module creates an APIM logger as well

Closes #273 #CES-799