### PR TITLE
Add secret support to Container App module

### DIFF
--- a/.changeset/twelve-planes-repeat.md
+++ b/.changeset/twelve-planes-repeat.md
@@ -1,0 +1,5 @@
+---
+"azure_container_app": minor
+---
+
+Add support to secrets with KeyVault reference

--- a/infra/modules/azure_container_app/README.md
+++ b/infra/modules/azure_container_app/README.md
@@ -53,8 +53,9 @@ A complete usage example can be found in the [example/complete](https://github.c
 | <a name="input_environment"></a> [environment](#input\_environment) | Values which are used to generate resource names and location short names. They are all mandatory except for domain, which should not be used only in the case of a resource used by multiple domains. | <pre>object({<br/>    prefix          = string<br/>    env_short       = string<br/>    location        = string<br/>    domain          = optional(string)<br/>    app_name        = string<br/>    instance_number = string<br/>  })</pre> | n/a | yes |
 | <a name="input_resource_group_name"></a> [resource\_group\_name](#input\_resource\_group\_name) | Resource group to deploy resources to | `string` | n/a | yes |
 | <a name="input_revision_mode"></a> [revision\_mode](#input\_revision\_mode) | The revision mode for the container app. Valid values are 'Single' and 'Multiple'. | `string` | `"Multiple"` | no |
+| <a name="input_secrets"></a> [secrets](#input\_secrets) | Key Vault secret references to be used in all the containers of this Container App. | <pre>list(object({<br/>    name                = string<br/>    key_vault_secret_id = string<br/>  }))</pre> | `[]` | no |
 | <a name="input_tags"></a> [tags](#input\_tags) | Resources tags | `map(any)` | n/a | yes |
-| <a name="input_target_port"></a> [target\_port](#input\_target\_port) | The target port for the container app. | `number` | `8080` | no |
+| <a name="input_target_port"></a> [target\_port](#input\_target\_port) | The target port for the Container App. | `number` | `8080` | no |
 | <a name="input_tier"></a> [tier](#input\_tier) | The offer type for the Container. Valid values are 'xs', 's', 'm' and 'l'. | `string` | `"s"` | no |
 
 ## Outputs

--- a/infra/modules/azure_container_app/container_app.tf
+++ b/infra/modules/azure_container_app/container_app.tf
@@ -22,7 +22,7 @@ resource "azurerm_container_app" "this" {
   dynamic "secret" {
     for_each = var.secrets
     content {
-      name                = secret.value.name
+      name                = lower(secret.value.name)
       key_vault_secret_id = secret.value.key_vault_secret_id
       identity            = "System"
     }
@@ -55,7 +55,7 @@ resource "azurerm_container_app" "this" {
 
           content {
             name        = env.value.name
-            secret_name = env.value.name
+            secret_name = lower(env.value.name)
           }
         }
 

--- a/infra/modules/azure_container_app/container_app.tf
+++ b/infra/modules/azure_container_app/container_app.tf
@@ -19,6 +19,15 @@ resource "azurerm_container_app" "this" {
     }
   }
 
+  dynamic "secret" {
+    for_each = var.secrets
+    content {
+      name                = secret.value.name
+      key_vault_secret_id = secret.value.key_vault_secret_id
+      identity            = "System"
+    }
+  }
+
   template {
     min_replicas = local.sku.replicas.min
     max_replicas = local.sku.replicas.max
@@ -38,6 +47,15 @@ resource "azurerm_container_app" "this" {
           content {
             name  = env.key
             value = env.value
+          }
+        }
+
+        dynamic "env" {
+          for_each = var.secrets
+
+          content {
+            name        = env.value.name
+            secret_name = env.value.name
           }
         }
 

--- a/infra/modules/azure_container_app/tests/containerapp.tftest.hcl
+++ b/infra/modules/azure_container_app/tests/containerapp.tftest.hcl
@@ -81,7 +81,7 @@ run "container_app_is_correct_plan" {
     condition = length([
       for env in azurerm_container_app.this.template[0].container[0].env :
       env if env.secret_name == null
-    ]) == 2
+    ]) == 2 # number of settings set above
     error_message = "The number of variables in the container app is not correct"
   }
 
@@ -89,7 +89,7 @@ run "container_app_is_correct_plan" {
     condition = length([
       for env in azurerm_container_app.this.template[0].container[0].env :
       env if env.secret_name != null
-    ]) == 2
+    ]) == 2 # number of secrets set above
     error_message = "The number of secrets set as variables in the container app is not correct"
   }
 

--- a/infra/modules/azure_container_app/tests/setup/README.md
+++ b/infra/modules/azure_container_app/tests/setup/README.md
@@ -17,7 +17,10 @@
 
 | Name | Type |
 |------|------|
+| [azurerm_key_vault_secret.test1](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/key_vault_secret) | resource |
+| [azurerm_key_vault_secret.test2](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/key_vault_secret) | resource |
 | [azurerm_container_app_environment.cae](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/data-sources/container_app_environment) | data source |
+| [azurerm_key_vault.kv](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/data-sources/key_vault) | data source |
 | [azurerm_log_analytics_workspace.logs](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/data-sources/log_analytics_workspace) | data source |
 | [azurerm_resource_group.rg](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/data-sources/resource_group) | data source |
 
@@ -32,6 +35,8 @@
 | Name | Description |
 |------|-------------|
 | <a name="output_container_app_environment_id"></a> [container\_app\_environment\_id](#output\_container\_app\_environment\_id) | n/a |
+| <a name="output_key_vault_secret1"></a> [key\_vault\_secret1](#output\_key\_vault\_secret1) | n/a |
+| <a name="output_key_vault_secret2"></a> [key\_vault\_secret2](#output\_key\_vault\_secret2) | n/a |
 | <a name="output_log_analytics_id"></a> [log\_analytics\_id](#output\_log\_analytics\_id) | n/a |
 | <a name="output_resource_group_name"></a> [resource\_group\_name](#output\_resource\_group\_name) | n/a |
 <!-- END_TF_DOCS -->

--- a/infra/modules/azure_container_app/tests/setup/README.md
+++ b/infra/modules/azure_container_app/tests/setup/README.md
@@ -39,4 +39,5 @@
 | <a name="output_key_vault_secret2"></a> [key\_vault\_secret2](#output\_key\_vault\_secret2) | n/a |
 | <a name="output_log_analytics_id"></a> [log\_analytics\_id](#output\_log\_analytics\_id) | n/a |
 | <a name="output_resource_group_name"></a> [resource\_group\_name](#output\_resource\_group\_name) | n/a |
+| <a name="output_tags"></a> [tags](#output\_tags) | n/a |
 <!-- END_TF_DOCS -->

--- a/infra/modules/azure_container_app/tests/setup/main.tf
+++ b/infra/modules/azure_container_app/tests/setup/main.tf
@@ -34,6 +34,27 @@ data "azurerm_container_app_environment" "cae" {
   resource_group_name = "${var.environment.prefix}-${var.environment.env_short}-itn-github-runner-rg-${module.naming_convention.suffix}"
 }
 
+data "azurerm_key_vault" "kv" {
+  name                = "${var.environment.prefix}-${var.environment.env_short}-itn-common-kv-${module.naming_convention.suffix}"
+  resource_group_name = "${var.environment.prefix}-${var.environment.env_short}-itn-common-rg-${module.naming_convention.suffix}"
+}
+
+resource "azurerm_key_vault_secret" "test1" {
+  name            = "TESTSECRET1"
+  value           = "value1"
+  key_vault_id    = data.azurerm_key_vault.kv.id
+  expiration_date = timeadd(timestamp(), "30m")
+  content_type    = "application/text"
+}
+
+resource "azurerm_key_vault_secret" "test2" {
+  name            = "TESTSECRET2"
+  value           = "value2"
+  key_vault_id    = data.azurerm_key_vault.kv.id
+  expiration_date = timeadd(timestamp(), "30m")
+  content_type    = "application/text"
+}
+
 output "resource_group_name" {
   value = data.azurerm_resource_group.rg.name
 }
@@ -44,4 +65,18 @@ output "log_analytics_id" {
 
 output "container_app_environment_id" {
   value = data.azurerm_container_app_environment.cae.id
+}
+
+output "key_vault_secret1" {
+  value = {
+    secret_id = azurerm_key_vault_secret.test1.versionless_id
+    name      = azurerm_key_vault_secret.test1.name
+  }
+}
+
+output "key_vault_secret2" {
+  value = {
+    secret_id = azurerm_key_vault_secret.test2.versionless_id
+    name      = azurerm_key_vault_secret.test2.name
+  }
 }

--- a/infra/modules/azure_container_app/tests/setup/main.tf
+++ b/infra/modules/azure_container_app/tests/setup/main.tf
@@ -7,6 +7,19 @@ terraform {
   }
 }
 
+locals {
+  tags = {
+    CostCenter     = "TS000 - Tecnologia e Servizi"
+    CreatedBy      = "Terraform"
+    Environment    = "Dev"
+    BusinessUnit   = "DevEx"
+    Source         = "https://github.com/pagopa/dx/blob/main/infra/modules/azure_container_app/tests"
+    ManagementTeam = "Developer Experience"
+    Test           = "true"
+    TestName       = "Create Container App for test"
+  }
+}
+
 module "naming_convention" {
   source = "../../../azure_naming_convention"
 
@@ -79,4 +92,8 @@ output "key_vault_secret2" {
     secret_id = azurerm_key_vault_secret.test2.versionless_id
     name      = azurerm_key_vault_secret.test2.name
   }
+}
+
+output "tags" {
+  value = local.tags
 }

--- a/infra/modules/azure_container_app/variables.tf
+++ b/infra/modules/azure_container_app/variables.tf
@@ -54,8 +54,17 @@ variable "revision_mode" {
 
 variable "target_port" {
   type        = number
-  description = "The target port for the container app."
+  description = "The target port for the Container App."
   default     = 8080
+}
+
+variable "secrets" {
+  type = list(object({
+    name                = string
+    key_vault_secret_id = string
+  }))
+  default     = []
+  description = "Key Vault secret references to be used in all the containers of this Container App."
 }
 
 variable "container_app_templates" {

--- a/infra/resources/dev/README.md
+++ b/infra/resources/dev/README.md
@@ -10,7 +10,9 @@
 
 ## Providers
 
-No providers.
+| Name | Version |
+|------|---------|
+| <a name="provider_azurerm"></a> [azurerm](#provider\_azurerm) | 4.22.0 |
 
 ## Modules
 
@@ -20,7 +22,12 @@ No providers.
 
 ## Resources
 
-No resources.
+| Name | Type |
+|------|------|
+| [azurerm_role_assignment.kv_cd](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/role_assignment) | resource |
+| [azurerm_role_assignment.kv_ci](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/role_assignment) | resource |
+| [azurerm_user_assigned_identity.infra_dev_cd](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/data-sources/user_assigned_identity) | data source |
+| [azurerm_user_assigned_identity.infra_dev_ci](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/data-sources/user_assigned_identity) | data source |
 
 ## Inputs
 

--- a/infra/resources/dev/data.tf
+++ b/infra/resources/dev/data.tf
@@ -1,0 +1,9 @@
+data "azurerm_user_assigned_identity" "infra_dev_ci" {
+  name                = "${local.project}-github-ci-identity"
+  resource_group_name = "${local.project}-identity-rg"
+}
+
+data "azurerm_user_assigned_identity" "infra_dev_cd" {
+  name                = "${local.project}-github-cd-identity"
+  resource_group_name = "${local.project}-identity-rg"
+}

--- a/infra/resources/dev/locals.tf
+++ b/infra/resources/dev/locals.tf
@@ -2,6 +2,7 @@ locals {
   prefix    = "dx"
   env_short = "d"
   location  = "italynorth"
+  project   = "${local.prefix}-${local.env_short}"
 
   tags = {
     CostCenter     = "TS000 - Tecnologia e Servizi"

--- a/infra/resources/dev/main.tf
+++ b/infra/resources/dev/main.tf
@@ -45,3 +45,17 @@ module "core" {
 
   tags = local.tags
 }
+
+resource "azurerm_role_assignment" "kv_ci" {
+  scope                = module.core.common_key_vault.id
+  role_definition_name = "Key Vault Secrets Officer"
+  principal_id         = data.azurerm_user_assigned_identity.infra_dev_ci.principal_id
+  description          = "Allow CI identity to access Key Vault secrets"
+}
+
+resource "azurerm_role_assignment" "kv_cd" {
+  scope                = module.core.common_key_vault.id
+  role_definition_name = "Key Vault Secrets Officer"
+  principal_id         = data.azurerm_user_assigned_identity.infra_dev_cd.principal_id
+  description          = "Allow CD identity to access Key Vault secrets"
+}

--- a/infra/resources/dev/tfmodules.lock.json
+++ b/infra/resources/dev/tfmodules.lock.json
@@ -1,4 +1,4 @@
 {
-  "core.naming_convention": "5b1d21788783dcf33e17a9842f9f7c874c8c5f736c82e70979eb9c8785a74ce4",
-  "core.naming_convention_gh_runner": "5b1d21788783dcf33e17a9842f9f7c874c8c5f736c82e70979eb9c8785a74ce4"
+  "core.naming_convention": "c71cfaa7ccaebb4dab588075d332bc788c21dc833f872218079e816c832aae69",
+  "core.naming_convention_gh_runner": "c71cfaa7ccaebb4dab588075d332bc788c21dc833f872218079e816c832aae69"
 }


### PR DESCRIPTION
Container App module now supports secrets.

Secrets are only supported by using KeyVault references, as best practices suggests. The Container App should have roles to read secrets from KV.

Closes CES-927