### PR TITLE
Edit terraform registry documentation after namespace change to pagopa-dx

### DIFF
--- a/.changeset/early-lizards-beg.md
+++ b/.changeset/early-lizards-beg.md
@@ -1,0 +1,5 @@
+---
+"docs": patch
+---
+
+Edit terraform registry documentation after namespace change to pagopa-dx

--- a/website/docs/infrastructure/infrastructure-as-code/publishing-terraform-modules.md
+++ b/website/docs/infrastructure/infrastructure-as-code/publishing-terraform-modules.md
@@ -13,7 +13,7 @@ This documentation is intended for contributors working on DevEx Terraform modul
 
 :::
 
-The Terraform Registry serves as a central repository where organizations can publish and share their Terraform modules with the community. It provides a standardized way to discover, distribute, and version infrastructure as code components. Our organization maintains a collection of modules in the PagoPA namespace, which you can find [here](https://registry.terraform.io/namespaces/pagopa).
+The Terraform Registry serves as a central repository where organizations can publish and share their Terraform modules with the community. It provides a standardized way to discover, distribute, and version infrastructure as code components. Our organization maintains a collection of modules in the PagoPA namespace, which you can find [here](https://registry.terraform.io/namespaces/pagopa-dx).
 
 We'll cover the entire lifecycle from initialization to publication, including our versioning system and automated workflows.
 
@@ -59,8 +59,8 @@ The Terraform Registry has specific requirements about repository structure - ea
 
 1. Takes the code from our monorepo's `infra/modules` directory
 2. Pushes each module to its dedicated sub-repository, following the Terraform Registry naming convention:
-   - Repository name format: `terraform-<PROVIDER>-dx-<NAME>`
-   - Example: `terraform-azurerm-dx-azure-api-management`
+   - Repository name format: `terraform-<PROVIDER>-<NAME>`
+   - Example: `terraform-azurerm-azure-api-management`
 
 This process is handled by the [`Push modules to subrepo`](https://github.com/pagopa/dx/blob/main/.github/workflows/push_modules_to_subrepo.yml) GitHub Action, which:
 - Identifies modified modules in the monorepo
@@ -76,9 +76,9 @@ infra/modules/
 ```
 
 They will be automatically pushed to separate repositories:
-- `terraform-azurerm-dx-azure-api-management`
-- `terraform-azurerm-dx-azure-container-app`
-- `terraform-azurerm-dx-azure-cosmos-db`
+- `terraform-azurerm-azure-api-management`
+- `terraform-azurerm-azure-container-app`
+- `terraform-azurerm-azure-cosmos-db`
 
 Each sub-repository maintains its own version history and tags, making it compatible with the Terraform Registry while allowing us to keep our centralized development workflow in the monorepo.
 
@@ -100,13 +100,12 @@ To create a new module, we provide an automated initialization script called `ad
 The script must be executed in the root of the dx repository and accepts the following parameters:
 
 ```bash
-./infra/scripts/add-module.sh --name <module-name> --description <brief-module-description> [--gh-org <organization>] [--provider <provider>]
+./infra/scripts/add-module.sh --name <module-name> --description <brief-module-description> [--provider <provider>]
 ```
 
 Parameters explained:
 - `--name`: Required. The name of your module (e.g., `azure_api_management`)
 - `--description`: Required. A brief description of the module's objective (e.g., `Deploys an Azure API Management service with monitoring and network configuration`)
-- `--gh-org`: Optional. The GitHub organization where the module's sub-repository will be created. Defaults to `pagopa`.
 - `--provider`: Optional. Defaults to `azurerm`. Specifies the cloud provider (e.g., `aws`, `azurerm`)
 
 ### What the Initialization Script Does

--- a/website/docs/infrastructure/infrastructure-as-code/publishing-terraform-modules.md
+++ b/website/docs/infrastructure/infrastructure-as-code/publishing-terraform-modules.md
@@ -119,9 +119,7 @@ The script performs several important steps:
 5. Initializes the repository with the module's base code
 
 After successful initialization, you'll need to:
-1. Contact DevEx team members in the #team_devex_help channel, to add the new repository to:
-   - The dx-pagopa-bot PAT
-   - Track it in the eng-github-authorization
+1. Start developing you module
 2. Create a changeset to produce the first release
 
 ### Adding the Module to the Terraform Registry
@@ -137,7 +135,7 @@ After completing all previous steps and ensuring that the module has been pushed
 
 3. **Add the Repository**  
    - Click **Publish** => **Module**.
-   - Select the **GitHub repository** corresponding to the module (e.g., `terraform-azurerm-dx-azure-api-management`).
+   - Select the **GitHub repository** corresponding to the module (e.g., `terraform-azurerm-azure-api-management`).
    - Confirm the repository settings.
 
 4. **Verify Publication**  

--- a/website/docs/infrastructure/infrastructure-as-code/using-terraform-registry-modules.md
+++ b/website/docs/infrastructure/infrastructure-as-code/using-terraform-registry-modules.md
@@ -4,7 +4,7 @@ sidebar_label: Using Terraform Registry Modules
 
 # Using Terraform Registry Modules
 
-The Terraform Registry serves as a central repository for discovering, sharing, and managing infrastructure modules. PagoPA maintains its own collection of modules in our dedicated namespace at [registry.terraform.io/namespaces/pagopa](https://registry.terraform.io/namespaces/pagopa), making it easier for teams to share and reuse infrastructure components.
+The Terraform Registry serves as a central repository for discovering, sharing, and managing infrastructure modules. PagoPA maintains its own collection of modules in our dedicated namespace at [registry.terraform.io/namespaces/pagopa-dx](https://registry.terraform.io/namespaces/pagopa-dx), making it easier for teams to share and reuse infrastructure components.
 
 :::note
 This documentation is relevant for all individual contributors making use of DevEx terraform modules.
@@ -116,8 +116,8 @@ module "roles" {
 **After (Registry source):**
 ```hcl
 module "roles" {
-  source  = "pagopa/dx-azure-role-assignments/azurerm"
-  version = "~> 0"
+  source  = "pagopa-dx/azure-role-assignments/azurerm"
+  version = "~> 0.0"
 
   principal_id = var.data_factory_principal_id
 
@@ -135,13 +135,13 @@ Let's break down the key changes:
 
 1. **Source Format**
    - Old: `github.com/pagopa/dx//infra/modules/azure_role_assignments?ref=main`
-   - New: `pagopa/dx-azure-role-assignments/azurerm`
+   - New: `pagopa-dx/azure-role-assignments/azurerm`
    
    The Registry format follows the pattern: `<NAMESPACE>/<NAME>/<PROVIDER>`
 
 2. **Version Specification**
    - Old: Using git ref (`?ref=main`)
-   - New: Using semantic versioning (`version = "~> 0"`)
+   - New: Using semantic versioning (`version = "~> 0.0"`)
    
    The `~>` operator allows updates within the same major version, providing stability while allowing minor updates.
 


### PR DESCRIPTION
To guide into the publishing and usage of the terraform registry, two documentation pages had been published on the dx website.
Due to the change of GH organization (hence the terraform registry namespace) from pagopa to pagopa-dx, some corrections were needed.

Resolves #CES-805

Depends on #336 