### PR TITLE
Remove `naming_convention` inside Cosmos module in favor of `pagopa-dx/azure` provider function

### DIFF
--- a/.changeset/late-deers-serve.md
+++ b/.changeset/late-deers-serve.md
@@ -1,0 +1,5 @@
+---
+"azure_cosmos_account": patch
+---
+
+Replace naming convention module with DX provider functions

--- a/infra/modules/azure_cosmos_account/README.md
+++ b/infra/modules/azure_cosmos_account/README.md
@@ -31,12 +31,11 @@ For usage examples, refer to the [examples folder](https://github.com/pagopa-dx/
 | Name | Version |
 |------|---------|
 | <a name="requirement_azurerm"></a> [azurerm](#requirement\_azurerm) | >= 3.110, < 5.0 |
+| <a name="requirement_dx"></a> [dx](#requirement\_dx) | ~>0 |
 
 ## Modules
 
-| Name | Source | Version |
-|------|--------|---------|
-| <a name="module_naming_convention"></a> [naming\_convention](#module\_naming\_convention) | pagopa-dx/azure-naming-convention/azurerm | ~> 0.0 |
+No modules.
 
 ## Resources
 

--- a/infra/modules/azure_cosmos_account/cosmos.tf
+++ b/infra/modules/azure_cosmos_account/cosmos.tf
@@ -1,5 +1,5 @@
 resource "azurerm_cosmosdb_account" "this" {
-  name                          = "${module.naming_convention.prefix}-cosno-${module.naming_convention.suffix}"
+  name                          = provider::dx::resource_name(merge(local.naming_config, { resource_type = "cosmos_db_nosql" }))
   location                      = var.environment.location
   resource_group_name           = var.resource_group_name
   offer_type                    = "Standard" # It is a required field that can only be set to Standard

--- a/infra/modules/azure_cosmos_account/examples/complete/README.md
+++ b/infra/modules/azure_cosmos_account/examples/complete/README.md
@@ -6,6 +6,7 @@
 | Name | Version |
 |------|---------|
 | <a name="requirement_azurerm"></a> [azurerm](#requirement\_azurerm) | <= 4.10.0 |
+| <a name="requirement_dx"></a> [dx](#requirement\_dx) | ~>0 |
 
 ## Modules
 

--- a/infra/modules/azure_cosmos_account/examples/complete/data.tf
+++ b/infra/modules/azure_cosmos_account/examples/complete/data.tf
@@ -1,7 +1,11 @@
 data "azurerm_subnet" "pep" {
-  name                 = "${local.project}-pep-snet-01"
-  virtual_network_name = "${local.project}-common-vnet-01"
-  resource_group_name  = "${local.project}-network-rg-01"
+  name = provider::dx::resource_name(merge(local.naming_config, {
+    domain        = "",
+    name          = "pep",
+    resource_type = "subnet"
+  }))
+  virtual_network_name = local.virtual_network.name
+  resource_group_name  = local.virtual_network.resource_group_name
 }
 
 data "azurerm_monitor_action_group" "example" {

--- a/infra/modules/azure_cosmos_account/examples/complete/locals.tf
+++ b/infra/modules/azure_cosmos_account/examples/complete/locals.tf
@@ -16,7 +16,28 @@ locals {
   }
 
   location_short = lookup(local.location_map, local.environment.location, "itn")
-  project        = "${local.environment.prefix}-${local.environment.env_short}-${local.location_short}"
+
+  naming_config = {
+    prefix          = local.environment.prefix,
+    environment     = local.environment.env_short,
+    location        = local.location_short
+    domain          = local.environment.domain,
+    name            = local.environment.app_name,
+    instance_number = tonumber(local.environment.instance_number),
+  }
+
+  virtual_network = {
+    name = provider::dx::resource_name(merge(local.naming_config, {
+      domain        = "",
+      name          = "common",
+      resource_type = "virtual_network"
+    }))
+    resource_group_name = provider::dx::resource_name(merge(local.naming_config, {
+      domain        = "",
+      name          = "network",
+      resource_type = "resource_group"
+    }))
+  }
 
   tags = {
     CostCenter     = "TS000 - Tecnologia e Servizi"

--- a/infra/modules/azure_cosmos_account/examples/complete/main.tf
+++ b/infra/modules/azure_cosmos_account/examples/complete/main.tf
@@ -1,5 +1,8 @@
 resource "azurerm_resource_group" "example" {
-  name     = "${local.project}-${local.environment.domain}-example-rg-${local.environment.instance_number}"
+  name = provider::dx::resource_name(merge(local.naming_config, {
+    name          = "example",
+    resource_type = "resource_group"
+  }))
   location = local.environment.location
 }
 
@@ -15,8 +18,12 @@ module "cosmos_db" {
   environment         = local.environment
   resource_group_name = azurerm_resource_group.example.name
 
-  subnet_pep_id                        = data.azurerm_subnet.pep.id
-  private_dns_zone_resource_group_name = "${local.environment.prefix}-${local.environment.env_short}-itn-network-rg-01"
+  subnet_pep_id = data.azurerm_subnet.pep.id
+  private_dns_zone_resource_group_name = provider::dx::resource_name(merge(local.naming_config, {
+    domain        = "",
+    name          = "network",
+    resource_type = "resource_group"
+  }))
 
   primary_geo_location = {
     location       = local.environment.location

--- a/infra/modules/azure_cosmos_account/examples/complete/versions.tf
+++ b/infra/modules/azure_cosmos_account/examples/complete/versions.tf
@@ -12,6 +12,10 @@ terraform {
       source  = "hashicorp/azurerm"
       version = "<= 4.10.0"
     }
+    dx = {
+      source  = "pagopa-dx/azure"
+      version = "~>0"
+    }
   }
 }
 

--- a/infra/modules/azure_cosmos_account/examples/minimum/README.md
+++ b/infra/modules/azure_cosmos_account/examples/minimum/README.md
@@ -6,6 +6,7 @@
 | Name | Version |
 |------|---------|
 | <a name="requirement_azurerm"></a> [azurerm](#requirement\_azurerm) | <= 4.10.0 |
+| <a name="requirement_dx"></a> [dx](#requirement\_dx) | ~>0 |
 
 ## Modules
 

--- a/infra/modules/azure_cosmos_account/examples/minimum/data.tf
+++ b/infra/modules/azure_cosmos_account/examples/minimum/data.tf
@@ -1,9 +1,12 @@
 data "azurerm_subnet" "pep" {
-  name                 = "${local.project}-pep-snet-01"
-  virtual_network_name = "${local.project}-common-vnet-01"
-  resource_group_name  = "${local.project}-network-rg-01"
+  name = provider::dx::resource_name(merge(local.naming_config, {
+    domain        = "",
+    name          = "pep",
+    resource_type = "subnet"
+  }))
+  virtual_network_name = local.virtual_network.name
+  resource_group_name  = local.virtual_network.resource_group_name
 }
-
 data "azurerm_monitor_action_group" "example" {
   name                = replace("${local.environment.prefix}-${local.environment.env_short}-error", "-", "")
   resource_group_name = "${local.environment.prefix}-${local.environment.env_short}-rg-common"

--- a/infra/modules/azure_cosmos_account/examples/minimum/locals.tf
+++ b/infra/modules/azure_cosmos_account/examples/minimum/locals.tf
@@ -16,7 +16,28 @@ locals {
   }
 
   location_short = lookup(local.location_map, local.environment.location, "itn")
-  project        = "${local.environment.prefix}-${local.environment.env_short}-${local.location_short}"
+
+  naming_config = {
+    prefix          = local.environment.prefix,
+    environment     = local.environment.env_short,
+    location        = local.location_short
+    domain          = local.environment.domain,
+    name            = local.environment.app_name,
+    instance_number = tonumber(local.environment.instance_number),
+  }
+
+  virtual_network = {
+    name = provider::dx::resource_name(merge(local.naming_config, {
+      domain        = "",
+      name          = "common",
+      resource_type = "virtual_network"
+    }))
+    resource_group_name = provider::dx::resource_name(merge(local.naming_config, {
+      domain        = "",
+      name          = "network",
+      resource_type = "resource_group"
+    }))
+  }
 
   tags = {
     CostCenter     = "TS000 - Tecnologia e Servizi"

--- a/infra/modules/azure_cosmos_account/examples/minimum/main.tf
+++ b/infra/modules/azure_cosmos_account/examples/minimum/main.tf
@@ -1,5 +1,8 @@
 resource "azurerm_resource_group" "example" {
-  name     = "${local.project}-${local.environment.domain}-example-rg-${local.environment.instance_number}"
+  name = provider::dx::resource_name(merge(local.naming_config, {
+    name          = "example",
+    resource_type = "resource_group"
+  }))
   location = local.environment.location
 }
 

--- a/infra/modules/azure_cosmos_account/examples/minimum/versions.tf
+++ b/infra/modules/azure_cosmos_account/examples/minimum/versions.tf
@@ -12,6 +12,10 @@ terraform {
       source  = "hashicorp/azurerm"
       version = "<= 4.10.0"
     }
+    dx = {
+      source  = "pagopa-dx/azure"
+      version = "~>0"
+    }
   }
 }
 

--- a/infra/modules/azure_cosmos_account/locals.tf
+++ b/infra/modules/azure_cosmos_account/locals.tf
@@ -1,4 +1,16 @@
 locals {
+  naming_config = {
+    prefix      = var.environment.prefix,
+    environment = var.environment.env_short,
+    location = tomap({
+      "italynorth" = "itn",
+      "westeurope" = "weu"
+    })[var.environment.location]
+    domain          = var.environment.domain,
+    name            = var.environment.app_name,
+    instance_number = tonumber(var.environment.instance_number),
+  }
+
   primary_location = var.primary_geo_location.location == null ? var.environment.location : var.primary_geo_location.location
 
   consistency_presets = {
@@ -31,5 +43,4 @@ locals {
     max_interval_in_seconds = var.consistency_policy.consistency_level == "BoundedStaleness" ? var.consistency_policy.max_interval_in_seconds : null
     max_staleness_prefix    = var.consistency_policy.consistency_level == "BoundedStaleness" ? var.consistency_policy.max_staleness_prefix : null
   } : local.consistency_presets[local.selected_preset]
-
 }

--- a/infra/modules/azure_cosmos_account/main.tf
+++ b/infra/modules/azure_cosmos_account/main.tf
@@ -4,19 +4,9 @@ terraform {
       source  = "hashicorp/azurerm"
       version = ">= 3.110, < 5.0"
     }
-  }
-}
-
-module "naming_convention" {
-  source  = "pagopa-dx/azure-naming-convention/azurerm"
-  version = "~> 0.0"
-
-  environment = {
-    prefix          = var.environment.prefix
-    env_short       = var.environment.env_short
-    location        = var.environment.location
-    domain          = var.environment.domain
-    app_name        = var.environment.app_name
-    instance_number = var.environment.instance_number
+    dx = {
+      source  = "pagopa-dx/azure"
+      version = "~>0"
+    }
   }
 }

--- a/infra/modules/azure_cosmos_account/networking.tf
+++ b/infra/modules/azure_cosmos_account/networking.tf
@@ -2,13 +2,13 @@
 # Private endpoints
 #
 resource "azurerm_private_endpoint" "sql" {
-  name                = "${module.naming_convention.prefix}-cosno-pep-${module.naming_convention.suffix}"
+  name                = provider::dx::resource_name(merge(local.naming_config, { resource_type = "cosmos_private_endpoint" }))
   location            = var.environment.location
   resource_group_name = var.resource_group_name
   subnet_id           = var.subnet_pep_id
 
   private_service_connection {
-    name                           = "${module.naming_convention.prefix}-cosno-pep-${module.naming_convention.suffix}"
+    name                           = provider::dx::resource_name(merge(local.naming_config, { resource_type = "cosmos_private_endpoint" }))
     private_connection_resource_id = azurerm_cosmosdb_account.this.id
     is_manual_connection           = false
     subresource_names              = ["Sql"]

--- a/infra/modules/azure_cosmos_account/tests/setup/README.md
+++ b/infra/modules/azure_cosmos_account/tests/setup/README.md
@@ -6,12 +6,11 @@
 | Name | Version |
 |------|---------|
 | <a name="requirement_azurerm"></a> [azurerm](#requirement\_azurerm) | >= 3.110, < 5.0 |
+| <a name="requirement_dx"></a> [dx](#requirement\_dx) | ~>0 |
 
 ## Modules
 
-| Name | Source | Version |
-|------|--------|---------|
-| <a name="module_naming_convention"></a> [naming\_convention](#module\_naming\_convention) | ../../../azure_naming_convention | n/a |
+No modules.
 
 ## Resources
 

--- a/infra/modules/azure_cosmos_account/tests/setup/main.tf
+++ b/infra/modules/azure_cosmos_account/tests/setup/main.tf
@@ -4,30 +4,56 @@ terraform {
       source  = "hashicorp/azurerm"
       version = ">= 3.110, < 5.0"
     }
+    dx = {
+      source  = "pagopa-dx/azure"
+      version = "~>0"
+    }
   }
 }
 
-module "naming_convention" {
-  source = "../../../azure_naming_convention"
-
-  environment = {
-    prefix          = var.environment.prefix
-    env_short       = var.environment.env_short
-    location        = var.environment.location
-    domain          = var.environment.domain
-    app_name        = var.environment.app_name
-    instance_number = var.environment.instance_number
+locals {
+  naming_config = {
+    prefix      = var.environment.prefix,
+    environment = var.environment.env_short,
+    location = tomap({
+      "italynorth" = "itn",
+      "westeurope" = "weu"
+    })[var.environment.location]
+    domain          = var.environment.domain,
+    name            = var.environment.app_name,
+    instance_number = tonumber(var.environment.instance_number),
   }
-}
 
-data "azurerm_subnet" "pep" {
-  name                 = "${module.naming_convention.project}-pep-snet-01"
-  virtual_network_name = "${module.naming_convention.project}-common-vnet-01"
-  resource_group_name  = "${module.naming_convention.project}-network-rg-01"
+  virtual_network = {
+    name = provider::dx::resource_name(merge(local.naming_config, {
+      domain        = "",
+      name          = "common",
+      resource_type = "virtual_network"
+    }))
+    resource_group_name = provider::dx::resource_name(merge(local.naming_config, {
+      domain        = "",
+      name          = "network",
+      resource_type = "resource_group"
+    }))
+  }
 }
 
 data "azurerm_resource_group" "rg" {
-  name = "${var.environment.prefix}-${var.environment.env_short}-itn-test-rg-${module.naming_convention.suffix}"
+  name = provider::dx::resource_name(merge(local.naming_config, {
+    domain        = "",
+    name          = "test",
+    resource_type = "resource_group"
+  }))
+}
+
+data "azurerm_subnet" "pep" {
+  name = provider::dx::resource_name(merge(local.naming_config, {
+    domain        = "",
+    name          = "pep",
+    resource_type = "subnet"
+  }))
+  virtual_network_name = local.virtual_network.name
+  resource_group_name  = local.virtual_network.resource_group_name
 }
 
 output "pep_id" {
@@ -39,5 +65,5 @@ output "resource_group_name" {
 }
 
 output "pvt_service_connection_name" {
-  value = "${module.naming_convention.prefix}-cosno-pep-${module.naming_convention.suffix}"
+  value = provider::dx::resource_name(merge(local.naming_config, { resource_type = "cosmos_private_endpoint" }))
 }


### PR DESCRIPTION
This PR removes all instances of the naming_convention module from the Cosmos module. The functionality has been replaced with the new naming convention function provided by the pagopa-dx/azure provider.

Resolves: CES-918