### PR TITLE
Remove `naming_convention` inside Function App modules in favor of `pagopa-dx/azure` provider function

### DIFF
--- a/.changeset/light-cobras-clap.md
+++ b/.changeset/light-cobras-clap.md
@@ -1,0 +1,6 @@
+---
+"azure_function_app_exposed": patch
+"azure_function_app": patch
+---
+
+Replace naming convention module with DX provider functions

--- a/infra/modules/azure_function_app/README.md
+++ b/infra/modules/azure_function_app/README.md
@@ -7,7 +7,7 @@
 | Name | Version |
 |------|---------|
 | <a name="requirement_azurerm"></a> [azurerm](#requirement\_azurerm) | >= 3.100.0, < 5.0 |
-| <a name="requirement_dx"></a> [dx](#requirement\_dx) | ~>0 |
+| <a name="requirement_dx"></a> [dx](#requirement\_dx) | ~>0.0 |
 
 ## Modules
 

--- a/infra/modules/azure_function_app/README.md
+++ b/infra/modules/azure_function_app/README.md
@@ -7,7 +7,7 @@
 | Name | Version |
 |------|---------|
 | <a name="requirement_azurerm"></a> [azurerm](#requirement\_azurerm) | >= 3.100.0, < 5.0 |
-| <a name="requirement_dx"></a> [dx](#requirement\_dx) | ~>0.0 |
+| <a name="requirement_dx"></a> [dx](#requirement\_dx) | >= 0.0.4, < 1.0.0 |
 
 ## Modules
 

--- a/infra/modules/azure_function_app/README.md
+++ b/infra/modules/azure_function_app/README.md
@@ -7,12 +7,11 @@
 | Name | Version |
 |------|---------|
 | <a name="requirement_azurerm"></a> [azurerm](#requirement\_azurerm) | >= 3.100.0, < 5.0 |
+| <a name="requirement_dx"></a> [dx](#requirement\_dx) | ~>0 |
 
 ## Modules
 
-| Name | Source | Version |
-|------|--------|---------|
-| <a name="module_naming_convention"></a> [naming\_convention](#module\_naming\_convention) | pagopa-dx/azure-naming-convention/azurerm | ~> 0.0 |
+No modules.
 
 ## Resources
 

--- a/infra/modules/azure_function_app/README.md
+++ b/infra/modules/azure_function_app/README.md
@@ -7,7 +7,7 @@
 | Name | Version |
 |------|---------|
 | <a name="requirement_azurerm"></a> [azurerm](#requirement\_azurerm) | >= 3.100.0, < 5.0 |
-| <a name="requirement_dx"></a> [dx](#requirement\_dx) | >= 0.0.4, < 1.0.0 |
+| <a name="requirement_dx"></a> [dx](#requirement\_dx) | >= 0.0.5, < 1.0.0 |
 
 ## Modules
 

--- a/infra/modules/azure_function_app/README.md
+++ b/infra/modules/azure_function_app/README.md
@@ -7,7 +7,7 @@
 | Name | Version |
 |------|---------|
 | <a name="requirement_azurerm"></a> [azurerm](#requirement\_azurerm) | >= 3.100.0, < 5.0 |
-| <a name="requirement_dx"></a> [dx](#requirement\_dx) | >= 0.0.5, < 1.0.0 |
+| <a name="requirement_dx"></a> [dx](#requirement\_dx) | >= 0.0.6, < 1.0.0 |
 
 ## Modules
 

--- a/infra/modules/azure_function_app/examples/complete/README.md
+++ b/infra/modules/azure_function_app/examples/complete/README.md
@@ -6,7 +6,7 @@
 | Name | Version |
 |------|---------|
 | <a name="requirement_azurerm"></a> [azurerm](#requirement\_azurerm) | >= 3.100.0, < 5.0 |
-| <a name="requirement_dx"></a> [dx](#requirement\_dx) | ~>0 |
+| <a name="requirement_dx"></a> [dx](#requirement\_dx) | ~>0.0 |
 
 ## Modules
 

--- a/infra/modules/azure_function_app/examples/complete/README.md
+++ b/infra/modules/azure_function_app/examples/complete/README.md
@@ -6,13 +6,13 @@
 | Name | Version |
 |------|---------|
 | <a name="requirement_azurerm"></a> [azurerm](#requirement\_azurerm) | >= 3.100.0, < 5.0 |
+| <a name="requirement_dx"></a> [dx](#requirement\_dx) | ~>0 |
 
 ## Modules
 
 | Name | Source | Version |
 |------|--------|---------|
 | <a name="module_azure_function_app"></a> [azure\_function\_app](#module\_azure\_function\_app) | ../../ | n/a |
-| <a name="module_naming_convention"></a> [naming\_convention](#module\_naming\_convention) | ../../../azure_naming_convention | n/a |
 
 ## Resources
 

--- a/infra/modules/azure_function_app/examples/complete/README.md
+++ b/infra/modules/azure_function_app/examples/complete/README.md
@@ -6,7 +6,7 @@
 | Name | Version |
 |------|---------|
 | <a name="requirement_azurerm"></a> [azurerm](#requirement\_azurerm) | >= 3.100.0, < 5.0 |
-| <a name="requirement_dx"></a> [dx](#requirement\_dx) | ~>0.0 |
+| <a name="requirement_dx"></a> [dx](#requirement\_dx) | >= 0.0.5, < 1.0.0 |
 
 ## Modules
 

--- a/infra/modules/azure_function_app/examples/complete/README.md
+++ b/infra/modules/azure_function_app/examples/complete/README.md
@@ -6,7 +6,7 @@
 | Name | Version |
 |------|---------|
 | <a name="requirement_azurerm"></a> [azurerm](#requirement\_azurerm) | >= 3.100.0, < 5.0 |
-| <a name="requirement_dx"></a> [dx](#requirement\_dx) | >= 0.0.5, < 1.0.0 |
+| <a name="requirement_dx"></a> [dx](#requirement\_dx) | >= 0.0.6, < 1.0.0 |
 
 ## Modules
 

--- a/infra/modules/azure_function_app/examples/complete/locals.tf
+++ b/infra/modules/azure_function_app/examples/complete/locals.tf
@@ -8,13 +8,34 @@ locals {
     instance_number = "01"
   }
 
-  project = module.naming_convention.project
+  naming_config = {
+    prefix      = local.environment.prefix,
+    environment = local.environment.env_short,
+    location = tomap({
+      "italynorth" = "itn",
+      "westeurope" = "weu"
+    })[local.environment.location]
+    name            = local.environment.app_name,
+    instance_number = tonumber(local.environment.instance_number),
+  }
+
+  virtual_network = {
+    name = provider::dx::resource_name(merge(local.naming_config, {
+      name          = "common",
+      resource_type = "virtual_network"
+    }))
+    resource_group_name = provider::dx::resource_name(merge(local.naming_config, {
+      name          = "network",
+      resource_type = "resource_group"
+    }))
+  }
 
   tags = {
-    CreatedBy   = "Terraform"
-    Environment = "Dev"
-    Owner       = "DevEx"
-    Source      = "https://github.com/pagopa/dx/modules/azure_function_app/examples/complete"
-    CostCenter  = "TS700 - ENGINEERING"
+    CostCenter     = "TS000 - Tecnologia e Servizi"
+    CreatedBy      = "Terraform"
+    Environment    = "Dev"
+    BusinessUnit   = "DevEx"
+    Source         = "https://github.com/pagopa/dx/blob/main/infra/modules/azure_function_app/examples/complete"
+    ManagementTeam = "Developer Experience"
   }
 }

--- a/infra/modules/azure_function_app/examples/complete/locals.tf
+++ b/infra/modules/azure_function_app/examples/complete/locals.tf
@@ -9,12 +9,9 @@ locals {
   }
 
   naming_config = {
-    prefix      = local.environment.prefix,
-    environment = local.environment.env_short,
-    location = tomap({
-      "italynorth" = "itn",
-      "westeurope" = "weu"
-    })[local.environment.location]
+    prefix          = local.environment.prefix,
+    environment     = local.environment.env_short,
+    location        = local.environment.location
     name            = local.environment.app_name,
     instance_number = tonumber(local.environment.instance_number),
   }

--- a/infra/modules/azure_function_app/examples/complete/main.tf
+++ b/infra/modules/azure_function_app/examples/complete/main.tf
@@ -1,17 +1,17 @@
-module "naming_convention" {
-  source = "../../../azure_naming_convention"
-
-  environment = local.environment
-}
-
 data "azurerm_subnet" "pep" {
-  name                 = "${local.project}-pep-snet-01"
-  virtual_network_name = "${local.project}-common-vnet-01"
-  resource_group_name  = "${local.project}-network-rg-01"
+  name = provider::dx::resource_name(merge(local.naming_config, {
+    name          = "pep",
+    resource_type = "subnet"
+  }))
+  virtual_network_name = local.virtual_network.name
+  resource_group_name  = local.virtual_network.resource_group_name
 }
 
 resource "azurerm_resource_group" "example" {
-  name     = "${local.project}-${local.environment.domain}-rg-${local.environment.instance_number}"
+  name = provider::dx::resource_name(merge(local.naming_config, {
+    name          = local.environment.domain,
+    resource_type = "resource_group"
+  }))
   location = local.environment.location
 }
 
@@ -29,8 +29,8 @@ module "azure_function_app" {
   resource_group_name = azurerm_resource_group.example.name
 
   virtual_network = {
-    name                = "${local.project}-common-vnet-01"
-    resource_group_name = "${local.project}-network-rg-01"
+    name                = local.virtual_network.name
+    resource_group_name = local.virtual_network.resource_group_name
   }
   subnet_pep_id = data.azurerm_subnet.pep.id
   subnet_cidr   = "10.50.248.0/24"

--- a/infra/modules/azure_function_app/examples/complete/versions.tf
+++ b/infra/modules/azure_function_app/examples/complete/versions.tf
@@ -1,7 +1,7 @@
 terraform {
 
   backend "azurerm" {
-    resource_group_name  = "dx-d-itn-network-rg-01"
+    resource_group_name  = "dx-d-itn-common-rg-01"
     storage_account_name = "dxditntfexamplesst01"
     container_name       = "terraform-state"
     key                  = "dx.function_app.example.complete.tfstate"
@@ -11,6 +11,10 @@ terraform {
     azurerm = {
       source  = "hashicorp/azurerm"
       version = ">= 3.100.0, < 5.0"
+    }
+    dx = {
+      source  = "pagopa-dx/azure"
+      version = "~>0"
     }
   }
 }

--- a/infra/modules/azure_function_app/examples/complete/versions.tf
+++ b/infra/modules/azure_function_app/examples/complete/versions.tf
@@ -14,7 +14,7 @@ terraform {
     }
     dx = {
       source  = "pagopa-dx/azure"
-      version = "~>0.0"
+      version = ">= 0.0.5, < 1.0.0"
     }
   }
 }

--- a/infra/modules/azure_function_app/examples/complete/versions.tf
+++ b/infra/modules/azure_function_app/examples/complete/versions.tf
@@ -14,7 +14,7 @@ terraform {
     }
     dx = {
       source  = "pagopa-dx/azure"
-      version = ">= 0.0.5, < 1.0.0"
+      version = ">= 0.0.6, < 1.0.0"
     }
   }
 }

--- a/infra/modules/azure_function_app/examples/complete/versions.tf
+++ b/infra/modules/azure_function_app/examples/complete/versions.tf
@@ -14,7 +14,7 @@ terraform {
     }
     dx = {
       source  = "pagopa-dx/azure"
-      version = "~>0"
+      version = "~>0.0"
     }
   }
 }

--- a/infra/modules/azure_function_app/locals.tf
+++ b/infra/modules/azure_function_app/locals.tf
@@ -49,7 +49,7 @@ locals {
   storage_account = {
     replication_type = local.tier == "s" ? "LRS" : "ZRS"
     name             = provider::dx::resource_name(merge(local.naming_config, { resource_type = "function_storage_account" }))
-    durable_name     = replace(provider::dx::resource_name(merge(local.naming_config, { resource_type = "function_storage_account" })), "stfn", "stfd")
+    durable_name     = provider::dx::resource_name(merge(local.naming_config, { resource_type = "durable_function_storage_account" }))
     pep_blob_name    = provider::dx::resource_name(merge(local.naming_config, { resource_type = "blob_private_endpoint" }))
     pep_file_name    = provider::dx::resource_name(merge(local.naming_config, { resource_type = "file_private_endpoint" }))
     pep_queue_name   = provider::dx::resource_name(merge(local.naming_config, { resource_type = "queue_private_endpoint" }))

--- a/infra/modules/azure_function_app/locals.tf
+++ b/infra/modules/azure_function_app/locals.tf
@@ -1,27 +1,39 @@
 locals {
+  naming_config = {
+    prefix      = var.environment.prefix,
+    environment = var.environment.env_short,
+    location = tomap({
+      "italynorth" = "itn",
+      "westeurope" = "weu"
+    })[var.environment.location]
+    domain          = var.environment.domain,
+    name            = var.environment.app_name,
+    instance_number = tonumber(var.environment.instance_number),
+  }
+
   subnet = {
     enable_service_endpoints = var.subnet_service_endpoints != null ? concat(
       var.subnet_service_endpoints.cosmos ? ["Microsoft.CosmosDB"] : [],
       var.subnet_service_endpoints.web ? ["Microsoft.Web"] : [],
       var.subnet_service_endpoints.storage ? ["Microsoft.Storage"] : [],
     ) : []
-    name = "${module.naming_convention.prefix}-func-snet-${module.naming_convention.suffix}"
+    name = provider::dx::resource_name(merge(local.naming_config, { resource_type = "function_subnet" }))
   }
 
   app_service_plan = {
     enable = var.app_service_plan_id == null
-    name   = "${module.naming_convention.prefix}-asp-${module.naming_convention.suffix}"
+    name   = provider::dx::resource_name(merge(local.naming_config, { resource_type = "app_service_plan" }))
   }
 
   function_app = {
-    name                   = "${module.naming_convention.prefix}-func-${module.naming_convention.suffix}"
+    name                   = provider::dx::resource_name(merge(local.naming_config, { resource_type = "function_app" }))
     sku_name               = local.sku_name_mapping[local.tier]
     zone_balancing_enabled = local.tier != "s"
     is_slot_enabled        = local.tier == "s" ? 0 : 1
     has_existing_subnet    = var.subnet_id != null
-    pep_sites              = "${module.naming_convention.prefix}-func-pep-${module.naming_convention.suffix}"
-    pep_sites_staging      = "${module.naming_convention.prefix}-staging-func-pep-${module.naming_convention.suffix}"
-    alert                  = "${module.naming_convention.prefix}-func-${module.naming_convention.suffix}] Health Check Failed"
+    pep_sites              = provider::dx::resource_name(merge(local.naming_config, { resource_type = "function_private_endpoint" }))
+    pep_sites_staging      = provider::dx::resource_name(merge(local.naming_config, { resource_type = "function_slot_private_endpoint" }))
+    alert                  = "${provider::dx::resource_name(merge(local.naming_config, { resource_type = "function_app" }))}] Health Check Failed"
     worker_process_count   = local.worker_process_count_mapping[local.tier]
     has_durable            = var.has_durable_functions ? 1 : 0
   }
@@ -36,16 +48,16 @@ locals {
 
   storage_account = {
     replication_type = local.tier == "s" ? "LRS" : "ZRS"
-    name             = lower(replace("${module.naming_convention.project}${replace(module.naming_convention.domain, "-", "")}${var.environment.app_name}stfn${module.naming_convention.suffix}", "-", ""))
-    durable_name     = lower(replace("${module.naming_convention.project}${replace(module.naming_convention.domain, "-", "")}${var.environment.app_name}stfd${module.naming_convention.suffix}", "-", ""))
-    pep_blob_name    = "${module.naming_convention.prefix}-blob-pep-${module.naming_convention.suffix}"
-    pep_file_name    = "${module.naming_convention.prefix}-file-pep-${module.naming_convention.suffix}"
-    pep_queue_name   = "${module.naming_convention.prefix}-queue-pep-${module.naming_convention.suffix}"
-    pep_dblob_name   = "${module.naming_convention.prefix}-dblob-pep-${module.naming_convention.suffix}"
-    pep_dfile_name   = "${module.naming_convention.prefix}-dfile-pep-${module.naming_convention.suffix}"
-    pep_dqueue_name  = "${module.naming_convention.prefix}-dqueue-pep-${module.naming_convention.suffix}"
-    pep_dtable_name  = "${module.naming_convention.prefix}-dtable-pep-${module.naming_convention.suffix}"
-    alert            = "[${replace("${module.naming_convention.project}${replace(module.naming_convention.domain, "-", "")}${var.environment.app_name}stfn${module.naming_convention.suffix}", "-", "")}] Low Availability"
+    name             = provider::dx::resource_name(merge(local.naming_config, { resource_type = "function_storage_account" }))
+    durable_name     = replace(provider::dx::resource_name(merge(local.naming_config, { resource_type = "function_storage_account" })), "stfn", "stfd")
+    pep_blob_name    = provider::dx::resource_name(merge(local.naming_config, { resource_type = "blob_private_endpoint" }))
+    pep_file_name    = provider::dx::resource_name(merge(local.naming_config, { resource_type = "file_private_endpoint" }))
+    pep_queue_name   = provider::dx::resource_name(merge(local.naming_config, { resource_type = "queue_private_endpoint" }))
+    pep_dblob_name   = replace(provider::dx::resource_name(merge(local.naming_config, { resource_type = "blob_private_endpoint" })), "blob-pep", "dblob-pep")
+    pep_dfile_name   = replace(provider::dx::resource_name(merge(local.naming_config, { resource_type = "file_private_endpoint" })), "file-pep", "dfile-pep")
+    pep_dqueue_name  = replace(provider::dx::resource_name(merge(local.naming_config, { resource_type = "queue_private_endpoint" })), "queue-pep", "dqueue-pep")
+    pep_dtable_name  = replace(provider::dx::resource_name(merge(local.naming_config, { resource_type = "table_private_endpoint" })), "table-pep", "dtable-pep")
+    alert            = "[${provider::dx::resource_name(merge(local.naming_config, { resource_type = "function_storage_account" }))}] Low Availability"
   }
 
   private_dns_zone = {

--- a/infra/modules/azure_function_app/locals.tf
+++ b/infra/modules/azure_function_app/locals.tf
@@ -1,11 +1,8 @@
 locals {
   naming_config = {
-    prefix      = var.environment.prefix,
-    environment = var.environment.env_short,
-    location = tomap({
-      "italynorth" = "itn",
-      "westeurope" = "weu"
-    })[var.environment.location]
+    prefix          = var.environment.prefix,
+    environment     = var.environment.env_short,
+    location        = var.environment.location
     domain          = var.environment.domain,
     name            = var.environment.app_name,
     instance_number = tonumber(var.environment.instance_number),

--- a/infra/modules/azure_function_app/main.tf
+++ b/infra/modules/azure_function_app/main.tf
@@ -6,7 +6,7 @@ terraform {
     }
     dx = {
       source  = "pagopa-dx/azure"
-      version = "~>0.0"
+      version = ">= 0.0.4, < 1.0.0"
     }
   }
 }

--- a/infra/modules/azure_function_app/main.tf
+++ b/infra/modules/azure_function_app/main.tf
@@ -4,19 +4,9 @@ terraform {
       source  = "hashicorp/azurerm"
       version = ">= 3.100.0, < 5.0"
     }
-  }
-}
-
-module "naming_convention" {
-  source  = "pagopa-dx/azure-naming-convention/azurerm"
-  version = "~> 0.0"
-
-  environment = {
-    prefix          = var.environment.prefix
-    env_short       = var.environment.env_short
-    location        = var.environment.location
-    domain          = var.environment.domain
-    app_name        = var.environment.app_name
-    instance_number = var.environment.instance_number
+    dx = {
+      source  = "pagopa-dx/azure"
+      version = "~>0"
+    }
   }
 }

--- a/infra/modules/azure_function_app/main.tf
+++ b/infra/modules/azure_function_app/main.tf
@@ -6,7 +6,7 @@ terraform {
     }
     dx = {
       source  = "pagopa-dx/azure"
-      version = ">= 0.0.5, < 1.0.0"
+      version = ">= 0.0.6, < 1.0.0"
     }
   }
 }

--- a/infra/modules/azure_function_app/main.tf
+++ b/infra/modules/azure_function_app/main.tf
@@ -6,7 +6,7 @@ terraform {
     }
     dx = {
       source  = "pagopa-dx/azure"
-      version = ">= 0.0.4, < 1.0.0"
+      version = ">= 0.0.5, < 1.0.0"
     }
   }
 }

--- a/infra/modules/azure_function_app/main.tf
+++ b/infra/modules/azure_function_app/main.tf
@@ -6,7 +6,7 @@ terraform {
     }
     dx = {
       source  = "pagopa-dx/azure"
-      version = "~>0"
+      version = "~>0.0"
     }
   }
 }

--- a/infra/modules/azure_function_app/tests/setup/README.md
+++ b/infra/modules/azure_function_app/tests/setup/README.md
@@ -6,7 +6,7 @@
 | Name | Version |
 |------|---------|
 | <a name="requirement_azurerm"></a> [azurerm](#requirement\_azurerm) | >= 3.100.0, < 5.0 |
-| <a name="requirement_dx"></a> [dx](#requirement\_dx) | ~>0 |
+| <a name="requirement_dx"></a> [dx](#requirement\_dx) | ~>0.0 |
 
 ## Modules
 

--- a/infra/modules/azure_function_app/tests/setup/README.md
+++ b/infra/modules/azure_function_app/tests/setup/README.md
@@ -6,7 +6,7 @@
 | Name | Version |
 |------|---------|
 | <a name="requirement_azurerm"></a> [azurerm](#requirement\_azurerm) | >= 3.100.0, < 5.0 |
-| <a name="requirement_dx"></a> [dx](#requirement\_dx) | ~>0.0 |
+| <a name="requirement_dx"></a> [dx](#requirement\_dx) | >= 0.0.5, < 1.0.0 |
 
 ## Modules
 

--- a/infra/modules/azure_function_app/tests/setup/README.md
+++ b/infra/modules/azure_function_app/tests/setup/README.md
@@ -6,7 +6,7 @@
 | Name | Version |
 |------|---------|
 | <a name="requirement_azurerm"></a> [azurerm](#requirement\_azurerm) | >= 3.100.0, < 5.0 |
-| <a name="requirement_dx"></a> [dx](#requirement\_dx) | >= 0.0.5, < 1.0.0 |
+| <a name="requirement_dx"></a> [dx](#requirement\_dx) | >= 0.0.6, < 1.0.0 |
 
 ## Modules
 

--- a/infra/modules/azure_function_app/tests/setup/README.md
+++ b/infra/modules/azure_function_app/tests/setup/README.md
@@ -6,12 +6,11 @@
 | Name | Version |
 |------|---------|
 | <a name="requirement_azurerm"></a> [azurerm](#requirement\_azurerm) | >= 3.100.0, < 5.0 |
+| <a name="requirement_dx"></a> [dx](#requirement\_dx) | ~>0 |
 
 ## Modules
 
-| Name | Source | Version |
-|------|--------|---------|
-| <a name="module_naming_convention"></a> [naming\_convention](#module\_naming\_convention) | ../../../azure_naming_convention | n/a |
+No modules.
 
 ## Resources
 

--- a/infra/modules/azure_function_app/tests/setup/main.tf
+++ b/infra/modules/azure_function_app/tests/setup/main.tf
@@ -4,36 +4,55 @@ terraform {
       source  = "hashicorp/azurerm"
       version = ">= 3.100.0, < 5.0"
     }
+    dx = {
+      source  = "pagopa-dx/azure"
+      version = "~>0"
+    }
   }
 }
 
-module "naming_convention" {
-  source = "../../../azure_naming_convention"
+locals {
+  naming_config = {
+    prefix      = var.environment.prefix,
+    environment = var.environment.env_short,
+    location = tomap({
+      "italynorth" = "itn",
+      "westeurope" = "weu"
+    })[var.environment.location]
+    name            = var.environment.app_name,
+    instance_number = tonumber(var.environment.instance_number),
+  }
 
-  environment = {
-    prefix          = var.environment.prefix
-    env_short       = var.environment.env_short
-    location        = var.environment.location
-    domain          = var.environment.domain
-    app_name        = var.environment.app_name
-    instance_number = var.environment.instance_number
+  virtual_network = {
+    name = provider::dx::resource_name(merge(local.naming_config, {
+      name          = "common",
+      resource_type = "virtual_network"
+    }))
+    resource_group_name = provider::dx::resource_name(merge(local.naming_config, {
+      name          = "network",
+      resource_type = "resource_group"
+    }))
   }
 }
-
 data "azurerm_virtual_network" "vnet" {
-  name                = "${module.naming_convention.project}-common-vnet-01"
-  resource_group_name = "${module.naming_convention.project}-network-rg-01"
+  name                = local.virtual_network.name
+  resource_group_name = local.virtual_network.resource_group_name
 }
 
 data "azurerm_subnet" "pep" {
-  name                 = "${module.naming_convention.project}-pep-snet-01"
-  virtual_network_name = "${module.naming_convention.project}-common-vnet-01"
-  resource_group_name  = "${module.naming_convention.project}-network-rg-01"
+  name = provider::dx::resource_name(merge(local.naming_config, {
+    name          = "pep",
+    resource_type = "subnet"
+  }))
+  virtual_network_name = data.azurerm_virtual_network.vnet.name
+  resource_group_name  = data.azurerm_virtual_network.vnet.resource_group_name
 }
 
 data "azurerm_resource_group" "rg" {
-  name = "${var.environment.prefix}-${var.environment.env_short}-itn-test-rg-${module.naming_convention.suffix}"
-
+  name = provider::dx::resource_name(merge(local.naming_config, {
+    name          = "test",
+    resource_type = "resource_group"
+  }))
 }
 
 output "pep_id" {

--- a/infra/modules/azure_function_app/tests/setup/main.tf
+++ b/infra/modules/azure_function_app/tests/setup/main.tf
@@ -6,19 +6,16 @@ terraform {
     }
     dx = {
       source  = "pagopa-dx/azure"
-      version = "~>0.0"
+      version = ">= 0.0.5, < 1.0.0"
     }
   }
 }
 
 locals {
   naming_config = {
-    prefix      = var.environment.prefix,
-    environment = var.environment.env_short,
-    location = tomap({
-      "italynorth" = "itn",
-      "westeurope" = "weu"
-    })[var.environment.location]
+    prefix          = var.environment.prefix,
+    environment     = var.environment.env_short,
+    location        = var.environment.location
     name            = var.environment.app_name,
     instance_number = tonumber(var.environment.instance_number),
   }

--- a/infra/modules/azure_function_app/tests/setup/main.tf
+++ b/infra/modules/azure_function_app/tests/setup/main.tf
@@ -6,7 +6,7 @@ terraform {
     }
     dx = {
       source  = "pagopa-dx/azure"
-      version = ">= 0.0.5, < 1.0.0"
+      version = ">= 0.0.6, < 1.0.0"
     }
   }
 }

--- a/infra/modules/azure_function_app/tests/setup/main.tf
+++ b/infra/modules/azure_function_app/tests/setup/main.tf
@@ -6,7 +6,7 @@ terraform {
     }
     dx = {
       source  = "pagopa-dx/azure"
-      version = "~>0"
+      version = "~>0.0"
     }
   }
 }

--- a/infra/modules/azure_function_app_exposed/README.md
+++ b/infra/modules/azure_function_app_exposed/README.md
@@ -7,7 +7,7 @@
 | Name | Version |
 |------|---------|
 | <a name="requirement_azurerm"></a> [azurerm](#requirement\_azurerm) | >= 3.100.0, < 5.0 |
-| <a name="requirement_dx"></a> [dx](#requirement\_dx) | ~>0 |
+| <a name="requirement_dx"></a> [dx](#requirement\_dx) | ~>0.0 |
 
 ## Modules
 

--- a/infra/modules/azure_function_app_exposed/README.md
+++ b/infra/modules/azure_function_app_exposed/README.md
@@ -7,7 +7,7 @@
 | Name | Version |
 |------|---------|
 | <a name="requirement_azurerm"></a> [azurerm](#requirement\_azurerm) | >= 3.100.0, < 5.0 |
-| <a name="requirement_dx"></a> [dx](#requirement\_dx) | ~>0.0 |
+| <a name="requirement_dx"></a> [dx](#requirement\_dx) | >= 0.0.4, < 1.0.0 |
 
 ## Modules
 

--- a/infra/modules/azure_function_app_exposed/README.md
+++ b/infra/modules/azure_function_app_exposed/README.md
@@ -7,12 +7,11 @@
 | Name | Version |
 |------|---------|
 | <a name="requirement_azurerm"></a> [azurerm](#requirement\_azurerm) | >= 3.100.0, < 5.0 |
+| <a name="requirement_dx"></a> [dx](#requirement\_dx) | ~>0 |
 
 ## Modules
 
-| Name | Source | Version |
-|------|--------|---------|
-| <a name="module_naming_convention"></a> [naming\_convention](#module\_naming\_convention) | pagopa-dx/azure-naming-convention/azurerm | ~> 0.0 |
+No modules.
 
 ## Resources
 

--- a/infra/modules/azure_function_app_exposed/README.md
+++ b/infra/modules/azure_function_app_exposed/README.md
@@ -7,7 +7,7 @@
 | Name | Version |
 |------|---------|
 | <a name="requirement_azurerm"></a> [azurerm](#requirement\_azurerm) | >= 3.100.0, < 5.0 |
-| <a name="requirement_dx"></a> [dx](#requirement\_dx) | >= 0.0.4, < 1.0.0 |
+| <a name="requirement_dx"></a> [dx](#requirement\_dx) | >= 0.0.5, < 1.0.0 |
 
 ## Modules
 

--- a/infra/modules/azure_function_app_exposed/README.md
+++ b/infra/modules/azure_function_app_exposed/README.md
@@ -7,7 +7,7 @@
 | Name | Version |
 |------|---------|
 | <a name="requirement_azurerm"></a> [azurerm](#requirement\_azurerm) | >= 3.100.0, < 5.0 |
-| <a name="requirement_dx"></a> [dx](#requirement\_dx) | >= 0.0.5, < 1.0.0 |
+| <a name="requirement_dx"></a> [dx](#requirement\_dx) | >= 0.0.6, < 1.0.0 |
 
 ## Modules
 

--- a/infra/modules/azure_function_app_exposed/examples/complete/README.md
+++ b/infra/modules/azure_function_app_exposed/examples/complete/README.md
@@ -6,7 +6,7 @@
 | Name | Version |
 |------|---------|
 | <a name="requirement_azurerm"></a> [azurerm](#requirement\_azurerm) | >= 3.100.0, < 5.0 |
-| <a name="requirement_dx"></a> [dx](#requirement\_dx) | ~>0 |
+| <a name="requirement_dx"></a> [dx](#requirement\_dx) | ~>0.0 |
 
 ## Modules
 

--- a/infra/modules/azure_function_app_exposed/examples/complete/README.md
+++ b/infra/modules/azure_function_app_exposed/examples/complete/README.md
@@ -6,13 +6,13 @@
 | Name | Version |
 |------|---------|
 | <a name="requirement_azurerm"></a> [azurerm](#requirement\_azurerm) | >= 3.100.0, < 5.0 |
+| <a name="requirement_dx"></a> [dx](#requirement\_dx) | ~>0 |
 
 ## Modules
 
 | Name | Source | Version |
 |------|--------|---------|
 | <a name="module_azure_function_app_exposed"></a> [azure\_function\_app\_exposed](#module\_azure\_function\_app\_exposed) | ../../ | n/a |
-| <a name="module_naming_convention"></a> [naming\_convention](#module\_naming\_convention) | ../../../azure_naming_convention | n/a |
 
 ## Resources
 

--- a/infra/modules/azure_function_app_exposed/examples/complete/README.md
+++ b/infra/modules/azure_function_app_exposed/examples/complete/README.md
@@ -6,7 +6,7 @@
 | Name | Version |
 |------|---------|
 | <a name="requirement_azurerm"></a> [azurerm](#requirement\_azurerm) | >= 3.100.0, < 5.0 |
-| <a name="requirement_dx"></a> [dx](#requirement\_dx) | ~>0.0 |
+| <a name="requirement_dx"></a> [dx](#requirement\_dx) | >= 0.0.5, < 1.0.0 |
 
 ## Modules
 

--- a/infra/modules/azure_function_app_exposed/examples/complete/README.md
+++ b/infra/modules/azure_function_app_exposed/examples/complete/README.md
@@ -6,7 +6,7 @@
 | Name | Version |
 |------|---------|
 | <a name="requirement_azurerm"></a> [azurerm](#requirement\_azurerm) | >= 3.100.0, < 5.0 |
-| <a name="requirement_dx"></a> [dx](#requirement\_dx) | >= 0.0.5, < 1.0.0 |
+| <a name="requirement_dx"></a> [dx](#requirement\_dx) | >= 0.0.6, < 1.0.0 |
 
 ## Modules
 

--- a/infra/modules/azure_function_app_exposed/examples/complete/locals.tf
+++ b/infra/modules/azure_function_app_exposed/examples/complete/locals.tf
@@ -9,12 +9,9 @@ locals {
   }
 
   naming_config = {
-    prefix      = local.environment.prefix,
-    environment = local.environment.env_short,
-    location = tomap({
-      "italynorth" = "itn",
-      "westeurope" = "weu"
-    })[local.environment.location]
+    prefix          = local.environment.prefix,
+    environment     = local.environment.env_short,
+    location        = local.environment.location
     name            = local.environment.app_name,
     instance_number = tonumber(local.environment.instance_number),
   }

--- a/infra/modules/azure_function_app_exposed/examples/complete/locals.tf
+++ b/infra/modules/azure_function_app_exposed/examples/complete/locals.tf
@@ -8,7 +8,16 @@ locals {
     instance_number = "01"
   }
 
-  project = module.naming_convention.project
+  naming_config = {
+    prefix      = local.environment.prefix,
+    environment = local.environment.env_short,
+    location = tomap({
+      "italynorth" = "itn",
+      "westeurope" = "weu"
+    })[local.environment.location]
+    name            = local.environment.app_name,
+    instance_number = tonumber(local.environment.instance_number),
+  }
 
   tags = {
     CreatedBy   = "Terraform"

--- a/infra/modules/azure_function_app_exposed/examples/complete/main.tf
+++ b/infra/modules/azure_function_app_exposed/examples/complete/main.tf
@@ -1,11 +1,8 @@
-module "naming_convention" {
-  source = "../../../azure_naming_convention"
-
-  environment = local.environment
-}
-
 resource "azurerm_resource_group" "example" {
-  name     = "${local.project}-${local.environment.domain}-rg-${local.environment.instance_number}"
+  name = provider::dx::resource_name(merge(local.naming_config, {
+    name          = local.environment.domain,
+    resource_type = "resource_group"
+  }))
   location = local.environment.location
 }
 

--- a/infra/modules/azure_function_app_exposed/examples/complete/versions.tf
+++ b/infra/modules/azure_function_app_exposed/examples/complete/versions.tf
@@ -14,7 +14,7 @@ terraform {
     }
     dx = {
       source  = "pagopa-dx/azure"
-      version = "~>0.0"
+      version = ">= 0.0.5, < 1.0.0"
     }
   }
 }

--- a/infra/modules/azure_function_app_exposed/examples/complete/versions.tf
+++ b/infra/modules/azure_function_app_exposed/examples/complete/versions.tf
@@ -14,7 +14,7 @@ terraform {
     }
     dx = {
       source  = "pagopa-dx/azure"
-      version = ">= 0.0.5, < 1.0.0"
+      version = ">= 0.0.6, < 1.0.0"
     }
   }
 }

--- a/infra/modules/azure_function_app_exposed/examples/complete/versions.tf
+++ b/infra/modules/azure_function_app_exposed/examples/complete/versions.tf
@@ -14,7 +14,7 @@ terraform {
     }
     dx = {
       source  = "pagopa-dx/azure"
-      version = "~>0"
+      version = "~>0.0"
     }
   }
 }

--- a/infra/modules/azure_function_app_exposed/examples/complete/versions.tf
+++ b/infra/modules/azure_function_app_exposed/examples/complete/versions.tf
@@ -1,7 +1,7 @@
 terraform {
 
   backend "azurerm" {
-    resource_group_name  = "dx-d-itn-network-rg-01"
+    resource_group_name  = "dx-d-itn-common-rg-01"
     storage_account_name = "dxditntfexamplesst01"
     container_name       = "terraform-state"
     key                  = "dx.function_app_exposed.example.complete.tfstate"
@@ -11,6 +11,10 @@ terraform {
     azurerm = {
       source  = "hashicorp/azurerm"
       version = ">= 3.100.0, < 5.0"
+    }
+    dx = {
+      source  = "pagopa-dx/azure"
+      version = "~>0"
     }
   }
 }

--- a/infra/modules/azure_function_app_exposed/locals.tf
+++ b/infra/modules/azure_function_app_exposed/locals.tf
@@ -36,6 +36,6 @@ locals {
   storage_account = {
     replication_type = local.tier == "s" ? "LRS" : "ZRS"
     name             = provider::dx::resource_name(merge(local.naming_config, { resource_type = "function_storage_account" }))
-    durable_name     = replace(provider::dx::resource_name(merge(local.naming_config, { resource_type = "function_storage_account" })), "stfn", "stfd")
+    durable_name     = provider::dx::resource_name(merge(local.naming_config, { resource_type = "durable_function_storage_account" }))
   }
 }

--- a/infra/modules/azure_function_app_exposed/locals.tf
+++ b/infra/modules/azure_function_app_exposed/locals.tf
@@ -1,11 +1,8 @@
 locals {
   naming_config = {
-    prefix      = var.environment.prefix,
-    environment = var.environment.env_short,
-    location = tomap({
-      "italynorth" = "itn",
-      "westeurope" = "weu"
-    })[var.environment.location]
+    prefix          = var.environment.prefix,
+    environment     = var.environment.env_short,
+    location        = var.environment.location
     domain          = var.environment.domain,
     name            = var.environment.app_name,
     instance_number = tonumber(var.environment.instance_number),

--- a/infra/modules/azure_function_app_exposed/main.tf
+++ b/infra/modules/azure_function_app_exposed/main.tf
@@ -6,7 +6,7 @@ terraform {
     }
     dx = {
       source  = "pagopa-dx/azure"
-      version = "~>0.0"
+      version = ">= 0.0.4, < 1.0.0"
     }
   }
 }

--- a/infra/modules/azure_function_app_exposed/main.tf
+++ b/infra/modules/azure_function_app_exposed/main.tf
@@ -4,19 +4,9 @@ terraform {
       source  = "hashicorp/azurerm"
       version = ">= 3.100.0, < 5.0"
     }
-  }
-}
-
-module "naming_convention" {
-  source  = "pagopa-dx/azure-naming-convention/azurerm"
-  version = "~> 0.0"
-
-  environment = {
-    prefix          = var.environment.prefix
-    env_short       = var.environment.env_short
-    location        = var.environment.location
-    domain          = var.environment.domain
-    app_name        = var.environment.app_name
-    instance_number = var.environment.instance_number
+    dx = {
+      source  = "pagopa-dx/azure"
+      version = "~>0"
+    }
   }
 }

--- a/infra/modules/azure_function_app_exposed/main.tf
+++ b/infra/modules/azure_function_app_exposed/main.tf
@@ -6,7 +6,7 @@ terraform {
     }
     dx = {
       source  = "pagopa-dx/azure"
-      version = ">= 0.0.5, < 1.0.0"
+      version = ">= 0.0.6, < 1.0.0"
     }
   }
 }

--- a/infra/modules/azure_function_app_exposed/main.tf
+++ b/infra/modules/azure_function_app_exposed/main.tf
@@ -6,7 +6,7 @@ terraform {
     }
     dx = {
       source  = "pagopa-dx/azure"
-      version = ">= 0.0.4, < 1.0.0"
+      version = ">= 0.0.5, < 1.0.0"
     }
   }
 }

--- a/infra/modules/azure_function_app_exposed/main.tf
+++ b/infra/modules/azure_function_app_exposed/main.tf
@@ -6,7 +6,7 @@ terraform {
     }
     dx = {
       source  = "pagopa-dx/azure"
-      version = "~>0"
+      version = "~>0.0"
     }
   }
 }

--- a/infra/modules/azure_function_app_exposed/tests/setup/README.md
+++ b/infra/modules/azure_function_app_exposed/tests/setup/README.md
@@ -6,7 +6,7 @@
 | Name | Version |
 |------|---------|
 | <a name="requirement_azurerm"></a> [azurerm](#requirement\_azurerm) | >= 3.100.0, < 5.0 |
-| <a name="requirement_dx"></a> [dx](#requirement\_dx) | ~>0 |
+| <a name="requirement_dx"></a> [dx](#requirement\_dx) | ~>0.0 |
 
 ## Modules
 

--- a/infra/modules/azure_function_app_exposed/tests/setup/README.md
+++ b/infra/modules/azure_function_app_exposed/tests/setup/README.md
@@ -6,7 +6,7 @@
 | Name | Version |
 |------|---------|
 | <a name="requirement_azurerm"></a> [azurerm](#requirement\_azurerm) | >= 3.100.0, < 5.0 |
-| <a name="requirement_dx"></a> [dx](#requirement\_dx) | ~>0.0 |
+| <a name="requirement_dx"></a> [dx](#requirement\_dx) | >= 0.0.5, < 1.0.0 |
 
 ## Modules
 

--- a/infra/modules/azure_function_app_exposed/tests/setup/README.md
+++ b/infra/modules/azure_function_app_exposed/tests/setup/README.md
@@ -6,7 +6,7 @@
 | Name | Version |
 |------|---------|
 | <a name="requirement_azurerm"></a> [azurerm](#requirement\_azurerm) | >= 3.100.0, < 5.0 |
-| <a name="requirement_dx"></a> [dx](#requirement\_dx) | >= 0.0.5, < 1.0.0 |
+| <a name="requirement_dx"></a> [dx](#requirement\_dx) | >= 0.0.6, < 1.0.0 |
 
 ## Modules
 

--- a/infra/modules/azure_function_app_exposed/tests/setup/README.md
+++ b/infra/modules/azure_function_app_exposed/tests/setup/README.md
@@ -6,12 +6,11 @@
 | Name | Version |
 |------|---------|
 | <a name="requirement_azurerm"></a> [azurerm](#requirement\_azurerm) | >= 3.100.0, < 5.0 |
+| <a name="requirement_dx"></a> [dx](#requirement\_dx) | ~>0 |
 
 ## Modules
 
-| Name | Source | Version |
-|------|--------|---------|
-| <a name="module_naming_convention"></a> [naming\_convention](#module\_naming\_convention) | ../../../azure_naming_convention | n/a |
+No modules.
 
 ## Resources
 

--- a/infra/modules/azure_function_app_exposed/tests/setup/main.tf
+++ b/infra/modules/azure_function_app_exposed/tests/setup/main.tf
@@ -4,36 +4,56 @@ terraform {
       source  = "hashicorp/azurerm"
       version = ">= 3.100.0, < 5.0"
     }
+    dx = {
+      source  = "pagopa-dx/azure"
+      version = "~>0"
+    }
   }
 }
 
-module "naming_convention" {
-  source = "../../../azure_naming_convention"
+locals {
+  naming_config = {
+    prefix      = var.environment.prefix,
+    environment = var.environment.env_short,
+    location = tomap({
+      "italynorth" = "itn",
+      "westeurope" = "weu"
+    })[var.environment.location]
+    name            = var.environment.app_name,
+    instance_number = tonumber(var.environment.instance_number),
+  }
 
-  environment = {
-    prefix          = var.environment.prefix
-    env_short       = var.environment.env_short
-    location        = var.environment.location
-    domain          = var.environment.domain
-    app_name        = var.environment.app_name
-    instance_number = var.environment.instance_number
+  virtual_network = {
+    name = provider::dx::resource_name(merge(local.naming_config, {
+      name          = "common",
+      resource_type = "virtual_network"
+    }))
+    resource_group_name = provider::dx::resource_name(merge(local.naming_config, {
+      name          = "network",
+      resource_type = "resource_group"
+    }))
   }
 }
 
 data "azurerm_virtual_network" "vnet" {
-  name                = "${module.naming_convention.project}-common-vnet-01"
-  resource_group_name = "${module.naming_convention.project}-network-rg-01"
+  name                = local.virtual_network.name
+  resource_group_name = local.virtual_network.resource_group_name
 }
 
 data "azurerm_subnet" "pep" {
-  name                 = "${module.naming_convention.project}-pep-snet-01"
-  virtual_network_name = "${module.naming_convention.project}-common-vnet-01"
-  resource_group_name  = "${module.naming_convention.project}-network-rg-01"
+  name = provider::dx::resource_name(merge(local.naming_config, {
+    name          = "pep",
+    resource_type = "subnet"
+  }))
+  virtual_network_name = data.azurerm_virtual_network.vnet.name
+  resource_group_name  = data.azurerm_virtual_network.vnet.resource_group_name
 }
 
 data "azurerm_resource_group" "rg" {
-  name = "${var.environment.prefix}-${var.environment.env_short}-itn-test-rg-${module.naming_convention.suffix}"
-
+  name = provider::dx::resource_name(merge(local.naming_config, {
+    name          = "test",
+    resource_type = "resource_group"
+  }))
 }
 
 output "pep_id" {

--- a/infra/modules/azure_function_app_exposed/tests/setup/main.tf
+++ b/infra/modules/azure_function_app_exposed/tests/setup/main.tf
@@ -6,19 +6,16 @@ terraform {
     }
     dx = {
       source  = "pagopa-dx/azure"
-      version = "~>0.0"
+      version = ">= 0.0.5, < 1.0.0"
     }
   }
 }
 
 locals {
   naming_config = {
-    prefix      = var.environment.prefix,
-    environment = var.environment.env_short,
-    location = tomap({
-      "italynorth" = "itn",
-      "westeurope" = "weu"
-    })[var.environment.location]
+    prefix          = var.environment.prefix,
+    environment     = var.environment.env_short,
+    location        = var.environment.location
     name            = var.environment.app_name,
     instance_number = tonumber(var.environment.instance_number),
   }

--- a/infra/modules/azure_function_app_exposed/tests/setup/main.tf
+++ b/infra/modules/azure_function_app_exposed/tests/setup/main.tf
@@ -6,7 +6,7 @@ terraform {
     }
     dx = {
       source  = "pagopa-dx/azure"
-      version = ">= 0.0.5, < 1.0.0"
+      version = ">= 0.0.6, < 1.0.0"
     }
   }
 }

--- a/infra/modules/azure_function_app_exposed/tests/setup/main.tf
+++ b/infra/modules/azure_function_app_exposed/tests/setup/main.tf
@@ -6,7 +6,7 @@ terraform {
     }
     dx = {
       source  = "pagopa-dx/azure"
-      version = "~>0"
+      version = "~>0.0"
     }
   }
 }


### PR DESCRIPTION
This PR removes all instances of the naming_convention module from the Function App and Function App Exposed modules. The functionality has been replaced with the new naming convention function provided by the `pagopa-dx/azure provider`.

Resolves: CES-915