### PR TITLE
Update Azure tracing article

### DIFF
--- a/.changeset/lovely-falcons-remember.md
+++ b/.changeset/lovely-falcons-remember.md
@@ -1,0 +1,5 @@
+---
+"docs": patch
+---
+
+Add instructions and examples to instrument Next.js app on Azure App Service

--- a/apps/website/docs/articles/azure-tracing.md
+++ b/apps/website/docs/articles/azure-tracing.md
@@ -70,8 +70,8 @@ the Azure Portal), end-to-end correlation does not function as expected.
 
 [Instrumentation of ESM modules is still experimental](https://github.com/open-telemetry/opentelemetry-js/tree/main/experimental/packages/opentelemetry-instrumentation#instrumentation-for-ecmascript-modules-esm-in-nodejs-experimental)
 and may not be as seamless as transpiling TypeScript to CommonJS modules.  
-[Inspired by a GitHub issue addressing a similar problem](https://github.com/open-telemetry/opentelemetry-js/issues/4845#issuecomment-2253556217),
-there is an alternative method to instrument the `@azure/monitor-opentelemetry`
+[Inspired by a GitHub issue addressing a similar problem](https://github.com/open-telemetry/opentelemetry-js/issues/4845#issuecomment-2253556217), there
+is an alternative method to instrument the `@azure/monitor-opentelemetry`
 package.
 
 ### Steps to Instrument an ESM Application

--- a/apps/website/docs/articles/azure-tracing.md
+++ b/apps/website/docs/articles/azure-tracing.md
@@ -355,6 +355,33 @@ before anything else:
 
 https://nextjs.org/docs/app/building-your-application/optimizing/open-telemetry#manual-opentelemetry-configuration
 
+It is possible to use the `@azure/monitor-opentelemetry` package to instrument a
+Next.js application. However, in order to track the HTTP calls made by the
+application, you need to use the `undici` instrumentation. This instrumentation
+is not included in the `@azure/monitor-opentelemetry` package, so you need to
+add it manually.  
+Here is a snippet to enable tracing in a Next.js application that uses the App
+router:
+
+```javascript
+// apps/instrumentation.ts
+
+import { useAzureMonitor } from "@azure/monitor-opentelemetry";
+import { metrics, trace } from "@opentelemetry/api";
+import { registerInstrumentations } from "@opentelemetry/instrumentation";
+import { UndiciInstrumentation } from "@opentelemetry/instrumentation-undici";
+
+export async function register() {
+  useAzureMonitor();
+
+  registerInstrumentations({
+    instrumentations: [new UndiciInstrumentation()],
+    meterProvider: metrics.getMeterProvider(),
+    tracerProvider: trace.getTracerProvider(),
+  });
+}
+```
+
 ## Integration with Azure Functions
 
 **Azure Functions** are a bit more complex to integrate with **OpenTelemetry**


### PR DESCRIPTION
Gives some instruction to instrument a Next.js application deployed on an Azure App Service

Closes CES-880