### PR TITLE
Add current_ref value into push_modules_to_subrepo workflow

### DIFF
--- a/.github/workflows/push_modules_to_subrepo.yml
+++ b/.github/workflows/push_modules_to_subrepo.yml
@@ -33,7 +33,9 @@ jobs:
         id: get-modified-modules
         if: ${{ github.event_name != 'workflow_dispatch' }}
         uses: pagopa/dx/.github/actions/get-modified-modules@main
-
+        with:
+          current_ref: ${{ github.event.before }}
+          
   push-modified-modules:
     runs-on: ubuntu-latest
     needs: [detect-modules]


### PR DESCRIPTION
Fix the workflow when a PR is merged