### PR TITLE
Fix yarn lock entries order after azure_cdn release

### DIFF
--- a/yarn.lock
+++ b/yarn.lock
@@ -4351,6 +4351,12 @@ __metadata:
   languageName: unknown
   linkType: soft
 
+"azure_cdn@workspace:infra/modules/azure_cdn":
+  version: 0.0.0-use.local
+  resolution: "azure_cdn@workspace:infra/modules/azure_cdn"
+  languageName: unknown
+  linkType: soft
+
 "azure_container_app@workspace:infra/modules/azure_container_app":
   version: 0.0.0-use.local
   resolution: "azure_container_app@workspace:infra/modules/azure_container_app"
@@ -4360,12 +4366,6 @@ __metadata:
 "azure_container_app_environment@workspace:infra/modules/azure_container_app_environment":
   version: 0.0.0-use.local
   resolution: "azure_container_app_environment@workspace:infra/modules/azure_container_app_environment"
-  languageName: unknown
-  linkType: soft
-
-"azure_cdn@workspace:infra/modules/azure_cdn":
-  version: 0.0.0-use.local
-  resolution: "azure_cdn@workspace:infra/modules/azure_cdn"
   languageName: unknown
   linkType: soft
 


### PR DESCRIPTION
The yarn.lock file requires the entries to be placed in alphabetical order.
In the release of the azure_cdn module, after a merge conflict resolution, the yarn.lock got out of order.