### PR TITLE
Upgrade APIM module minimum provider version

### DIFF
--- a/.changeset/ninety-mangos-drum.md
+++ b/.changeset/ninety-mangos-drum.md
@@ -1,0 +1,5 @@
+---
+"azure_api_management": patch
+---
+
+Set the minimum version of Azure provider to `4.1.0`

--- a/infra/modules/azure_api_management/README.md
+++ b/infra/modules/azure_api_management/README.md
@@ -42,7 +42,7 @@ module "apim" {
 
 | Name | Version |
 |------|---------|
-| <a name="requirement_azurerm"></a> [azurerm](#requirement\_azurerm) | >= 3.111.0, < 5.0 |
+| <a name="requirement_azurerm"></a> [azurerm](#requirement\_azurerm) | >= 4.1.0, < 5.0 |
 
 ## Modules
 

--- a/infra/modules/azure_api_management/main.tf
+++ b/infra/modules/azure_api_management/main.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     azurerm = {
       source  = "hashicorp/azurerm"
-      version = ">= 3.111.0, < 5.0"
+      version = ">= 4.1.0, < 5.0"
     }
   }
 }


### PR DESCRIPTION
The `connection_string` for the `azurerm_api_management_logger` resource has been introduced in version `4.1.0` of the provider

Fixes #CES-809