### PR TITLE
Removed zone_redundant variable into Container App Environment module

### DIFF
--- a/.changeset/shaggy-spies-perform.md
+++ b/.changeset/shaggy-spies-perform.md
@@ -1,0 +1,5 @@
+---
+"azure_container_app_environment": patch
+---
+
+Removed zone_redundant variable

--- a/infra/modules/azure_container_app_environment/README.md
+++ b/infra/modules/azure_container_app_environment/README.md
@@ -52,7 +52,6 @@ This Terraform module deploys an Azure Container App Environment along with nece
 | <a name="input_subnet_pep_id"></a> [subnet\_pep\_id](#input\_subnet\_pep\_id) | Id of the subnet which holds private endpoints | `string` | n/a | yes |
 | <a name="input_tags"></a> [tags](#input\_tags) | Resources tags | `map(any)` | n/a | yes |
 | <a name="input_virtual_network"></a> [virtual\_network](#input\_virtual\_network) | (Optional) Virtual network in which to create the subnet | <pre>object({<br/>    name                = string<br/>    resource_group_name = string<br/>  })</pre> | <pre>{<br/>  "name": null,<br/>  "resource_group_name": null<br/>}</pre> | no |
-| <a name="input_zone_redundant"></a> [zone\_redundant](#input\_zone\_redundant) | Indicates whether the container app environment is zone redundant or not | `bool` | `true` | no |
 
 ## Outputs
 

--- a/infra/modules/azure_container_app_environment/container_app_environment.tf
+++ b/infra/modules/azure_container_app_environment/container_app_environment.tf
@@ -14,7 +14,7 @@ resource "azurerm_container_app_environment" "this" {
     maximum_count         = 1
   }
 
-  zone_redundancy_enabled = var.environment.env_short != "p" ? false : true
+  zone_redundancy_enabled = var.environment.env_short != "d" ? true : false
 
   lifecycle {
     ignore_changes = [

--- a/infra/modules/azure_container_app_environment/container_app_environment.tf
+++ b/infra/modules/azure_container_app_environment/container_app_environment.tf
@@ -14,7 +14,7 @@ resource "azurerm_container_app_environment" "this" {
     maximum_count         = 1
   }
 
-  zone_redundancy_enabled = var.zone_redundant
+  zone_redundancy_enabled = var.environment.env_short != "p" ? false : true
 
   lifecycle {
     ignore_changes = [

--- a/infra/modules/azure_container_app_environment/tests/containerappenv.tftest.hcl
+++ b/infra/modules/azure_container_app_environment/tests/containerappenv.tftest.hcl
@@ -54,8 +54,6 @@ run "container_app_env_is_correct_plan" {
     }
     subnet_pep_id = run.setup_tests.pep_snet_id
     subnet_cidr   = "10.50.100.0/24"
-
-    zone_redundant = true
   }
 
   # Checks some assertions
@@ -90,7 +88,7 @@ run "container_app_env_is_correct_plan" {
   }
 
   assert {
-    condition     = azurerm_container_app_environment.this.zone_redundancy_enabled == true
+    condition     = azurerm_container_app_environment.this.zone_redundancy_enabled == false
     error_message = "The container app environment zone redundancy enabled is not correct"
   }
 }

--- a/infra/modules/azure_container_app_environment/variables.tf
+++ b/infra/modules/azure_container_app_environment/variables.tf
@@ -28,12 +28,6 @@ variable "log_analytics_workspace_id" {
   description = "The ID of the Log Analytics workspace to use for the container app environment."
 }
 
-variable "zone_redundant" {
-  type        = bool
-  description = "Indicates whether the container app environment is zone redundant or not"
-  default     = true
-}
-
 # ------------ NETWORKING ------------ #
 
 variable "subnet_id" {


### PR DESCRIPTION
To reduce configuration complexity the variable `zone_redundant` now is defined automatically, based on environment in use:
if environment is `dev` zone redundancy is `true`, otherwise is `false`.

Resolves: CES-856