### PR TITLE
Remove `naming_convention` inside Storage Account module in favor of `pagopa-dx/azure` provider function

### DIFF
--- a/.changeset/gorgeous-keys-visit.md
+++ b/.changeset/gorgeous-keys-visit.md
@@ -1,0 +1,5 @@
+---
+"azure_storage_account": patch
+---
+
+Used provider resoruce type function instead of naming convention module

--- a/infra/modules/azure_storage_account/README.md
+++ b/infra/modules/azure_storage_account/README.md
@@ -6,12 +6,11 @@
 | Name | Version |
 |------|---------|
 | <a name="requirement_azurerm"></a> [azurerm](#requirement\_azurerm) | >= 3.110, < 5.0 |
+| <a name="requirement_dx"></a> [dx](#requirement\_dx) | >= 0.0.3 |
 
 ## Modules
 
-| Name | Source | Version |
-|------|--------|---------|
-| <a name="module_naming_convention"></a> [naming\_convention](#module\_naming\_convention) | pagopa-dx/azure-naming-convention/azurerm | ~> 0.0 |
+No modules.
 
 ## Resources
 

--- a/infra/modules/azure_storage_account/cmk.tf
+++ b/infra/modules/azure_storage_account/cmk.tf
@@ -2,7 +2,7 @@
 # tfsec:ignore:azure-keyvault-ensure-key-expiry
 resource "azurerm_key_vault_key" "key" {
   for_each     = (local.cmk_flags.kv && var.customer_managed_key.key_name == null ? toset(["kv"]) : toset([]))
-  name         = "${replace("${module.naming_convention.prefix}-st", "-", "")}-cmk-${module.naming_convention.suffix}"
+  name         = provider::dx::resource_name(merge(local.naming_config, { resource_type = "customer_key_storage_account" }))
   key_vault_id = var.customer_managed_key.key_vault_id
   key_type     = "RSA"
   key_size     = 4096

--- a/infra/modules/azure_storage_account/examples/complete/README.md
+++ b/infra/modules/azure_storage_account/examples/complete/README.md
@@ -5,7 +5,7 @@
 
 | Name | Version |
 |------|---------|
-| <a name="requirement_azurerm"></a> [azurerm](#requirement\_azurerm) | >= 3.110, < 5.0 |
+| <a name="requirement_azurerm"></a> [azurerm](#requirement\_azurerm) | ~>4 |
 
 ## Modules
 

--- a/infra/modules/azure_storage_account/examples/complete/main.tf
+++ b/infra/modules/azure_storage_account/examples/complete/main.tf
@@ -41,7 +41,7 @@ module "azure_storage_account" {
   resource_group_name = azurerm_resource_group.example.name
 
   subnet_pep_id                        = data.azurerm_subnet.pep.id
-  private_dns_zone_resource_group_name = "${local.environment.prefix}-${local.environment.env_short}-rg-common"
+  private_dns_zone_resource_group_name = "${local.project}-network-rg-01"
 
   customer_managed_key = {
     enabled      = true

--- a/infra/modules/azure_storage_account/examples/complete/versions.tf
+++ b/infra/modules/azure_storage_account/examples/complete/versions.tf
@@ -1,7 +1,7 @@
 terraform {
 
   backend "azurerm" {
-    resource_group_name  = "dx-d-itn-network-rg-01"
+    resource_group_name  = "dx-d-itn-common-rg-01"
     storage_account_name = "dxditntfexamplesst01"
     container_name       = "terraform-state"
     key                  = "dx.storage_account.example.complete.tfstate"
@@ -10,7 +10,7 @@ terraform {
   required_providers {
     azurerm = {
       source  = "hashicorp/azurerm"
-      version = ">= 3.110, < 5.0"
+      version = "~>4"
     }
   }
 }

--- a/infra/modules/azure_storage_account/locals.tf
+++ b/infra/modules/azure_storage_account/locals.tf
@@ -1,4 +1,17 @@
 locals {
+
+  naming_config = {
+    prefix          = var.environment.prefix,
+    environment     = var.environment.env_short,
+    location = tomap({
+      "italynorth" = "itn",
+      "westeurope" = "weu"
+    })[var.environment.location]
+    domain          = var.environment.domain,
+    name        = var.environment.app_name,
+    instance_number = tonumber(var.environment.instance_number),
+  }
+
   tiers = {
     s = {
       alerts                     = false
@@ -19,22 +32,22 @@ locals {
 
   peps = {
     blob = {
-      name     = "${module.naming_convention.prefix}-blob-pep-${module.naming_convention.suffix}"
+      name = provider::dx::resource_name(merge(local.naming_config, { resource_type = "blob_private_endpoint" }))
       dns_zone = "privatelink.blob.core.windows.net"
     }
 
     file = {
-      name     = "${module.naming_convention.prefix}-file-pep-${module.naming_convention.suffix}"
+      name = provider::dx::resource_name(merge(local.naming_config, { resource_type = "file_private_endpoint" }))
       dns_zone = "privatelink.file.core.windows.net"
     }
 
     queue = {
-      name     = "${module.naming_convention.prefix}-queue-pep-${module.naming_convention.suffix}"
+      name = provider::dx::resource_name(merge(local.naming_config, { resource_type = "queue_private_endpoint" }))
       dns_zone = "privatelink.queue.core.windows.net"
     }
 
     table = {
-      name     = "${module.naming_convention.prefix}-table-pep-${module.naming_convention.suffix}"
+      name = provider::dx::resource_name(merge(local.naming_config, { resource_type = "table_private_endpoint" }))
       dns_zone = "privatelink.table.core.windows.net"
     }
   }

--- a/infra/modules/azure_storage_account/locals.tf
+++ b/infra/modules/azure_storage_account/locals.tf
@@ -1,14 +1,14 @@
 locals {
 
   naming_config = {
-    prefix          = var.environment.prefix,
-    environment     = var.environment.env_short,
+    prefix      = var.environment.prefix,
+    environment = var.environment.env_short,
     location = tomap({
       "italynorth" = "itn",
       "westeurope" = "weu"
     })[var.environment.location]
     domain          = var.environment.domain,
-    name        = var.environment.app_name,
+    name            = var.environment.app_name,
     instance_number = tonumber(var.environment.instance_number),
   }
 
@@ -32,22 +32,22 @@ locals {
 
   peps = {
     blob = {
-      name = provider::dx::resource_name(merge(local.naming_config, { resource_type = "blob_private_endpoint" }))
+      name     = provider::dx::resource_name(merge(local.naming_config, { resource_type = "blob_private_endpoint" }))
       dns_zone = "privatelink.blob.core.windows.net"
     }
 
     file = {
-      name = provider::dx::resource_name(merge(local.naming_config, { resource_type = "file_private_endpoint" }))
+      name     = provider::dx::resource_name(merge(local.naming_config, { resource_type = "file_private_endpoint" }))
       dns_zone = "privatelink.file.core.windows.net"
     }
 
     queue = {
-      name = provider::dx::resource_name(merge(local.naming_config, { resource_type = "queue_private_endpoint" }))
+      name     = provider::dx::resource_name(merge(local.naming_config, { resource_type = "queue_private_endpoint" }))
       dns_zone = "privatelink.queue.core.windows.net"
     }
 
     table = {
-      name = provider::dx::resource_name(merge(local.naming_config, { resource_type = "table_private_endpoint" }))
+      name     = provider::dx::resource_name(merge(local.naming_config, { resource_type = "table_private_endpoint" }))
       dns_zone = "privatelink.table.core.windows.net"
     }
   }

--- a/infra/modules/azure_storage_account/main.tf
+++ b/infra/modules/azure_storage_account/main.tf
@@ -5,21 +5,8 @@ terraform {
       version = ">= 3.110, < 5.0"
     }
     dx = {
-      source = "pagopa-dx/azure"
+      source  = "pagopa-dx/azure"
+      version = ">= 0.0.3"
     }
   }
 }
-
-# module "naming_convention" {
-#   source  = "pagopa-dx/azure-naming-convention/azurerm"
-#   version = "~> 0.0"
-
-#   environment = {
-#     prefix          = var.environment.prefix
-#     env_short       = var.environment.env_short
-#     location        = var.environment.location
-#     domain          = var.environment.domain
-#     app_name        = var.environment.app_name
-#     instance_number = var.environment.instance_number
-#   }
-# }

--- a/infra/modules/azure_storage_account/main.tf
+++ b/infra/modules/azure_storage_account/main.tf
@@ -4,19 +4,22 @@ terraform {
       source  = "hashicorp/azurerm"
       version = ">= 3.110, < 5.0"
     }
+    dx = {
+      source = "pagopa-dx/azure"
+    }
   }
 }
 
-module "naming_convention" {
-  source  = "pagopa-dx/azure-naming-convention/azurerm"
-  version = "~> 0.0"
+# module "naming_convention" {
+#   source  = "pagopa-dx/azure-naming-convention/azurerm"
+#   version = "~> 0.0"
 
-  environment = {
-    prefix          = var.environment.prefix
-    env_short       = var.environment.env_short
-    location        = var.environment.location
-    domain          = var.environment.domain
-    app_name        = var.environment.app_name
-    instance_number = var.environment.instance_number
-  }
-}
+#   environment = {
+#     prefix          = var.environment.prefix
+#     env_short       = var.environment.env_short
+#     location        = var.environment.location
+#     domain          = var.environment.domain
+#     app_name        = var.environment.app_name
+#     instance_number = var.environment.instance_number
+#   }
+# }

--- a/infra/modules/azure_storage_account/storage_account.tf
+++ b/infra/modules/azure_storage_account/storage_account.tf
@@ -1,6 +1,6 @@
 #tfsec:ignore:azure-storage-queue-services-logging-enabled
 resource "azurerm_storage_account" "this" {
-  name                          = replace("${module.naming_convention.prefix}-st-${module.naming_convention.suffix}", "-", "")
+  name = provider::dx::resource_name(merge(local.naming_config, { resource_type = "storage_account" }))
   resource_group_name           = var.resource_group_name
   location                      = var.environment.location
   account_kind                  = "StorageV2"

--- a/infra/modules/azure_storage_account/storage_account.tf
+++ b/infra/modules/azure_storage_account/storage_account.tf
@@ -1,6 +1,6 @@
 #tfsec:ignore:azure-storage-queue-services-logging-enabled
 resource "azurerm_storage_account" "this" {
-  name = provider::dx::resource_name(merge(local.naming_config, { resource_type = "storage_account" }))
+  name                          = provider::dx::resource_name(merge(local.naming_config, { resource_type = "storage_account" }))
   resource_group_name           = var.resource_group_name
   location                      = var.environment.location
   account_kind                  = "StorageV2"


### PR DESCRIPTION
This PR removes all instances of the naming_convention module from the Storage Account module. The functionality has been replaced with the new naming convention function provided by the pagopa-dx/azure provider.

Resolves: CES-913