### PR TITLE
Fix an issue that prevented AppSettings to be displayed in Terraform Plans

### DIFF
--- a/.changeset/odd-coats-clap.md
+++ b/.changeset/odd-coats-clap.md
@@ -1,0 +1,5 @@
+---
+"azure_function_app": patch
+---
+
+Fix visibility of app settings containing sensitive values in Terraform Plan

--- a/infra/modules/azure_function_app/locals.tf
+++ b/infra/modules/azure_function_app/locals.tf
@@ -31,7 +31,7 @@ locals {
   }
 
   application_insights = {
-    enable = var.application_insights_connection_string != null
+    enable = nonsensitive(var.application_insights_connection_string) != null
   }
 
   storage_account = {

--- a/infra/modules/azure_function_app/locals.tf
+++ b/infra/modules/azure_function_app/locals.tf
@@ -31,7 +31,7 @@ locals {
   }
 
   application_insights = {
-    enable = nonsensitive(var.application_insights_connection_string) != null
+    enable = nonsensitive(var.application_insights_connection_string != null)
   }
 
   storage_account = {

--- a/infra/modules/azure_function_app/variables.tf
+++ b/infra/modules/azure_function_app/variables.tf
@@ -40,7 +40,7 @@ variable "subnet_id" {
 
 variable "application_insights_connection_string" {
   type        = string
-  sensitive   = true
+  sensitive   = false
   default     = null
   description = "(Optional) Application Insights connection string"
 }
@@ -178,7 +178,7 @@ variable "action_group_id" {
 variable "application_insights_key" {
   type        = string
   description = "(Optional) Application Insights key"
-  sensitive   = true
+  sensitive   = false
   default     = null
 }
 

--- a/infra/modules/azure_function_app/variables.tf
+++ b/infra/modules/azure_function_app/variables.tf
@@ -40,7 +40,7 @@ variable "subnet_id" {
 
 variable "application_insights_connection_string" {
   type        = string
-  sensitive   = false
+  sensitive   = true
   default     = null
   description = "(Optional) Application Insights connection string"
 }
@@ -178,7 +178,7 @@ variable "action_group_id" {
 variable "application_insights_key" {
   type        = string
   description = "(Optional) Application Insights key"
-  sensitive   = false
+  sensitive   = true
   default     = null
 }
 


### PR DESCRIPTION
By using Terraform >= 1.10.x, the AppSettings property was marked as sensitive and therefore no longer displayed.

By forcing the boolean local to not being sensitive, the "mark" is not propagated to the `app_settings` resource property, which then doesn't result sensitive anymore

Closes CES-740