### PR TITLE
Remove `naming_convention` inside App Service modules in favor of `pagopa-dx/azure` provider function

### DIFF
--- a/.changeset/sixty-foxes-fetch.md
+++ b/.changeset/sixty-foxes-fetch.md
@@ -1,0 +1,6 @@
+---
+"azure_app_service_exposed": patch
+"azure_app_service": patch
+---
+
+Replace naming convention module with DX provider functions

--- a/infra/modules/azure_app_service/README.md
+++ b/infra/modules/azure_app_service/README.md
@@ -7,7 +7,7 @@
 | Name | Version |
 |------|---------|
 | <a name="requirement_azurerm"></a> [azurerm](#requirement\_azurerm) | >= 3.100.0, < 5.0 |
-| <a name="requirement_dx"></a> [dx](#requirement\_dx) | ~>0 |
+| <a name="requirement_dx"></a> [dx](#requirement\_dx) | ~>0.0 |
 
 ## Modules
 

--- a/infra/modules/azure_app_service/README.md
+++ b/infra/modules/azure_app_service/README.md
@@ -7,12 +7,11 @@
 | Name | Version |
 |------|---------|
 | <a name="requirement_azurerm"></a> [azurerm](#requirement\_azurerm) | >= 3.100.0, < 5.0 |
+| <a name="requirement_dx"></a> [dx](#requirement\_dx) | ~>0 |
 
 ## Modules
 
-| Name | Source | Version |
-|------|--------|---------|
-| <a name="module_naming_convention"></a> [naming\_convention](#module\_naming\_convention) | pagopa-dx/azure-naming-convention/azurerm | ~> 0.0 |
+No modules.
 
 ## Resources
 

--- a/infra/modules/azure_app_service/README.md
+++ b/infra/modules/azure_app_service/README.md
@@ -7,7 +7,7 @@
 | Name | Version |
 |------|---------|
 | <a name="requirement_azurerm"></a> [azurerm](#requirement\_azurerm) | >= 3.100.0, < 5.0 |
-| <a name="requirement_dx"></a> [dx](#requirement\_dx) | ~>0.0 |
+| <a name="requirement_dx"></a> [dx](#requirement\_dx) | >= 0.0.5, < 1.0.0 |
 
 ## Modules
 

--- a/infra/modules/azure_app_service/README.md
+++ b/infra/modules/azure_app_service/README.md
@@ -7,7 +7,7 @@
 | Name | Version |
 |------|---------|
 | <a name="requirement_azurerm"></a> [azurerm](#requirement\_azurerm) | >= 3.100.0, < 5.0 |
-| <a name="requirement_dx"></a> [dx](#requirement\_dx) | >= 0.0.5, < 1.0.0 |
+| <a name="requirement_dx"></a> [dx](#requirement\_dx) | >= 0.0.6, < 1.0.0 |
 
 ## Modules
 

--- a/infra/modules/azure_app_service/app_service_plan.tf
+++ b/infra/modules/azure_app_service/app_service_plan.tf
@@ -1,7 +1,7 @@
 resource "azurerm_service_plan" "this" {
   count = local.app_service_plan.enable ? 1 : 0
 
-  name                   = "${module.naming_convention.prefix}-asp-${module.naming_convention.suffix}"
+  name                   = provider::dx::resource_name(merge(local.naming_config, { resource_type = "app_service_plan" }))
   location               = var.environment.location
   resource_group_name    = var.resource_group_name
   os_type                = "Linux"

--- a/infra/modules/azure_app_service/examples/complete/README.md
+++ b/infra/modules/azure_app_service/examples/complete/README.md
@@ -6,7 +6,7 @@
 | Name | Version |
 |------|---------|
 | <a name="requirement_azurerm"></a> [azurerm](#requirement\_azurerm) | >= 3.100.0, < 5.0 |
-| <a name="requirement_dx"></a> [dx](#requirement\_dx) | ~>0 |
+| <a name="requirement_dx"></a> [dx](#requirement\_dx) | ~>0.0 |
 
 ## Modules
 

--- a/infra/modules/azure_app_service/examples/complete/README.md
+++ b/infra/modules/azure_app_service/examples/complete/README.md
@@ -6,13 +6,13 @@
 | Name | Version |
 |------|---------|
 | <a name="requirement_azurerm"></a> [azurerm](#requirement\_azurerm) | >= 3.100.0, < 5.0 |
+| <a name="requirement_dx"></a> [dx](#requirement\_dx) | ~>0 |
 
 ## Modules
 
 | Name | Source | Version |
 |------|--------|---------|
 | <a name="module_azure_app_service"></a> [azure\_app\_service](#module\_azure\_app\_service) | ../../ | n/a |
-| <a name="module_naming_convention"></a> [naming\_convention](#module\_naming\_convention) | ../../../azure_naming_convention | n/a |
 
 ## Resources
 

--- a/infra/modules/azure_app_service/examples/complete/README.md
+++ b/infra/modules/azure_app_service/examples/complete/README.md
@@ -6,7 +6,7 @@
 | Name | Version |
 |------|---------|
 | <a name="requirement_azurerm"></a> [azurerm](#requirement\_azurerm) | >= 3.100.0, < 5.0 |
-| <a name="requirement_dx"></a> [dx](#requirement\_dx) | ~>0.0 |
+| <a name="requirement_dx"></a> [dx](#requirement\_dx) | >= 0.0.5, < 1.0.0 |
 
 ## Modules
 

--- a/infra/modules/azure_app_service/examples/complete/README.md
+++ b/infra/modules/azure_app_service/examples/complete/README.md
@@ -6,7 +6,7 @@
 | Name | Version |
 |------|---------|
 | <a name="requirement_azurerm"></a> [azurerm](#requirement\_azurerm) | >= 3.100.0, < 5.0 |
-| <a name="requirement_dx"></a> [dx](#requirement\_dx) | >= 0.0.5, < 1.0.0 |
+| <a name="requirement_dx"></a> [dx](#requirement\_dx) | >= 0.0.6, < 1.0.0 |
 
 ## Modules
 

--- a/infra/modules/azure_app_service/examples/complete/locals.tf
+++ b/infra/modules/azure_app_service/examples/complete/locals.tf
@@ -8,7 +8,23 @@ locals {
     instance_number = "01"
   }
 
-  project = module.naming_convention.project
+  location_short = "itn"
+
+  naming_config = {
+    prefix          = local.environment.prefix,
+    environment     = local.environment.env_short,
+    location        = local.location_short,
+    instance_number = tonumber(local.environment.instance_number),
+  }
+
+  virtual_network_name = provider::dx::resource_name(merge(local.naming_config, {
+    name          = "common",
+    resource_type = "virtual_network"
+  }))
+  network_rg_name = provider::dx::resource_name(merge(local.naming_config, {
+    name          = "network",
+    resource_type = "resource_group"
+  }))
 
   tags = {
     CreatedBy   = "Terraform"

--- a/infra/modules/azure_app_service/examples/complete/main.tf
+++ b/infra/modules/azure_app_service/examples/complete/main.tf
@@ -1,17 +1,17 @@
-module "naming_convention" {
-  source = "../../../azure_naming_convention"
-
-  environment = local.environment
-}
-
 data "azurerm_subnet" "pep" {
-  name                 = "${local.project}-pep-snet-01"
-  virtual_network_name = "${local.project}-common-vnet-01"
-  resource_group_name  = "${local.project}-network-rg-01"
+  name = provider::dx::resource_name(merge(local.naming_config, {
+    name          = "pep",
+    resource_type = "subnet"
+  }))
+  virtual_network_name = local.virtual_network_name
+  resource_group_name  = local.network_rg_name
 }
 
 resource "azurerm_resource_group" "example" {
-  name     = "${local.project}-${local.environment.domain}-rg-${local.environment.instance_number}"
+  name = provider::dx::resource_name(merge(local.naming_config, {
+    name          = "modules",
+    resource_type = "resource_group"
+  }))
   location = local.environment.location
 }
 
@@ -22,15 +22,14 @@ resource "azurerm_user_assigned_identity" "example" {
 }
 
 module "azure_app_service" {
-  source = "../../"
-
+  source              = "../../"
   environment         = local.environment
   tier                = "l"
   resource_group_name = azurerm_resource_group.example.name
 
   virtual_network = {
-    name                = "${local.project}-common-vnet-01"
-    resource_group_name = "${local.project}-network-rg-01"
+    name                = local.virtual_network_name
+    resource_group_name = local.network_rg_name
   }
   subnet_pep_id = data.azurerm_subnet.pep.id
   subnet_cidr   = "10.50.250.0/24"
@@ -39,6 +38,5 @@ module "azure_app_service" {
   slot_app_settings = {}
 
   health_check_path = "/health"
-
-  tags = local.tags
+  tags              = local.tags
 }

--- a/infra/modules/azure_app_service/examples/complete/versions.tf
+++ b/infra/modules/azure_app_service/examples/complete/versions.tf
@@ -14,7 +14,7 @@ terraform {
     }
     dx = {
       source  = "pagopa-dx/azure"
-      version = "~>0.0"
+      version = ">= 0.0.5, < 1.0.0"
     }
   }
 }

--- a/infra/modules/azure_app_service/examples/complete/versions.tf
+++ b/infra/modules/azure_app_service/examples/complete/versions.tf
@@ -14,7 +14,7 @@ terraform {
     }
     dx = {
       source  = "pagopa-dx/azure"
-      version = ">= 0.0.5, < 1.0.0"
+      version = ">= 0.0.6, < 1.0.0"
     }
   }
 }

--- a/infra/modules/azure_app_service/examples/complete/versions.tf
+++ b/infra/modules/azure_app_service/examples/complete/versions.tf
@@ -14,7 +14,7 @@ terraform {
     }
     dx = {
       source  = "pagopa-dx/azure"
-      version = "~>0"
+      version = "~>0.0"
     }
   }
 }

--- a/infra/modules/azure_app_service/examples/complete/versions.tf
+++ b/infra/modules/azure_app_service/examples/complete/versions.tf
@@ -1,7 +1,7 @@
 terraform {
 
   backend "azurerm" {
-    resource_group_name  = "dx-d-itn-network-rg-01"
+    resource_group_name  = "dx-d-itn-common-rg-01"
     storage_account_name = "dxditntfexamplesst01"
     container_name       = "terraform-state"
     key                  = "dx.app_service.example.complete.tfstate"
@@ -11,6 +11,10 @@ terraform {
     azurerm = {
       source  = "hashicorp/azurerm"
       version = ">= 3.100.0, < 5.0"
+    }
+    dx = {
+      source  = "pagopa-dx/azure"
+      version = "~>0"
     }
   }
 }

--- a/infra/modules/azure_app_service/locals.tf
+++ b/infra/modules/azure_app_service/locals.tf
@@ -26,10 +26,12 @@ locals {
     has_existing_subnet    = var.subnet_id != null
     zone_balancing_enabled = local.tier != "s"
     is_slot_enabled        = local.tier == "s" ? 0 : 1
+    private_endpoint_name  = provider::dx::resource_name(merge(local.naming_config, { resource_type = "app_private_endpoint" }))
   }
 
   app_service_slot = {
-    name = "staging"
+    name                  = "staging"
+    private_endpoint_name = provider::dx::resource_name(merge(local.naming_config, { resource_type = "app_slot_private_endpoint" }))
   }
 
   application_insights = {

--- a/infra/modules/azure_app_service/locals.tf
+++ b/infra/modules/azure_app_service/locals.tf
@@ -1,4 +1,16 @@
 locals {
+  naming_config = {
+    prefix      = var.environment.prefix,
+    environment = var.environment.env_short,
+    location = tomap({
+      "italynorth" = "itn",
+      "westeurope" = "weu"
+    })[var.environment.location]
+    domain          = var.environment.domain,
+    name            = var.environment.app_name,
+    instance_number = tonumber(var.environment.instance_number),
+  }
+
   subnet = {
     enable_service_endpoints = var.subnet_service_endpoints != null ? concat(
       var.subnet_service_endpoints.cosmos ? ["Microsoft.CosmosDB"] : [],
@@ -12,7 +24,7 @@ locals {
   }
 
   app_service = {
-    name                   = "${module.naming_convention.prefix}-app-${module.naming_convention.suffix}"
+    name                   = provider::dx::resource_name(merge(local.naming_config, { resource_type = "app_service" }))
     sku_name               = local.sku_name_mapping[local.tier]
     has_existing_subnet    = var.subnet_id != null
     zone_balancing_enabled = local.tier != "s"

--- a/infra/modules/azure_app_service/locals.tf
+++ b/infra/modules/azure_app_service/locals.tf
@@ -1,11 +1,8 @@
 locals {
   naming_config = {
-    prefix      = var.environment.prefix,
-    environment = var.environment.env_short,
-    location = tomap({
-      "italynorth" = "itn",
-      "westeurope" = "weu"
-    })[var.environment.location]
+    prefix          = var.environment.prefix,
+    environment     = var.environment.env_short,
+    location        = var.environment.location
     domain          = var.environment.domain,
     name            = var.environment.app_name,
     instance_number = tonumber(var.environment.instance_number),

--- a/infra/modules/azure_app_service/main.tf
+++ b/infra/modules/azure_app_service/main.tf
@@ -4,19 +4,9 @@ terraform {
       source  = "hashicorp/azurerm"
       version = ">= 3.100.0, < 5.0"
     }
-  }
-}
-
-module "naming_convention" {
-  source  = "pagopa-dx/azure-naming-convention/azurerm"
-  version = "~> 0.0"
-
-  environment = {
-    prefix          = var.environment.prefix
-    env_short       = var.environment.env_short
-    location        = var.environment.location
-    domain          = var.environment.domain
-    app_name        = var.environment.app_name
-    instance_number = var.environment.instance_number
+    dx = {
+      source  = "pagopa-dx/azure"
+      version = "~>0"
+    }
   }
 }

--- a/infra/modules/azure_app_service/main.tf
+++ b/infra/modules/azure_app_service/main.tf
@@ -6,7 +6,7 @@ terraform {
     }
     dx = {
       source  = "pagopa-dx/azure"
-      version = ">= 0.0.5, < 1.0.0"
+      version = ">= 0.0.6, < 1.0.0"
     }
   }
 }

--- a/infra/modules/azure_app_service/main.tf
+++ b/infra/modules/azure_app_service/main.tf
@@ -6,7 +6,7 @@ terraform {
     }
     dx = {
       source  = "pagopa-dx/azure"
-      version = "~>0.0"
+      version = ">= 0.0.5, < 1.0.0"
     }
   }
 }

--- a/infra/modules/azure_app_service/main.tf
+++ b/infra/modules/azure_app_service/main.tf
@@ -6,7 +6,7 @@ terraform {
     }
     dx = {
       source  = "pagopa-dx/azure"
-      version = "~>0"
+      version = "~>0.0"
     }
   }
 }

--- a/infra/modules/azure_app_service/networking.tf
+++ b/infra/modules/azure_app_service/networking.tf
@@ -1,11 +1,11 @@
 resource "azurerm_private_endpoint" "app_service_sites" {
-  name                = "${module.naming_convention.prefix}-app-pep-${module.naming_convention.suffix}"
+  name                = provider::dx::resource_name(merge(local.naming_config, { resource_type = "app_private_endpoint" }))
   location            = var.environment.location
   resource_group_name = var.resource_group_name
   subnet_id           = var.subnet_pep_id
 
   private_service_connection {
-    name                           = "${module.naming_convention.prefix}-app-pep-${module.naming_convention.suffix}"
+    name                           = provider::dx::resource_name(merge(local.naming_config, { resource_type = "app_private_endpoint" }))
     private_connection_resource_id = azurerm_linux_web_app.this.id
     is_manual_connection           = false
     subresource_names              = ["sites"]
@@ -22,13 +22,13 @@ resource "azurerm_private_endpoint" "app_service_sites" {
 resource "azurerm_private_endpoint" "staging_app_service_sites" {
   count = local.app_service.is_slot_enabled
 
-  name                = "${module.naming_convention.prefix}-staging-app-pep-${module.naming_convention.suffix}"
+  name                = provider::dx::resource_name(merge(local.naming_config, { resource_type = "app_slot_private_endpoint" }))
   location            = var.environment.location
   resource_group_name = var.resource_group_name
   subnet_id           = var.subnet_pep_id
 
   private_service_connection {
-    name                           = "${module.naming_convention.prefix}-staging-app-pep-${module.naming_convention.suffix}"
+    name                           = provider::dx::resource_name(merge(local.naming_config, { resource_type = "app_slot_private_endpoint" }))
     private_connection_resource_id = azurerm_linux_web_app.this.id
     is_manual_connection           = false
     subresource_names              = ["sites-${azurerm_linux_web_app_slot.this[0].name}"]

--- a/infra/modules/azure_app_service/networking.tf
+++ b/infra/modules/azure_app_service/networking.tf
@@ -1,11 +1,11 @@
 resource "azurerm_private_endpoint" "app_service_sites" {
-  name                = provider::dx::resource_name(merge(local.naming_config, { resource_type = "app_private_endpoint" }))
+  name                = local.app_service.private_endpoint_name
   location            = var.environment.location
   resource_group_name = var.resource_group_name
   subnet_id           = var.subnet_pep_id
 
   private_service_connection {
-    name                           = provider::dx::resource_name(merge(local.naming_config, { resource_type = "app_private_endpoint" }))
+    name                           = local.app_service.private_endpoint_name
     private_connection_resource_id = azurerm_linux_web_app.this.id
     is_manual_connection           = false
     subresource_names              = ["sites"]
@@ -22,13 +22,13 @@ resource "azurerm_private_endpoint" "app_service_sites" {
 resource "azurerm_private_endpoint" "staging_app_service_sites" {
   count = local.app_service.is_slot_enabled
 
-  name                = provider::dx::resource_name(merge(local.naming_config, { resource_type = "app_slot_private_endpoint" }))
+  name                = local.app_service_slot.private_endpoint_name
   location            = var.environment.location
   resource_group_name = var.resource_group_name
   subnet_id           = var.subnet_pep_id
 
   private_service_connection {
-    name                           = provider::dx::resource_name(merge(local.naming_config, { resource_type = "app_slot_private_endpoint" }))
+    name                           = local.app_service_slot.private_endpoint_name
     private_connection_resource_id = azurerm_linux_web_app.this.id
     is_manual_connection           = false
     subresource_names              = ["sites-${azurerm_linux_web_app_slot.this[0].name}"]

--- a/infra/modules/azure_app_service/subnets.tf
+++ b/infra/modules/azure_app_service/subnets.tf
@@ -1,7 +1,7 @@
 resource "azurerm_subnet" "this" {
   count = local.app_service.has_existing_subnet ? 0 : 1
 
-  name                 = "${module.naming_convention.prefix}-app-snet-${module.naming_convention.suffix}"
+  name                 = provider::dx::resource_name(merge(local.naming_config, { resource_type = "app_subnet" }))
   virtual_network_name = data.azurerm_virtual_network.this.name
   resource_group_name  = data.azurerm_virtual_network.this.resource_group_name
   address_prefixes     = [var.subnet_cidr]

--- a/infra/modules/azure_app_service/tests/setup/README.md
+++ b/infra/modules/azure_app_service/tests/setup/README.md
@@ -6,12 +6,11 @@
 | Name | Version |
 |------|---------|
 | <a name="requirement_azurerm"></a> [azurerm](#requirement\_azurerm) | >= 3.100.0, < 5.0 |
+| <a name="requirement_dx"></a> [dx](#requirement\_dx) | ~>0.0 |
 
 ## Modules
 
-| Name | Source | Version |
-|------|--------|---------|
-| <a name="module_naming_convention"></a> [naming\_convention](#module\_naming\_convention) | ../../../azure_naming_convention | n/a |
+No modules.
 
 ## Resources
 

--- a/infra/modules/azure_app_service/tests/setup/README.md
+++ b/infra/modules/azure_app_service/tests/setup/README.md
@@ -6,7 +6,7 @@
 | Name | Version |
 |------|---------|
 | <a name="requirement_azurerm"></a> [azurerm](#requirement\_azurerm) | >= 3.100.0, < 5.0 |
-| <a name="requirement_dx"></a> [dx](#requirement\_dx) | ~>0.0 |
+| <a name="requirement_dx"></a> [dx](#requirement\_dx) | >= 0.0.5, < 1.0.0 |
 
 ## Modules
 

--- a/infra/modules/azure_app_service/tests/setup/README.md
+++ b/infra/modules/azure_app_service/tests/setup/README.md
@@ -6,7 +6,7 @@
 | Name | Version |
 |------|---------|
 | <a name="requirement_azurerm"></a> [azurerm](#requirement\_azurerm) | >= 3.100.0, < 5.0 |
-| <a name="requirement_dx"></a> [dx](#requirement\_dx) | >= 0.0.5, < 1.0.0 |
+| <a name="requirement_dx"></a> [dx](#requirement\_dx) | >= 0.0.6, < 1.0.0 |
 
 ## Modules
 

--- a/infra/modules/azure_app_service/tests/setup/main.tf
+++ b/infra/modules/azure_app_service/tests/setup/main.tf
@@ -6,19 +6,16 @@ terraform {
     }
     dx = {
       source  = "pagopa-dx/azure"
-      version = "~>0.0"
+      version = ">= 0.0.5, < 1.0.0"
     }
   }
 }
 
 locals {
   naming_config = {
-    prefix      = var.environment.prefix,
-    environment = var.environment.env_short,
-    location = tomap({
-      "italynorth" = "itn",
-      "westeurope" = "weu"
-    })[var.environment.location]
+    prefix          = var.environment.prefix,
+    environment     = var.environment.env_short,
+    location        = var.environment.location
     name            = var.environment.app_name,
     instance_number = tonumber(var.environment.instance_number),
   }

--- a/infra/modules/azure_app_service/tests/setup/main.tf
+++ b/infra/modules/azure_app_service/tests/setup/main.tf
@@ -6,7 +6,7 @@ terraform {
     }
     dx = {
       source  = "pagopa-dx/azure"
-      version = ">= 0.0.5, < 1.0.0"
+      version = ">= 0.0.6, < 1.0.0"
     }
   }
 }

--- a/infra/modules/azure_app_service_exposed/README.md
+++ b/infra/modules/azure_app_service_exposed/README.md
@@ -9,7 +9,7 @@ This module is used to create an Azure App Service, allowing it to be configured
 | Name | Version |
 |------|---------|
 | <a name="requirement_azurerm"></a> [azurerm](#requirement\_azurerm) | >= 3.111.0, < 5.0 |
-| <a name="requirement_dx"></a> [dx](#requirement\_dx) | ~>0.0 |
+| <a name="requirement_dx"></a> [dx](#requirement\_dx) | >= 0.0.5, < 1.0.0 |
 
 ## Modules
 

--- a/infra/modules/azure_app_service_exposed/README.md
+++ b/infra/modules/azure_app_service_exposed/README.md
@@ -9,12 +9,11 @@ This module is used to create an Azure App Service, allowing it to be configured
 | Name | Version |
 |------|---------|
 | <a name="requirement_azurerm"></a> [azurerm](#requirement\_azurerm) | >= 3.111.0, < 5.0 |
+| <a name="requirement_dx"></a> [dx](#requirement\_dx) | ~>0 |
 
 ## Modules
 
-| Name | Source | Version |
-|------|--------|---------|
-| <a name="module_naming_convention"></a> [naming\_convention](#module\_naming\_convention) | pagopa-dx/azure-naming-convention/azurerm | ~> 0.0 |
+No modules.
 
 ## Resources
 

--- a/infra/modules/azure_app_service_exposed/README.md
+++ b/infra/modules/azure_app_service_exposed/README.md
@@ -9,7 +9,7 @@ This module is used to create an Azure App Service, allowing it to be configured
 | Name | Version |
 |------|---------|
 | <a name="requirement_azurerm"></a> [azurerm](#requirement\_azurerm) | >= 3.111.0, < 5.0 |
-| <a name="requirement_dx"></a> [dx](#requirement\_dx) | >= 0.0.5, < 1.0.0 |
+| <a name="requirement_dx"></a> [dx](#requirement\_dx) | >= 0.0.6, < 1.0.0 |
 
 ## Modules
 

--- a/infra/modules/azure_app_service_exposed/README.md
+++ b/infra/modules/azure_app_service_exposed/README.md
@@ -9,7 +9,7 @@ This module is used to create an Azure App Service, allowing it to be configured
 | Name | Version |
 |------|---------|
 | <a name="requirement_azurerm"></a> [azurerm](#requirement\_azurerm) | >= 3.111.0, < 5.0 |
-| <a name="requirement_dx"></a> [dx](#requirement\_dx) | ~>0 |
+| <a name="requirement_dx"></a> [dx](#requirement\_dx) | ~>0.0 |
 
 ## Modules
 

--- a/infra/modules/azure_app_service_exposed/app_service_plan.tf
+++ b/infra/modules/azure_app_service_exposed/app_service_plan.tf
@@ -1,7 +1,7 @@
 resource "azurerm_service_plan" "this" {
   count = local.app_service_plan.enable ? 1 : 0
 
-  name                   = "${module.naming_convention.prefix}-asp-${module.naming_convention.suffix}"
+  name                   = provider::dx::resource_name(merge(local.naming_config, { resource_type = "app_service_plan" }))
   location               = var.environment.location
   resource_group_name    = var.resource_group_name
   os_type                = "Linux"

--- a/infra/modules/azure_app_service_exposed/app_service_slot.tf
+++ b/infra/modules/azure_app_service_exposed/app_service_slot.tf
@@ -1,7 +1,7 @@
 resource "azurerm_linux_web_app_slot" "this" {
   count = local.app_service.is_slot_enabled
 
-  name = "${module.naming_convention.prefix}-staging-app-${module.naming_convention.suffix}"
+  name = local.app_service_slot.name
 
   app_service_id = azurerm_linux_web_app.this.id
 

--- a/infra/modules/azure_app_service_exposed/examples/complete/README.md
+++ b/infra/modules/azure_app_service_exposed/examples/complete/README.md
@@ -6,7 +6,7 @@
 | Name | Version |
 |------|---------|
 | <a name="requirement_azurerm"></a> [azurerm](#requirement\_azurerm) | >= 3.111.0, < 5.0 |
-| <a name="requirement_dx"></a> [dx](#requirement\_dx) | >= 0.0.5, < 1.0.0 |
+| <a name="requirement_dx"></a> [dx](#requirement\_dx) | >= 0.0.6, < 1.0.0 |
 
 ## Modules
 

--- a/infra/modules/azure_app_service_exposed/examples/complete/README.md
+++ b/infra/modules/azure_app_service_exposed/examples/complete/README.md
@@ -6,13 +6,13 @@
 | Name | Version |
 |------|---------|
 | <a name="requirement_azurerm"></a> [azurerm](#requirement\_azurerm) | >= 3.111.0, < 5.0 |
+| <a name="requirement_dx"></a> [dx](#requirement\_dx) | ~>0 |
 
 ## Modules
 
 | Name | Source | Version |
 |------|--------|---------|
 | <a name="module_azure_app_service_exposed"></a> [azure\_app\_service\_exposed](#module\_azure\_app\_service\_exposed) | ../../ | n/a |
-| <a name="module_naming_convention"></a> [naming\_convention](#module\_naming\_convention) | ../../../azure_naming_convention | n/a |
 
 ## Resources
 

--- a/infra/modules/azure_app_service_exposed/examples/complete/README.md
+++ b/infra/modules/azure_app_service_exposed/examples/complete/README.md
@@ -6,7 +6,7 @@
 | Name | Version |
 |------|---------|
 | <a name="requirement_azurerm"></a> [azurerm](#requirement\_azurerm) | >= 3.111.0, < 5.0 |
-| <a name="requirement_dx"></a> [dx](#requirement\_dx) | ~>0.0 |
+| <a name="requirement_dx"></a> [dx](#requirement\_dx) | >= 0.0.5, < 1.0.0 |
 
 ## Modules
 

--- a/infra/modules/azure_app_service_exposed/examples/complete/README.md
+++ b/infra/modules/azure_app_service_exposed/examples/complete/README.md
@@ -6,7 +6,7 @@
 | Name | Version |
 |------|---------|
 | <a name="requirement_azurerm"></a> [azurerm](#requirement\_azurerm) | >= 3.111.0, < 5.0 |
-| <a name="requirement_dx"></a> [dx](#requirement\_dx) | ~>0 |
+| <a name="requirement_dx"></a> [dx](#requirement\_dx) | ~>0.0 |
 
 ## Modules
 

--- a/infra/modules/azure_app_service_exposed/examples/complete/locals.tf
+++ b/infra/modules/azure_app_service_exposed/examples/complete/locals.tf
@@ -8,12 +8,10 @@ locals {
     instance_number = "01"
   }
 
-  location_short = "itn"
-
   naming_config = {
     prefix          = local.environment.prefix,
     environment     = local.environment.env_short,
-    location        = local.location_short,
+    location        = local.environment.location,
     instance_number = tonumber(local.environment.instance_number),
   }
 

--- a/infra/modules/azure_app_service_exposed/examples/complete/locals.tf
+++ b/infra/modules/azure_app_service_exposed/examples/complete/locals.tf
@@ -8,7 +8,14 @@ locals {
     instance_number = "01"
   }
 
-  project = module.naming_convention.project
+  location_short = "itn"
+
+  naming_config = {
+    prefix          = local.environment.prefix,
+    environment     = local.environment.env_short,
+    location        = local.location_short,
+    instance_number = tonumber(local.environment.instance_number),
+  }
 
   tags = {
     CreatedBy   = "Terraform"

--- a/infra/modules/azure_app_service_exposed/examples/complete/main.tf
+++ b/infra/modules/azure_app_service_exposed/examples/complete/main.tf
@@ -1,11 +1,8 @@
-module "naming_convention" {
-  source = "../../../azure_naming_convention"
-
-  environment = local.environment
-}
-
 resource "azurerm_resource_group" "example" {
-  name     = "${local.project}-${local.environment.domain}-rg-${local.environment.instance_number}"
+  name = provider::dx::resource_name(merge(local.naming_config, {
+    name          = "modules",
+    resource_type = "resource_group"
+  }))
   location = local.environment.location
 }
 

--- a/infra/modules/azure_app_service_exposed/examples/complete/versions.tf
+++ b/infra/modules/azure_app_service_exposed/examples/complete/versions.tf
@@ -1,7 +1,7 @@
 terraform {
 
   backend "azurerm" {
-    resource_group_name  = "dx-d-itn-network-rg-01"
+    resource_group_name  = "dx-d-itn-common-rg-01"
     storage_account_name = "dxditntfexamplesst01"
     container_name       = "terraform-state"
     key                  = "dx.app_service_exposed.example.complete.tfstate"
@@ -11,6 +11,10 @@ terraform {
     azurerm = {
       source  = "hashicorp/azurerm"
       version = ">= 3.111.0, < 5.0"
+    }
+    dx = {
+      source  = "pagopa-dx/azure"
+      version = "~>0"
     }
   }
 }

--- a/infra/modules/azure_app_service_exposed/examples/complete/versions.tf
+++ b/infra/modules/azure_app_service_exposed/examples/complete/versions.tf
@@ -14,7 +14,7 @@ terraform {
     }
     dx = {
       source  = "pagopa-dx/azure"
-      version = "~>0.0"
+      version = ">= 0.0.5, < 1.0.0"
     }
   }
 }

--- a/infra/modules/azure_app_service_exposed/examples/complete/versions.tf
+++ b/infra/modules/azure_app_service_exposed/examples/complete/versions.tf
@@ -14,7 +14,7 @@ terraform {
     }
     dx = {
       source  = "pagopa-dx/azure"
-      version = ">= 0.0.5, < 1.0.0"
+      version = ">= 0.0.6, < 1.0.0"
     }
   }
 }

--- a/infra/modules/azure_app_service_exposed/examples/complete/versions.tf
+++ b/infra/modules/azure_app_service_exposed/examples/complete/versions.tf
@@ -14,7 +14,7 @@ terraform {
     }
     dx = {
       source  = "pagopa-dx/azure"
-      version = "~>0"
+      version = "~>0.0"
     }
   }
 }

--- a/infra/modules/azure_app_service_exposed/locals.tf
+++ b/infra/modules/azure_app_service_exposed/locals.tf
@@ -1,14 +1,32 @@
 locals {
+  naming_config = {
+    prefix      = var.environment.prefix,
+    environment = var.environment.env_short,
+    location = tomap({
+      "italynorth" = "itn",
+      "westeurope" = "weu"
+    })[var.environment.location]
+    domain          = var.environment.domain,
+    name            = var.environment.app_name,
+    instance_number = tonumber(var.environment.instance_number),
+  }
   app_service_plan = {
     enable = var.app_service_plan_id == null
   }
 
   app_service = {
-    name                   = "${module.naming_convention.prefix}-app-${module.naming_convention.suffix}"
+    name                   = provider::dx::resource_name(merge(local.naming_config, { resource_type = "app_service" }))
     sku_name               = local.sku_name_mapping[local.tier]
     zone_balancing_enabled = local.tier != "s" && local.tier != "xs"
     is_slot_enabled        = local.tier == "s" || local.tier == "xs" ? 0 : 1
     always_on              = local.tier == "xs" ? false : true
+  }
+
+  app_service_slot = {
+    name = provider::dx::resource_name(merge(local.naming_config, {
+      name          = "${var.environment.app_name}-staging",
+      resource_type = "app_service"
+    }))
   }
 
   application_insights = {

--- a/infra/modules/azure_app_service_exposed/locals.tf
+++ b/infra/modules/azure_app_service_exposed/locals.tf
@@ -1,11 +1,8 @@
 locals {
   naming_config = {
-    prefix      = var.environment.prefix,
-    environment = var.environment.env_short,
-    location = tomap({
-      "italynorth" = "itn",
-      "westeurope" = "weu"
-    })[var.environment.location]
+    prefix          = var.environment.prefix,
+    environment     = var.environment.env_short,
+    location        = var.environment.location
     domain          = var.environment.domain,
     name            = var.environment.app_name,
     instance_number = tonumber(var.environment.instance_number),

--- a/infra/modules/azure_app_service_exposed/main.tf
+++ b/infra/modules/azure_app_service_exposed/main.tf
@@ -6,7 +6,7 @@ terraform {
     }
     dx = {
       source  = "pagopa-dx/azure"
-      version = ">= 0.0.5, < 1.0.0"
+      version = ">= 0.0.6, < 1.0.0"
     }
   }
 }

--- a/infra/modules/azure_app_service_exposed/main.tf
+++ b/infra/modules/azure_app_service_exposed/main.tf
@@ -6,7 +6,7 @@ terraform {
     }
     dx = {
       source  = "pagopa-dx/azure"
-      version = "~>0.0"
+      version = ">= 0.0.5, < 1.0.0"
     }
   }
 }

--- a/infra/modules/azure_app_service_exposed/main.tf
+++ b/infra/modules/azure_app_service_exposed/main.tf
@@ -4,19 +4,9 @@ terraform {
       source  = "hashicorp/azurerm"
       version = ">= 3.111.0, < 5.0"
     }
-  }
-}
-
-module "naming_convention" {
-  source  = "pagopa-dx/azure-naming-convention/azurerm"
-  version = "~> 0.0"
-
-  environment = {
-    prefix          = var.environment.prefix
-    env_short       = var.environment.env_short
-    location        = var.environment.location
-    domain          = var.environment.domain
-    app_name        = var.environment.app_name
-    instance_number = var.environment.instance_number
+    dx = {
+      source  = "pagopa-dx/azure"
+      version = "~>0"
+    }
   }
 }

--- a/infra/modules/azure_app_service_exposed/main.tf
+++ b/infra/modules/azure_app_service_exposed/main.tf
@@ -6,7 +6,7 @@ terraform {
     }
     dx = {
       source  = "pagopa-dx/azure"
-      version = "~>0"
+      version = "~>0.0"
     }
   }
 }

--- a/infra/modules/azure_app_service_exposed/tests/setup/README.md
+++ b/infra/modules/azure_app_service_exposed/tests/setup/README.md
@@ -6,7 +6,7 @@
 | Name | Version |
 |------|---------|
 | <a name="requirement_azurerm"></a> [azurerm](#requirement\_azurerm) | >= 3.111.0, < 5.0 |
-| <a name="requirement_dx"></a> [dx](#requirement\_dx) | >= 0.0.5, < 1.0.0 |
+| <a name="requirement_dx"></a> [dx](#requirement\_dx) | >= 0.0.6, < 1.0.0 |
 
 ## Modules
 

--- a/infra/modules/azure_app_service_exposed/tests/setup/README.md
+++ b/infra/modules/azure_app_service_exposed/tests/setup/README.md
@@ -6,12 +6,11 @@
 | Name | Version |
 |------|---------|
 | <a name="requirement_azurerm"></a> [azurerm](#requirement\_azurerm) | >= 3.111.0, < 5.0 |
+| <a name="requirement_dx"></a> [dx](#requirement\_dx) | ~>0.0 |
 
 ## Modules
 
-| Name | Source | Version |
-|------|--------|---------|
-| <a name="module_naming_convention"></a> [naming\_convention](#module\_naming\_convention) | ../../../azure_naming_convention | n/a |
+No modules.
 
 ## Resources
 

--- a/infra/modules/azure_app_service_exposed/tests/setup/README.md
+++ b/infra/modules/azure_app_service_exposed/tests/setup/README.md
@@ -6,7 +6,7 @@
 | Name | Version |
 |------|---------|
 | <a name="requirement_azurerm"></a> [azurerm](#requirement\_azurerm) | >= 3.111.0, < 5.0 |
-| <a name="requirement_dx"></a> [dx](#requirement\_dx) | ~>0.0 |
+| <a name="requirement_dx"></a> [dx](#requirement\_dx) | >= 0.0.5, < 1.0.0 |
 
 ## Modules
 

--- a/infra/modules/azure_app_service_exposed/tests/setup/main.tf
+++ b/infra/modules/azure_app_service_exposed/tests/setup/main.tf
@@ -6,19 +6,16 @@ terraform {
     }
     dx = {
       source  = "pagopa-dx/azure"
-      version = "~>0.0"
+      version = ">= 0.0.5, < 1.0.0"
     }
   }
 }
 
 locals {
   naming_config = {
-    prefix      = var.environment.prefix,
-    environment = var.environment.env_short,
-    location = tomap({
-      "italynorth" = "itn",
-      "westeurope" = "weu"
-    })[var.environment.location]
+    prefix          = var.environment.prefix,
+    environment     = var.environment.env_short,
+    location        = var.environment.location
     name            = var.environment.app_name,
     instance_number = tonumber(var.environment.instance_number),
   }

--- a/infra/modules/azure_app_service_exposed/tests/setup/main.tf
+++ b/infra/modules/azure_app_service_exposed/tests/setup/main.tf
@@ -4,25 +4,31 @@ terraform {
       source  = "hashicorp/azurerm"
       version = ">= 3.111.0, < 5.0"
     }
+    dx = {
+      source  = "pagopa-dx/azure"
+      version = "~>0.0"
+    }
   }
 }
 
-module "naming_convention" {
-  source = "../../../azure_naming_convention"
-
-  environment = {
-    prefix          = var.environment.prefix
-    env_short       = var.environment.env_short
-    location        = var.environment.location
-    domain          = var.environment.domain
-    app_name        = var.environment.app_name
-    instance_number = var.environment.instance_number
+locals {
+  naming_config = {
+    prefix      = var.environment.prefix,
+    environment = var.environment.env_short,
+    location = tomap({
+      "italynorth" = "itn",
+      "westeurope" = "weu"
+    })[var.environment.location]
+    name            = var.environment.app_name,
+    instance_number = tonumber(var.environment.instance_number),
   }
 }
 
 data "azurerm_resource_group" "rg" {
-  name = "${var.environment.prefix}-${var.environment.env_short}-itn-test-rg-${module.naming_convention.suffix}"
-
+  name = provider::dx::resource_name(merge(local.naming_config, {
+    name          = "test",
+    resource_type = "resource_group"
+  }))
 }
 
 output "resource_group_name" {

--- a/infra/modules/azure_app_service_exposed/tests/setup/main.tf
+++ b/infra/modules/azure_app_service_exposed/tests/setup/main.tf
@@ -6,7 +6,7 @@ terraform {
     }
     dx = {
       source  = "pagopa-dx/azure"
-      version = ">= 0.0.5, < 1.0.0"
+      version = ">= 0.0.6, < 1.0.0"
     }
   }
 }


### PR DESCRIPTION
This PR removes all instances of the `naming_convention` module from the App Service and App Service Exposed modules. The functionality has been replaced with the new naming convention function provided by the `pagopa-dx/azure` provider.

Resolves: CES-914