### PR TITLE
Replace Azure Naming Convention module references

### DIFF
--- a/.changeset/red-bulldogs-kiss.md
+++ b/.changeset/red-bulldogs-kiss.md
@@ -1,0 +1,20 @@
+---
+"github_selfhosted_runner_on_container_app_jobs": patch
+"azure_federated_identity_with_github": patch
+"azure_github_environment_bootstrap": patch
+"azure_container_app_environment": patch
+"azure_function_app_exposed": patch
+"azure_app_service_exposed": patch
+"azure_postgres_server": patch
+"azure_storage_account": patch
+"azure_api_management": patch
+"azure_cosmos_account": patch
+"azure_container_app": patch
+"azure_function_app": patch
+"azure_app_service": patch
+"azure_core_infra": patch
+"azure_event_hub": patch
+"azure_cdn": patch
+---
+
+Update reference to Azure Naming Convention Module

--- a/infra/modules/azure_api_management/README.md
+++ b/infra/modules/azure_api_management/README.md
@@ -48,7 +48,7 @@ module "apim" {
 
 | Name | Source | Version |
 |------|--------|---------|
-| <a name="module_naming_convention"></a> [naming\_convention](#module\_naming\_convention) | pagopa/dx-azure-naming-convention/azurerm | ~> 0 |
+| <a name="module_naming_convention"></a> [naming\_convention](#module\_naming\_convention) | pagopa-dx/azure-naming-convention/azurerm | ~> 0.0 |
 
 ## Resources
 

--- a/infra/modules/azure_api_management/main.tf
+++ b/infra/modules/azure_api_management/main.tf
@@ -8,8 +8,8 @@ terraform {
 }
 
 module "naming_convention" {
-  source  = "pagopa/dx-azure-naming-convention/azurerm"
-  version = "~> 0"
+  source  = "pagopa-dx/azure-naming-convention/azurerm"
+  version = "~> 0.0"
 
   environment = {
     prefix          = var.environment.prefix

--- a/infra/modules/azure_app_service/README.md
+++ b/infra/modules/azure_app_service/README.md
@@ -12,7 +12,7 @@
 
 | Name | Source | Version |
 |------|--------|---------|
-| <a name="module_naming_convention"></a> [naming\_convention](#module\_naming\_convention) | pagopa/dx-azure-naming-convention/azurerm | ~> 0 |
+| <a name="module_naming_convention"></a> [naming\_convention](#module\_naming\_convention) | pagopa-dx/azure-naming-convention/azurerm | ~> 0.0 |
 
 ## Resources
 

--- a/infra/modules/azure_app_service/main.tf
+++ b/infra/modules/azure_app_service/main.tf
@@ -8,8 +8,8 @@ terraform {
 }
 
 module "naming_convention" {
-  source  = "pagopa/dx-azure-naming-convention/azurerm"
-  version = "~> 0"
+  source  = "pagopa-dx/azure-naming-convention/azurerm"
+  version = "~> 0.0"
 
   environment = {
     prefix          = var.environment.prefix

--- a/infra/modules/azure_app_service_exposed/README.md
+++ b/infra/modules/azure_app_service_exposed/README.md
@@ -14,7 +14,7 @@ This module is used to create an Azure App Service, allowing it to be configured
 
 | Name | Source | Version |
 |------|--------|---------|
-| <a name="module_naming_convention"></a> [naming\_convention](#module\_naming\_convention) | pagopa/dx-azure-naming-convention/azurerm | ~> 0 |
+| <a name="module_naming_convention"></a> [naming\_convention](#module\_naming\_convention) | pagopa-dx/azure-naming-convention/azurerm | ~> 0.0 |
 
 ## Resources
 

--- a/infra/modules/azure_app_service_exposed/main.tf
+++ b/infra/modules/azure_app_service_exposed/main.tf
@@ -8,8 +8,8 @@ terraform {
 }
 
 module "naming_convention" {
-  source  = "pagopa/dx-azure-naming-convention/azurerm"
-  version = "~> 0"
+  source  = "pagopa-dx/azure-naming-convention/azurerm"
+  version = "~> 0.0"
 
   environment = {
     prefix          = var.environment.prefix

--- a/infra/modules/azure_cdn/README.md
+++ b/infra/modules/azure_cdn/README.md
@@ -76,7 +76,7 @@ terraform test
 
 | Name | Source | Version |
 |------|--------|---------|
-| <a name="module_naming_convention"></a> [naming\_convention](#module\_naming\_convention) | pagopa/dx-azure-naming-convention/azurerm | ~> 0.0 |
+| <a name="module_naming_convention"></a> [naming\_convention](#module\_naming\_convention) | pagopa-dx/azure-naming-convention/azurerm | ~> 0.0 |
 
 ## Resources
 

--- a/infra/modules/azure_cdn/examples/basic/README.md
+++ b/infra/modules/azure_cdn/examples/basic/README.md
@@ -12,7 +12,7 @@
 | Name | Source | Version |
 |------|--------|---------|
 | <a name="module_azure_cdn"></a> [azure\_cdn](#module\_azure\_cdn) | ../../ | n/a |
-| <a name="module_naming_convention"></a> [naming\_convention](#module\_naming\_convention) | pagopa/dx-azure-naming-convention/azurerm | ~> 0.0 |
+| <a name="module_naming_convention"></a> [naming\_convention](#module\_naming\_convention) | pagopa-dx/azure-naming-convention/azurerm | ~> 0.0 |
 | <a name="module_storage_account"></a> [storage\_account](#module\_storage\_account) | ../../../azure_storage_account | n/a |
 
 ## Resources

--- a/infra/modules/azure_cdn/examples/basic/versions.tf
+++ b/infra/modules/azure_cdn/examples/basic/versions.tf
@@ -20,7 +20,7 @@ provider "azurerm" {
 }
 
 module "naming_convention" {
-  source  = "pagopa/dx-azure-naming-convention/azurerm"
+  source  = "pagopa-dx/azure-naming-convention/azurerm"
   version = "~> 0.0"
 
   environment = {

--- a/infra/modules/azure_cdn/main.tf
+++ b/infra/modules/azure_cdn/main.tf
@@ -8,7 +8,7 @@ terraform {
 }
 
 module "naming_convention" {
-  source  = "pagopa/dx-azure-naming-convention/azurerm"
+  source  = "pagopa-dx/azure-naming-convention/azurerm"
   version = "~> 0.0"
 
   environment = {

--- a/infra/modules/azure_container_app/README.md
+++ b/infra/modules/azure_container_app/README.md
@@ -63,7 +63,7 @@ This Terraform module deploys an Azure Container App in a provided Azure Contain
 
 | Name | Source | Version |
 |------|--------|---------|
-| <a name="module_naming_convention"></a> [naming\_convention](#module\_naming\_convention) | pagopa/dx-azure-naming-convention/azurerm | ~> 0.0 |
+| <a name="module_naming_convention"></a> [naming\_convention](#module\_naming\_convention) | pagopa-dx/azure-naming-convention/azurerm | ~> 0.0 |
 
 ## Resources
 

--- a/infra/modules/azure_container_app/main.tf
+++ b/infra/modules/azure_container_app/main.tf
@@ -8,7 +8,7 @@ terraform {
 }
 
 module "naming_convention" {
-  source  = "pagopa/dx-azure-naming-convention/azurerm"
+  source  = "pagopa-dx/azure-naming-convention/azurerm"
   version = "~> 0.0"
 
   environment = {

--- a/infra/modules/azure_container_app_environment/README.md
+++ b/infra/modules/azure_container_app_environment/README.md
@@ -27,7 +27,7 @@ This Terraform module deploys an Azure Container App Environment along with nece
 
 | Name | Source | Version |
 |------|--------|---------|
-| <a name="module_naming_convention"></a> [naming\_convention](#module\_naming\_convention) | pagopa/dx-azure-naming-convention/azurerm | ~> 0.0 |
+| <a name="module_naming_convention"></a> [naming\_convention](#module\_naming\_convention) | pagopa-dx/azure-naming-convention/azurerm | ~> 0.0 |
 
 ## Resources
 

--- a/infra/modules/azure_container_app_environment/main.tf
+++ b/infra/modules/azure_container_app_environment/main.tf
@@ -8,7 +8,7 @@ terraform {
 }
 
 module "naming_convention" {
-  source  = "pagopa/dx-azure-naming-convention/azurerm"
+  source  = "pagopa-dx/azure-naming-convention/azurerm"
   version = "~> 0.0"
 
   environment = {

--- a/infra/modules/azure_core_infra/README.md
+++ b/infra/modules/azure_core_infra/README.md
@@ -49,8 +49,8 @@ For more specific examples check out the `./example` folder. There you'll find a
 | <a name="module_dns"></a> [dns](#module\_dns) | ./_modules/dns | n/a |
 | <a name="module_github_runner"></a> [github\_runner](#module\_github\_runner) | ./_modules/github_runner | n/a |
 | <a name="module_key_vault"></a> [key\_vault](#module\_key\_vault) | ./_modules/key_vault | n/a |
-| <a name="module_naming_convention"></a> [naming\_convention](#module\_naming\_convention) | pagopa/dx-azure-naming-convention/azurerm | ~> 0 |
-| <a name="module_naming_convention_gh_runner"></a> [naming\_convention\_gh\_runner](#module\_naming\_convention\_gh\_runner) | pagopa/dx-azure-naming-convention/azurerm | ~> 0 |
+| <a name="module_naming_convention"></a> [naming\_convention](#module\_naming\_convention) | pagopa-dx/azure-naming-convention/azurerm | ~> 0.0 |
+| <a name="module_naming_convention_gh_runner"></a> [naming\_convention\_gh\_runner](#module\_naming\_convention\_gh\_runner) | pagopa-dx/azure-naming-convention/azurerm | ~> 0.0 |
 | <a name="module_nat_gateway"></a> [nat\_gateway](#module\_nat\_gateway) | ./_modules/nat_gateway | n/a |
 | <a name="module_network"></a> [network](#module\_network) | ./_modules/networking | n/a |
 | <a name="module_vpn"></a> [vpn](#module\_vpn) | ./_modules/vpn | n/a |

--- a/infra/modules/azure_core_infra/example/develop/README.md
+++ b/infra/modules/azure_core_infra/example/develop/README.md
@@ -103,7 +103,7 @@ Then, in different modules, you can use these data sources as follows:
 | <a name="module_apim"></a> [apim](#module\_apim) | ../../../azure_api_management | n/a |
 | <a name="module_core"></a> [core](#module\_core) | ../.. | n/a |
 | <a name="module_cosmos"></a> [cosmos](#module\_cosmos) | ../../../azure_cosmos_account | n/a |
-| <a name="module_naming_convention"></a> [naming\_convention](#module\_naming\_convention) | pagopa/dx-azure-naming-convention/azurerm | ~> 0 |
+| <a name="module_naming_convention"></a> [naming\_convention](#module\_naming\_convention) | pagopa-dx/azure-naming-convention/azurerm | ~> 0.0 |
 | <a name="module_storage_account"></a> [storage\_account](#module\_storage\_account) | ../../../azure_storage_account | n/a |
 
 ## Resources

--- a/infra/modules/azure_core_infra/example/develop/versions.tf
+++ b/infra/modules/azure_core_infra/example/develop/versions.tf
@@ -20,8 +20,8 @@ provider "azurerm" {
 }
 
 module "naming_convention" {
-  source  = "pagopa/dx-azure-naming-convention/azurerm"
-  version = "~> 0"
+  source  = "pagopa-dx/azure-naming-convention/azurerm"
+  version = "~> 0.0"
 
   environment = {
     prefix          = local.environment.prefix

--- a/infra/modules/azure_core_infra/main.tf
+++ b/infra/modules/azure_core_infra/main.tf
@@ -8,8 +8,8 @@ terraform {
 }
 
 module "naming_convention" {
-  source  = "pagopa/dx-azure-naming-convention/azurerm"
-  version = "~> 0"
+  source  = "pagopa-dx/azure-naming-convention/azurerm"
+  version = "~> 0.0"
 
   environment = {
     prefix          = var.environment.prefix
@@ -22,8 +22,8 @@ module "naming_convention" {
 }
 
 module "naming_convention_gh_runner" {
-  source  = "pagopa/dx-azure-naming-convention/azurerm"
-  version = "~> 0"
+  source  = "pagopa-dx/azure-naming-convention/azurerm"
+  version = "~> 0.0"
 
   environment = {
     prefix          = var.environment.prefix

--- a/infra/modules/azure_cosmos_account/README.md
+++ b/infra/modules/azure_cosmos_account/README.md
@@ -16,7 +16,7 @@ This Terraform module provisions an Azure Cosmos DB Account with configurable se
 ```hcl
 module "cosmosdb" {
   source  = "pagopa/dx-azure-cosmos-account/azurerm"
-  version = "~> 0"
+  version = "~> 0.0"
 
   environment                = var.environment
   resource_group_name        = var.resource_group_name
@@ -57,7 +57,7 @@ module "cosmosdb" {
 
 | Name | Source | Version |
 |------|--------|---------|
-| <a name="module_naming_convention"></a> [naming\_convention](#module\_naming\_convention) | pagopa/dx-azure-naming-convention/azurerm | ~> 0 |
+| <a name="module_naming_convention"></a> [naming\_convention](#module\_naming\_convention) | pagopa-dx/azure-naming-convention/azurerm | ~> 0.0 |
 
 ## Resources
 

--- a/infra/modules/azure_cosmos_account/main.tf
+++ b/infra/modules/azure_cosmos_account/main.tf
@@ -8,8 +8,8 @@ terraform {
 }
 
 module "naming_convention" {
-  source  = "pagopa/dx-azure-naming-convention/azurerm"
-  version = "~> 0"
+  source  = "pagopa-dx/azure-naming-convention/azurerm"
+  version = "~> 0.0"
 
   environment = {
     prefix          = var.environment.prefix

--- a/infra/modules/azure_event_hub/README.md
+++ b/infra/modules/azure_event_hub/README.md
@@ -12,7 +12,7 @@
 
 | Name | Source | Version |
 |------|--------|---------|
-| <a name="module_naming_convention"></a> [naming\_convention](#module\_naming\_convention) | pagopa/dx-azure-naming-convention/azurerm | ~> 0 |
+| <a name="module_naming_convention"></a> [naming\_convention](#module\_naming\_convention) | pagopa-dx/azure-naming-convention/azurerm | ~> 0.0 |
 
 ## Resources
 

--- a/infra/modules/azure_event_hub/main.tf
+++ b/infra/modules/azure_event_hub/main.tf
@@ -8,8 +8,8 @@ terraform {
 }
 
 module "naming_convention" {
-  source  = "pagopa/dx-azure-naming-convention/azurerm"
-  version = "~> 0"
+  source  = "pagopa-dx/azure-naming-convention/azurerm"
+  version = "~> 0.0"
 
   environment = {
     prefix          = var.environment.prefix

--- a/infra/modules/azure_federated_identity_with_github/README.md
+++ b/infra/modules/azure_federated_identity_with_github/README.md
@@ -12,7 +12,7 @@
 
 | Name | Source | Version |
 |------|--------|---------|
-| <a name="module_naming_convention"></a> [naming\_convention](#module\_naming\_convention) | pagopa/dx-azure-naming-convention/azurerm | ~>0 |
+| <a name="module_naming_convention"></a> [naming\_convention](#module\_naming\_convention) | pagopa-dx/azure-naming-convention/azurerm | ~> 0.0 |
 
 ## Resources
 

--- a/infra/modules/azure_federated_identity_with_github/main.tf
+++ b/infra/modules/azure_federated_identity_with_github/main.tf
@@ -8,8 +8,8 @@ terraform {
 }
 
 module "naming_convention" {
-  source  = "pagopa/dx-azure-naming-convention/azurerm"
-  version = "~>0"
+  source  = "pagopa-dx/azure-naming-convention/azurerm"
+  version = "~> 0.0"
 
   environment = {
     prefix          = var.environment.prefix

--- a/infra/modules/azure_function_app/README.md
+++ b/infra/modules/azure_function_app/README.md
@@ -12,7 +12,7 @@
 
 | Name | Source | Version |
 |------|--------|---------|
-| <a name="module_naming_convention"></a> [naming\_convention](#module\_naming\_convention) | pagopa/dx-azure-naming-convention/azurerm | ~> 0 |
+| <a name="module_naming_convention"></a> [naming\_convention](#module\_naming\_convention) | pagopa-dx/azure-naming-convention/azurerm | ~> 0.0 |
 
 ## Resources
 

--- a/infra/modules/azure_function_app/main.tf
+++ b/infra/modules/azure_function_app/main.tf
@@ -8,8 +8,8 @@ terraform {
 }
 
 module "naming_convention" {
-  source  = "pagopa/dx-azure-naming-convention/azurerm"
-  version = "~> 0"
+  source  = "pagopa-dx/azure-naming-convention/azurerm"
+  version = "~> 0.0"
 
   environment = {
     prefix          = var.environment.prefix

--- a/infra/modules/azure_function_app_exposed/README.md
+++ b/infra/modules/azure_function_app_exposed/README.md
@@ -12,7 +12,7 @@
 
 | Name | Source | Version |
 |------|--------|---------|
-| <a name="module_naming_convention"></a> [naming\_convention](#module\_naming\_convention) | pagopa/dx-azure-naming-convention/azurerm | ~> 0 |
+| <a name="module_naming_convention"></a> [naming\_convention](#module\_naming\_convention) | pagopa-dx/azure-naming-convention/azurerm | ~> 0.0 |
 
 ## Resources
 

--- a/infra/modules/azure_function_app_exposed/main.tf
+++ b/infra/modules/azure_function_app_exposed/main.tf
@@ -8,8 +8,8 @@ terraform {
 }
 
 module "naming_convention" {
-  source  = "pagopa/dx-azure-naming-convention/azurerm"
-  version = "~> 0"
+  source  = "pagopa-dx/azure-naming-convention/azurerm"
+  version = "~> 0.0"
 
   environment = {
     prefix          = var.environment.prefix

--- a/infra/modules/azure_github_environment_bootstrap/README.md
+++ b/infra/modules/azure_github_environment_bootstrap/README.md
@@ -109,7 +109,7 @@ resource "github_repository_environment_deployment_policy" "release_branch" {
 
 | Name | Source | Version |
 |------|--------|---------|
-| <a name="module_naming_convention"></a> [naming\_convention](#module\_naming\_convention) | pagopa/dx-azure-naming-convention/azurerm | ~>0 |
+| <a name="module_naming_convention"></a> [naming\_convention](#module\_naming\_convention) | pagopa-dx/azure-naming-convention/azurerm | ~> 0.0 |
 
 ## Resources
 

--- a/infra/modules/azure_github_environment_bootstrap/main.tf
+++ b/infra/modules/azure_github_environment_bootstrap/main.tf
@@ -13,8 +13,8 @@ terraform {
 }
 
 module "naming_convention" {
-  source  = "pagopa/dx-azure-naming-convention/azurerm"
-  version = "~>0"
+  source  = "pagopa-dx/azure-naming-convention/azurerm"
+  version = "~> 0.0"
 
   environment = {
     prefix          = var.environment.prefix

--- a/infra/modules/azure_postgres_server/README.md
+++ b/infra/modules/azure_postgres_server/README.md
@@ -12,7 +12,7 @@
 
 | Name | Source | Version |
 |------|--------|---------|
-| <a name="module_naming_convention"></a> [naming\_convention](#module\_naming\_convention) | pagopa/dx-azure-naming-convention/azurerm | ~> 0 |
+| <a name="module_naming_convention"></a> [naming\_convention](#module\_naming\_convention) | pagopa-dx/azure-naming-convention/azurerm | ~> 0.0 |
 
 ## Resources
 

--- a/infra/modules/azure_postgres_server/main.tf
+++ b/infra/modules/azure_postgres_server/main.tf
@@ -8,8 +8,8 @@ terraform {
 }
 
 module "naming_convention" {
-  source  = "pagopa/dx-azure-naming-convention/azurerm"
-  version = "~> 0"
+  source  = "pagopa-dx/azure-naming-convention/azurerm"
+  version = "~> 0.0"
 
   environment = {
     prefix          = var.environment.prefix

--- a/infra/modules/azure_storage_account/README.md
+++ b/infra/modules/azure_storage_account/README.md
@@ -11,7 +11,7 @@
 
 | Name | Source | Version |
 |------|--------|---------|
-| <a name="module_naming_convention"></a> [naming\_convention](#module\_naming\_convention) | pagopa/dx-azure-naming-convention/azurerm | ~> 0 |
+| <a name="module_naming_convention"></a> [naming\_convention](#module\_naming\_convention) | pagopa-dx/azure-naming-convention/azurerm | ~> 0.0 |
 
 ## Resources
 

--- a/infra/modules/azure_storage_account/main.tf
+++ b/infra/modules/azure_storage_account/main.tf
@@ -8,8 +8,8 @@ terraform {
 }
 
 module "naming_convention" {
-  source  = "pagopa/dx-azure-naming-convention/azurerm"
-  version = "~> 0"
+  source  = "pagopa-dx/azure-naming-convention/azurerm"
+  version = "~> 0.0"
 
   environment = {
     prefix          = var.environment.prefix

--- a/infra/modules/github_selfhosted_runner_on_container_app_jobs/README.md
+++ b/infra/modules/github_selfhosted_runner_on_container_app_jobs/README.md
@@ -12,7 +12,7 @@
 
 | Name | Source | Version |
 |------|--------|---------|
-| <a name="module_naming_convention"></a> [naming\_convention](#module\_naming\_convention) | pagopa/dx-azure-naming-convention/azurerm | ~> 0 |
+| <a name="module_naming_convention"></a> [naming\_convention](#module\_naming\_convention) | pagopa-dx/azure-naming-convention/azurerm | ~> 0.0 |
 
 ## Resources
 

--- a/infra/modules/github_selfhosted_runner_on_container_app_jobs/main.tf
+++ b/infra/modules/github_selfhosted_runner_on_container_app_jobs/main.tf
@@ -9,8 +9,8 @@ terraform {
 }
 
 module "naming_convention" {
-  source  = "pagopa/dx-azure-naming-convention/azurerm"
-  version = "~> 0"
+  source  = "pagopa-dx/azure-naming-convention/azurerm"
+  version = "~> 0.0"
 
   environment = {
     prefix          = var.environment.prefix

--- a/infra/policy/dev/README.md
+++ b/infra/policy/dev/README.md
@@ -17,7 +17,7 @@
 
 | Name | Source | Version |
 |------|--------|---------|
-| <a name="module_naming_convention"></a> [naming\_convention](#module\_naming\_convention) | pagopa/dx-azure-naming-convention/azurerm | ~> 0 |
+| <a name="module_naming_convention"></a> [naming\_convention](#module\_naming\_convention) | pagopa-dx/azure-naming-convention/azurerm | ~> 0.0 |
 
 ## Resources
 

--- a/infra/policy/dev/main.tf
+++ b/infra/policy/dev/main.tf
@@ -21,7 +21,7 @@ provider "azurerm" {
 }
 
 module "naming_convention" {
-  source      = "pagopa/dx-azure-naming-convention/azurerm"
-  version     = "~> 0"
+  source      = "pagopa-dx/azure-naming-convention/azurerm"
+  version     = "~> 0.0"
   environment = local.environment
 }


### PR DESCRIPTION
Terraform modules were using the old Terraform registry organisation to reference the Azure Naming Convention module

Closes CES-859