### PR TITLE
Update PR description guideline

### DIFF
--- a/.changeset/pretty-fishes-exercise.md
+++ b/.changeset/pretty-fishes-exercise.md
@@ -1,0 +1,5 @@
+---
+"docs": patch
+---
+
+Update PR description guideline discouraging the use of images and links in PR description

--- a/website/docs/conventions/pull-requests/format.md
+++ b/website/docs/conventions/pull-requests/format.md
@@ -32,6 +32,9 @@ context. It should include:
 - A summary of the problem being solved or the feature being added.
 - When applicable: a reference to the tracking system at the end of the
   description using `Resolves #<Jira task ID>` (e.g., `Resolves #DX-1234`).
+- Don't include images or links in the description, as they add noise to the Git
+  history since the PR description is used as the commit message. Use a comment
+  to provide more context instead.
 
 ### Tracking System References
 

--- a/website/docs/conventions/pull-requests/format.md
+++ b/website/docs/conventions/pull-requests/format.md
@@ -33,8 +33,8 @@ context. It should include:
 - When applicable: a reference to the tracking system at the end of the
   description using `Resolves #<Jira task ID>` (e.g., `Resolves #DX-1234`).
 - Don't include images or links in the description, as they add noise to the Git
-  history since the PR description is used as the commit message. Use a comment
-  to provide more context instead.
+  history since the PR description is used as summary of the merge commit. Use a
+  comment to provide more context instead.
 
 ### Tracking System References
 


### PR DESCRIPTION
Discourage the use of images and links in PR description in favor of a comment in the PR.

PR description will be the commit description of the merge commit.