### PR TITLE
Reuse GitHub SelfHosted Runner on Container App Job module in Bootstrapper

### DIFF
--- a/.changeset/tough-owls-live.md
+++ b/.changeset/tough-owls-live.md
@@ -1,0 +1,5 @@
+---
+"azure_github_environment_bootstrap": minor
+---
+
+Add variables to control GitHub runner timeout and support to KeyVaults using RBAC

--- a/infra/modules/azure_github_environment_bootstrap/README.md
+++ b/infra/modules/azure_github_environment_bootstrap/README.md
@@ -109,13 +109,13 @@ resource "github_repository_environment_deployment_policy" "release_branch" {
 
 | Name | Source | Version |
 |------|--------|---------|
+| <a name="module_github_runner"></a> [github\_runner](#module\_github\_runner) | pagopa-dx/github-selfhosted-runner-on-container-app-jobs/azurerm | ~> 1.0 |
 | <a name="module_naming_convention"></a> [naming\_convention](#module\_naming\_convention) | pagopa-dx/azure-naming-convention/azurerm | ~> 0.0 |
 
 ## Resources
 
 | Name | Type |
 |------|------|
-| [azurerm_container_app_job.github_runner](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/container_app_job) | resource |
 | [azurerm_federated_identity_credential.github_app_cd](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/federated_identity_credential) | resource |
 | [azurerm_federated_identity_credential.github_infra_cd](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/federated_identity_credential) | resource |
 | [azurerm_federated_identity_credential.github_infra_ci](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/federated_identity_credential) | resource |
@@ -123,7 +123,6 @@ resource "github_repository_environment_deployment_policy" "release_branch" {
 | [azurerm_federated_identity_credential.github_opex_ci](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/federated_identity_credential) | resource |
 | [azurerm_key_vault_access_policy.infra_cd_kv_common](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/key_vault_access_policy) | resource |
 | [azurerm_key_vault_access_policy.infra_ci_kv_common](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/key_vault_access_policy) | resource |
-| [azurerm_key_vault_access_policy.keyvault_containerapp](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/key_vault_access_policy) | resource |
 | [azurerm_resource_group.main](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/resource_group) | resource |
 | [azurerm_role_assignment.admins_group_rgs](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/role_assignment) | resource |
 | [azurerm_role_assignment.admins_group_rgs_kv_admin](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/role_assignment) | resource |
@@ -197,7 +196,6 @@ resource "github_repository_environment_deployment_policy" "release_branch" {
 | [github_repository_environment_deployment_policy.infra_prod_cd_tag](https://registry.terraform.io/providers/integrations/github/latest/docs/resources/repository_environment_deployment_policy) | resource |
 | [github_repository_environment_deployment_policy.opex_prod_cd_branch](https://registry.terraform.io/providers/integrations/github/latest/docs/resources/repository_environment_deployment_policy) | resource |
 | [github_repository_environment_deployment_policy.opex_prod_cd_tag](https://registry.terraform.io/providers/integrations/github/latest/docs/resources/repository_environment_deployment_policy) | resource |
-| [azurerm_key_vault.runner](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/data-sources/key_vault) | data source |
 | [github_organization_teams.all](https://registry.terraform.io/providers/integrations/github/latest/docs/data-sources/organization_teams) | data source |
 
 ## Inputs
@@ -208,7 +206,7 @@ resource "github_repository_environment_deployment_policy" "release_branch" {
 | <a name="input_apim_id"></a> [apim\_id](#input\_apim\_id) | (Optional) ID of the APIM instance | `string` | `null` | no |
 | <a name="input_entraid_groups"></a> [entraid\_groups](#input\_entraid\_groups) | Azure Entra Id groups to give role to | <pre>object({<br/>    admins_object_id    = string<br/>    devs_object_id      = string<br/>    externals_object_id = optional(string, null)<br/>  })</pre> | n/a | yes |
 | <a name="input_environment"></a> [environment](#input\_environment) | Values which are used to generate resource names and location short names. They are all mandatory except for domain, which should not be used only in the case of a resource used by multiple domains. | <pre>object({<br/>    prefix          = string<br/>    env_short       = string<br/>    location        = string<br/>    domain          = string<br/>    instance_number = string<br/>  })</pre> | n/a | yes |
-| <a name="input_github_private_runner"></a> [github\_private\_runner](#input\_github\_private\_runner) | n/a | <pre>object({<br/>    container_app_environment_id       = string<br/>    container_app_environment_location = string<br/>    polling_interval_in_seconds        = optional(number, 30)<br/>    min_instances                      = optional(number, 0)<br/>    max_instances                      = optional(number, 30)<br/>    labels                             = optional(list(string), [])<br/>    key_vault = object({<br/>      name                = string<br/>      resource_group_name = string<br/>      secret_name         = optional(string, "github-runner-pat")<br/>    })<br/>    cpu    = optional(number, 0.5)<br/>    memory = optional(string, "1Gi")<br/>  })</pre> | n/a | yes |
+| <a name="input_github_private_runner"></a> [github\_private\_runner](#input\_github\_private\_runner) | n/a | <pre>object({<br/>    container_app_environment_id       = string<br/>    container_app_environment_location = string<br/>    replica_timeout_in_seconds         = optional(number, 1800)<br/>    polling_interval_in_seconds        = optional(number, 30)<br/>    min_instances                      = optional(number, 0)<br/>    max_instances                      = optional(number, 30)<br/>    labels                             = optional(list(string), [])<br/>    key_vault = object({<br/>      name                = string<br/>      resource_group_name = string<br/>      secret_name         = optional(string, "github-runner-pat")<br/>      use_rbac            = optional(bool, false)<br/>    })<br/>    cpu    = optional(number, 0.5)<br/>    memory = optional(string, "1Gi")<br/>  })</pre> | n/a | yes |
 | <a name="input_keyvault_common_ids"></a> [keyvault\_common\_ids](#input\_keyvault\_common\_ids) | Id of the KeyVault containing common secrets | `list(string)` | `[]` | no |
 | <a name="input_log_analytics_workspace_id"></a> [log\_analytics\_workspace\_id](#input\_log\_analytics\_workspace\_id) | (Optional) ID of the Log Analytics Workspace | `string` | `null` | no |
 | <a name="input_nat_gateway_resource_group_id"></a> [nat\_gateway\_resource\_group\_id](#input\_nat\_gateway\_resource\_group\_id) | (Optional) Id of the resource group hosting NAT Gateways | `string` | `null` | no |

--- a/infra/modules/azure_github_environment_bootstrap/container_app_job_runner.tf
+++ b/infra/modules/azure_github_environment_bootstrap/container_app_job_runner.tf
@@ -1,93 +1,41 @@
+module "github_runner" {
+  source  = "pagopa-dx/github-selfhosted-runner-on-container-app-jobs/azurerm"
+  version = "~> 1.0"
 
-resource "azurerm_container_app_job" "github_runner" {
-  container_app_environment_id = var.github_private_runner.container_app_environment_id
-  name                         = local.container_apps.job_name
-  location                     = var.github_private_runner.container_app_environment_location
-  resource_group_name          = azurerm_resource_group.main.name
-
-  identity {
-    type = "SystemAssigned"
+  environment = {
+    prefix          = var.environment.prefix
+    env_short       = var.environment.env_short
+    location        = var.environment.location
+    domain          = var.environment.domain
+    instance_number = var.environment.instance_number
   }
 
-  replica_timeout_in_seconds = 1800
-  replica_retry_limit        = 1
+  resource_group_name = azurerm_resource_group.main.name
 
-  event_trigger_config {
-    parallelism              = 1
-    replica_completion_count = 1
-
-    scale {
-      max_executions              = var.github_private_runner.max_instances
-      min_executions              = var.github_private_runner.min_instances
-      polling_interval_in_seconds = var.github_private_runner.polling_interval_in_seconds
-
-      rules {
-        name             = "github-runner-rule"
-        custom_rule_type = "github-runner"
-        metadata = merge({
-          owner                     = var.repository.owner
-          runnerScope               = "repo"
-          repos                     = var.repository.name
-          targetWorkflowQueueLength = "1"
-          github-runner             = "https://api.github.com"
-        }, length(var.github_private_runner.labels) > 0 ? { labels = join(",", var.github_private_runner.labels) } : {})
-
-        authentication {
-          secret_name       = local.container_apps.secret_name
-          trigger_parameter = "personalAccessToken"
-        }
-      }
-    }
+  repository = {
+    owner = var.repository.owner
+    name  = var.repository.name
   }
 
-  secret {
-    key_vault_secret_id = "${data.azurerm_key_vault.runner.vault_uri}secrets/${var.github_private_runner.key_vault.secret_name}" # no versioning
-
-    identity = "System"
-    name     = local.container_apps.secret_name
+  container_app_environment = {
+    id                          = var.github_private_runner.container_app_environment_id
+    location                    = var.github_private_runner.container_app_environment_location
+    replica_timeout_in_seconds  = var.github_private_runner.replica_timeout_in_seconds
+    polling_interval_in_seconds = var.github_private_runner.polling_interval_in_seconds
+    min_instances               = var.github_private_runner.min_instances
+    max_instances               = var.github_private_runner.max_instances
+    use_labels                  = length(var.github_private_runner.labels) > 0
+    override_labels             = var.github_private_runner.labels
+    cpu                         = var.github_private_runner.cpu
+    memory                      = var.github_private_runner.memory
   }
 
-  template {
-    container {
-      cpu    = var.github_private_runner.cpu
-      image  = "ghcr.io/pagopa/github-self-hosted-runner-azure:latest"
-      memory = var.github_private_runner.memory
-      name   = "github-runner"
-
-      dynamic "env" {
-        for_each = var.github_private_runner.labels
-        content {
-          name  = "LABELS"
-          value = join(",", var.github_private_runner.labels)
-        }
-      }
-
-      env {
-        name  = "REPO_URL"
-        value = "https://github.com/${var.repository.owner}/${var.repository.name}"
-      }
-
-      env {
-        name  = "REGISTRATION_TOKEN_API_URL"
-        value = "https://api.github.com/repos/${var.repository.owner}/${var.repository.name}/actions/runners/registration-token"
-      }
-
-      env {
-        name        = "GITHUB_PAT"
-        secret_name = local.container_apps.secret_name
-      }
-    }
+  key_vault = {
+    name                = var.github_private_runner.key_vault.name
+    resource_group_name = var.github_private_runner.key_vault.resource_group_name
+    secret_name         = var.github_private_runner.key_vault.secret_name
+    use_rbac            = var.github_private_runner.key_vault.use_rbac
   }
 
   tags = var.tags
-}
-
-resource "azurerm_key_vault_access_policy" "keyvault_containerapp" {
-  key_vault_id = data.azurerm_key_vault.runner.id
-  tenant_id    = azurerm_container_app_job.github_runner.identity[0].tenant_id
-  object_id    = azurerm_container_app_job.github_runner.identity[0].principal_id
-
-  secret_permissions = [
-    "Get",
-  ]
 }

--- a/infra/modules/azure_github_environment_bootstrap/data.tf
+++ b/infra/modules/azure_github_environment_bootstrap/data.tf
@@ -2,8 +2,3 @@ data "github_organization_teams" "all" {
   root_teams_only = true
   summary_only    = true
 }
-
-data "azurerm_key_vault" "runner" {
-  name                = var.github_private_runner.key_vault.name
-  resource_group_name = var.github_private_runner.key_vault.resource_group_name
-}

--- a/infra/modules/azure_github_environment_bootstrap/locals.tf
+++ b/infra/modules/azure_github_environment_bootstrap/locals.tf
@@ -13,11 +13,6 @@ locals {
     }
   )
 
-  container_apps = {
-    job_name    = "${module.naming_convention.prefix}-caj-${module.naming_convention.suffix}"
-    secret_name = "personal-access-token"
-  }
-
   has_apim                    = var.apim_id != null ? 1 : 0
   has_log_analytics_workspace = var.log_analytics_workspace_id != null ? 1 : 0
 

--- a/infra/modules/azure_github_environment_bootstrap/outputs.tf
+++ b/infra/modules/azure_github_environment_bootstrap/outputs.tf
@@ -15,9 +15,9 @@ output "repository" {
 
 output "github_private_runner" {
   value = {
-    id                  = azurerm_container_app_job.github_runner.id
-    name                = azurerm_container_app_job.github_runner.name
-    resource_group_name = azurerm_container_app_job.github_runner.resource_group_name
+    id                  = module.github_runner.container_app_job.id
+    name                = module.github_runner.container_app_job.name
+    resource_group_name = module.github_runner.container_app_job.resource_group_name
   }
 }
 

--- a/infra/modules/azure_github_environment_bootstrap/variables.tf
+++ b/infra/modules/azure_github_environment_bootstrap/variables.tf
@@ -107,6 +107,7 @@ variable "github_private_runner" {
   type = object({
     container_app_environment_id       = string
     container_app_environment_location = string
+    replica_timeout_in_seconds         = optional(number, 1800)
     polling_interval_in_seconds        = optional(number, 30)
     min_instances                      = optional(number, 0)
     max_instances                      = optional(number, 30)
@@ -115,6 +116,7 @@ variable "github_private_runner" {
       name                = string
       resource_group_name = string
       secret_name         = optional(string, "github-runner-pat")
+      use_rbac            = optional(bool, false)
     })
     cpu    = optional(number, 0.5)
     memory = optional(string, "1Gi")


### PR DESCRIPTION
Reuse `github_selfhosted_runner_on_container_app_jobs` module in `azure_github_environment_bootstrap`.

This also involves:
- the addition of a variables to control the job timeout
- the possibility to use KeyVaults with RBAC as access model

Closes CES-864