### PR TITLE
Move Pull Request Guidelines under Convention section

### DIFF
--- a/website/docs/conventions/pull-requests/acceptance-criteria.md
+++ b/website/docs/conventions/pull-requests/acceptance-criteria.md
@@ -8,22 +8,22 @@ sidebar_position: 4
 To increase the likelihood of PR approval, consider meeting the following
 criteria:
 
-- Code and comments must be written in English
+- Code and comments must be written in English.
 - A PR must contain the **smallest number of changes** possible allowing the
-  feedback loop to be as quick as possible
+  feedback loop to be as quick as possible.
 - If backward compatibility is broken, an explanation must be included. Make
-  sure to include a migration guide within the changelog, using
-  [changeset](changeset.md)
+  sure to include a **migration guide** within the changelog, using
+  [changeset](changeset.md).
 - The changes must include passing unit tests. The only exception is for tests
-  that expose an existing bug
-- No bugs, logical issues, uncovered edge cases, or known vulnerabilities have
-  been left in the code
-- The PR must be free of merge conflicts
+  that expose an existing bug.
+- No bugs, logical issues, uncovered edge cases, or known vulnerabilities should
+  be left in the code.
+- The PR must be free of merge conflicts.
 - The PR should address only **one specific issue** or add **only one feature**.
   Avoid combining multiple changes; always submit separate PRs for different
-  issues or features
+  issues or features.
 - The CI pipeline must run successfully without errors when the PR is _ready for
-  review_. For Draft PRs, it is reasonable to have some errors as the PR is
-  still in progress
-- The PR should contain a changeset file to properly handle the versioning of
-  the project
+  review_. For Draft PRs, it is reasonable to have unresolved issues as the PR
+  is still in progress.
+- The PR should contain a [changeset](changeset.md) file to properly handle the
+  versioning of the project.

--- a/website/docs/conventions/pull-requests/auto-merge.md
+++ b/website/docs/conventions/pull-requests/auto-merge.md
@@ -8,7 +8,8 @@ sidebar_position: 2
 [Auto-merge is a powerful feature in GitHub](https://github.blog/changelog/2021-02-04-pull-request-auto-merge-is-now-generally-available/)
 that automatically merges pull requests once they meet the required conditions,
 such as passing all status checks (e.g., CI pipeline, dependency on another PR)
-or receiving approvals from designated reviewers.  
+or receiving approvals from designated reviewers.
+
 This feature simplifies the development process, reduces manual work, and
 ensures code is merged automatically when ready, saving time and avoiding
 delays.
@@ -16,9 +17,9 @@ delays.
 ## Benefits of Auto Merge
 
 - **Time Saving**: eliminates the need for manual intervention once the PR meets
-  the conditions
+  the conditions.
 - **Consistency**: ensures that only code passing all tests and reviews gets
-  merged, maintaining high quality
+  merged, maintaining high quality.
 - **Faster Time to Production**: automates the merge process, enabling faster
   deployment of code
 

--- a/website/docs/conventions/pull-requests/changeset.md
+++ b/website/docs/conventions/pull-requests/changeset.md
@@ -14,19 +14,18 @@ tracking and auditing of changes over time.
 
 There are multiple ways to create a changeset file:
 
-- follow the
-  [official Changesets guide](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md)
-- [enable the Changeset bot](https://github.com/apps/changeset-bot) in your
+- Follow the
+  [official Changesets guide](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md).
+- [Enable the Changeset bot](https://github.com/apps/changeset-bot) in your
   repository and interact with it on pull requests. The bot will add a comment
   to each PR, summarizing whether it includes a changeset or not. If it doesn’t,
-  you can create one directly through the GitHub UI
+  you can create one directly through the GitHub UI.
 
 ## Breaking Changes
 
-In cases where the code added in a PR breaks backward compatibility, a migration
-path or guide must be included in the changeset with `major` update. This
-ensures that users can transition smoothly to the new version without
-disruption.
+When the code added in a PR breaks backward compatibility, a migration path or
+guide must be included in the changeset with a `major` update. This ensures that
+users can transition smoothly to the new version without disruption.
 
 ### Example
 

--- a/website/docs/conventions/pull-requests/format.md
+++ b/website/docs/conventions/pull-requests/format.md
@@ -6,17 +6,20 @@ sidebar_position: 1
 # Format for Pull Requests
 
 This document outlines the required format for pull requests to ensure clarity
-and consistency.  
+and consistency.
+
 Adhering to these guidelines will facilitate smoother reviews and better
 communication among team members.
 
 ## Title
 
 The title of a pull request should be concise and meaningful, summarizing the
-changes made.  
-Keep the title within 72 characters to avoid truncation by GitHub, ensuring that
-the full title is visible in notifications and lists, which aids in quick
-identification and understanding of the PR's purpose.  
+changes made.
+
+Keep the title **within 72 characters** to avoid truncation by GitHub, ensuring
+that the full title is visible in notifications and lists, which aids in quick
+identification and understanding of the PR's purpose.
+
 Avoid including references to tracking systems (e.g., Jira task IDs) in the
 title, as they can clutter it and may not be useful for external reviewers.
 
@@ -24,24 +27,24 @@ title, as they can clutter it and may not be useful for external reviewers.
 
 The description of a pull request must explain the rationale behind the
 modifications, offering a brief overview of the updates along with any relevant
-context.  
-It should include:
+context. It should include:
 
-- A summary of the problem being solved or the feature being added
-- If applicable, include a reference to the tracking system at the end of the
-  description using `Resolves #<Jira task ID>` (e.g., `Resolves #DX-1234`)
+- A summary of the problem being solved or the feature being added.
+- When applicable: a reference to the tracking system at the end of the
+  description using `Resolves #<Jira task ID>` (e.g., `Resolves #DX-1234`).
 
 ### Tracking System References
 
 When referencing an activity, such as a Jira task, in a pull request, use one of
 [GitHub's supported keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
-followed by the task ID.  
-Although these keywords do not automatically link the pull request to Jira, we
-follow this convention to maintain consistency rather than introducing a new
-one.  
-We recommend placing issue references in the description rather than the title.
-This approach allows for multiple issue references within the description while
-keeping the title clean and focused.  
+followed by the task ID. Although these keywords do not automatically link the
+pull request to Jira, we follow this convention to maintain consistency rather
+than introducing a new one.
+
+**We recommend placing issue references in the description rather than the
+title**. This approach allows for multiple issue references within the
+description while keeping the title clean and focused.
+
 The reference should be placed on a separate line at the end of the description,
 preceded by a blank line for separation. The sentence should begin with an
 uppercase letter.
@@ -95,7 +98,9 @@ or boards.
 
 ```markdown
 <Pull Request description>
-  
+
+<!-- Bad: multiple tasks in the same PR -->
+
 Close #DX-002 #DX-003
 ```
 
@@ -105,7 +110,9 @@ into two separate PRs, each linked to a single task. This ensures better
 traceability and avoids merging unrelated changes together.
 
 ```markdown
-This PR fixes #DX-002
+<!-- Bad: verbose reference within the PR description instead of placing it at the end -->
+
+This PR fixes #DX-002...
 ```
 
 This format is discouraged because the reference is embedded within the

--- a/website/docs/conventions/pull-requests/index.md
+++ b/website/docs/conventions/pull-requests/index.md
@@ -1,4 +1,4 @@
-# Pull Request
+# Pull Requests
 
 Pull requests (PRs) are a critical part of the development workflow, enabling
 collaboration and code review.
@@ -8,17 +8,18 @@ easier for team members to understand and review changes.
 
 ## General Principles
 
-### Transparency
-
-Transparency is crucial in the development process.
-[Opening pull requests in draft mode](https://github.blog/news-insights/product-news/introducing-draft-pull-requests/)
-is encouraged to provide visibility into ongoing work and foster collaboration.
-While draft PRs can facilitate early feedback, it is the author's responsibility
-to request it when needed.
-
 ### Pragmatic Minimalism
 
 Adopting a pragmatic minimalism approach means keeping pull requests small and
 focused on a single purpose. Avoid unnecessary complexity, and ensure clear PR
 descriptions and commit messages to help reviewers understand the intent
 quickly.
+
+### Transparency and Draft PRs
+
+Transparency is crucial in the development process.
+[Opening pull requests in draft mode](https://github.blog/news-insights/product-news/introducing-draft-pull-requests/)
+is encouraged to provide visibility into ongoing work and foster collaboration.
+
+While draft PRs can facilitate early feedback, it is the author's responsibility
+to proactively request it when needed.

--- a/website/docs/guidelines/index.md
+++ b/website/docs/guidelines/index.md
@@ -1,5 +1,0 @@
----
-sidebar_position: 3
----
-
-# Guidelines


### PR DESCRIPTION
Consolidate pull request guidelines into a dedicated conventions section to enhance organization and accessibility for contributors. 