### PR TITLE
Add GitHub Copilot guidelines

### DIFF
--- a/.github/copilot/code-instructions.md
+++ b/.github/copilot/code-instructions.md
@@ -1,0 +1,30 @@
+# Copilot Guidelines for Code Generation
+
+- Respect our project structure and organization
+- Follow existing naming conventions in similar files
+
+## Code Organization
+
+- Use named exports over default exports when possible
+- Avoid unnecessary complexity in code structure
+- Keep files small and focused on a single concern
+
+## Documentation
+
+- Comment methods where necessary to explain complex logic
+- Try to add a file header comment to explain the purpose of the module
+
+## Infrastructure Code
+
+- For Terraform code, follow the structure used in the `infra/` directory
+- Respect the `.terraform-version` and `.tflint.hcl` configurations
+
+## Version Control
+
+- Create changesets in the `.changeset` directory for significant changes
+- Follow the format used in existing changeset files
+
+## Monorepo Structure
+
+- Respect the monorepo structure managed by Turborepo (see `turbo.json`)
+- Place new packages in the appropriate directory under `packages/`

--- a/.github/copilot/commit-instructions.md
+++ b/.github/copilot/commit-instructions.md
@@ -1,5 +1,8 @@
 # Copilot Guidelines for Commit Messages
 
-- Use descriptive commit messages that explain the purpose of the change
-- Reference issues or pull requests in the commit message when relevant
-- Follow the commit message format used in the repository
+- Keep the subject line concise, ideally under 50 characters
+- Never exceed 72 characters
+- Capitalize the subject line
+- Don't put a period at the end of the subject line
+- Use the imperative mood
+- Try to describe the rationale behind the changes instead of the changes themselves

--- a/.github/copilot/commit-instructions.md
+++ b/.github/copilot/commit-instructions.md
@@ -1,0 +1,5 @@
+# Copilot Guidelines for Commit Messages
+
+- Use descriptive commit messages that explain the purpose of the change
+- Reference issues or pull requests in the commit message when relevant
+- Follow the commit message format used in the repository

--- a/.github/copilot/pull-request-instructions.md
+++ b/.github/copilot/pull-request-instructions.md
@@ -1,0 +1,3 @@
+# Copilot Guidelines for Pull Request Title and Description
+
+- Use descriptive pull request titles that explain the purpose of the change

--- a/.github/copilot/review-instructions.md
+++ b/.github/copilot/review-instructions.md
@@ -1,0 +1,7 @@
+# Copilot Guidelines for Code Review
+
+- Avoid unnecessary complexity in code structure
+- Ask for clarification when code is unclear
+- Provide constructive feedback on code quality
+- Suggest improvements to code structure using diffs
+- Review the code for potential bugs and security issues

--- a/.github/copilot/test-instructions.md
+++ b/.github/copilot/test-instructions.md
@@ -1,0 +1,3 @@
+# Copilot Guidelines for Test Generation
+
+- Use descriptive test names that explain the expected behavior

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -3,5 +3,30 @@
     "**/.yarn": true,
     "**/.pnp.*": true
   },
-  "prettier.prettierPath": ".yarn/sdks/prettier/index.cjs"
+  "prettier.prettierPath": ".yarn/sdks/prettier/index.cjs",
+  "github.copilot.chat.codeGeneration.instructions": [
+    {
+      "file": ".github/copilot/code-instructions.md"
+    }
+  ],
+  "github.copilot.chat.commitMessageGeneration.instructions": [
+    {
+      "file": ".github/copilot/commit-instructions.md"
+    }
+  ],
+  "github.copilot.chat.pullRequestDescriptionGeneration.instructions": [
+    {
+      "file": ".github/copilot/pull-request-instructions.md"
+    }
+  ],
+  "github.copilot.chat.reviewSelection.instructions": [
+    {
+      "file": ".github/review-instructions.md"
+    }
+  ],
+  "github.copilot.chat.testGeneration.instructions": [
+    {
+      "file": ".github/copilot/test-instructions.md"
+    }
+  ]
 }


### PR DESCRIPTION
Add Copilot guidelines for code generation, commit messages, pull requests, reviews, and tests.

Content is stubbed, consider these files as placeholders by now.