### PR TITLE
Remove `naming_convention` inside PostgreSQL module in favor of `pagopa-dx/azure` provider function

### DIFF
--- a/.changeset/clean-dancers-burn.md
+++ b/.changeset/clean-dancers-burn.md
@@ -1,0 +1,5 @@
+---
+"azure_postgres_server": patch
+---
+
+Replace naming convention module with DX provider functions

--- a/infra/modules/azure_postgres_server/README.md
+++ b/infra/modules/azure_postgres_server/README.md
@@ -32,7 +32,7 @@ A complete example of how to use this module can be found in the [example/comple
 | Name | Version |
 |------|---------|
 | <a name="requirement_azurerm"></a> [azurerm](#requirement\_azurerm) | >= 3.116, < 5.0 |
-| <a name="requirement_dx"></a> [dx](#requirement\_dx) | >= 0.0.5, < 1.0.0 |
+| <a name="requirement_dx"></a> [dx](#requirement\_dx) | >= 0.0.6, < 1.0.0 |
 
 ## Modules
 

--- a/infra/modules/azure_postgres_server/README.md
+++ b/infra/modules/azure_postgres_server/README.md
@@ -32,12 +32,11 @@ A complete example of how to use this module can be found in the [example/comple
 | Name | Version |
 |------|---------|
 | <a name="requirement_azurerm"></a> [azurerm](#requirement\_azurerm) | >= 3.116, < 5.0 |
+| <a name="requirement_dx"></a> [dx](#requirement\_dx) | ~>0.0 |
 
 ## Modules
 
-| Name | Source | Version |
-|------|--------|---------|
-| <a name="module_naming_convention"></a> [naming\_convention](#module\_naming\_convention) | pagopa-dx/azure-naming-convention/azurerm | ~> 0.0 |
+No modules.
 
 ## Resources
 

--- a/infra/modules/azure_postgres_server/README.md
+++ b/infra/modules/azure_postgres_server/README.md
@@ -32,7 +32,7 @@ A complete example of how to use this module can be found in the [example/comple
 | Name | Version |
 |------|---------|
 | <a name="requirement_azurerm"></a> [azurerm](#requirement\_azurerm) | >= 3.116, < 5.0 |
-| <a name="requirement_dx"></a> [dx](#requirement\_dx) | ~>0.0 |
+| <a name="requirement_dx"></a> [dx](#requirement\_dx) | >= 0.0.4, < 1.0.0 |
 
 ## Modules
 

--- a/infra/modules/azure_postgres_server/README.md
+++ b/infra/modules/azure_postgres_server/README.md
@@ -32,7 +32,7 @@ A complete example of how to use this module can be found in the [example/comple
 | Name | Version |
 |------|---------|
 | <a name="requirement_azurerm"></a> [azurerm](#requirement\_azurerm) | >= 3.116, < 5.0 |
-| <a name="requirement_dx"></a> [dx](#requirement\_dx) | >= 0.0.4, < 1.0.0 |
+| <a name="requirement_dx"></a> [dx](#requirement\_dx) | >= 0.0.5, < 1.0.0 |
 
 ## Modules
 

--- a/infra/modules/azure_postgres_server/example/complete/README.md
+++ b/infra/modules/azure_postgres_server/example/complete/README.md
@@ -6,7 +6,7 @@
 | Name | Version |
 |------|---------|
 | <a name="requirement_azurerm"></a> [azurerm](#requirement\_azurerm) | >= 3.116, < 5.0 |
-| <a name="requirement_dx"></a> [dx](#requirement\_dx) | ~>0.0 |
+| <a name="requirement_dx"></a> [dx](#requirement\_dx) | >= 0.0.5, < 1.0.0 |
 
 ## Modules
 

--- a/infra/modules/azure_postgres_server/example/complete/README.md
+++ b/infra/modules/azure_postgres_server/example/complete/README.md
@@ -6,7 +6,7 @@
 | Name | Version |
 |------|---------|
 | <a name="requirement_azurerm"></a> [azurerm](#requirement\_azurerm) | >= 3.116, < 5.0 |
-| <a name="requirement_dx"></a> [dx](#requirement\_dx) | >= 0.0.5, < 1.0.0 |
+| <a name="requirement_dx"></a> [dx](#requirement\_dx) | >= 0.0.6, < 1.0.0 |
 
 ## Modules
 

--- a/infra/modules/azure_postgres_server/example/complete/README.md
+++ b/infra/modules/azure_postgres_server/example/complete/README.md
@@ -6,6 +6,7 @@
 | Name | Version |
 |------|---------|
 | <a name="requirement_azurerm"></a> [azurerm](#requirement\_azurerm) | >= 3.116, < 5.0 |
+| <a name="requirement_dx"></a> [dx](#requirement\_dx) | ~>0.0 |
 
 ## Modules
 

--- a/infra/modules/azure_postgres_server/example/complete/locals.tf
+++ b/infra/modules/azure_postgres_server/example/complete/locals.tf
@@ -9,12 +9,9 @@ locals {
   }
 
   naming_config = {
-    prefix      = local.environment.prefix,
-    environment = local.environment.env_short,
-    location = tomap({
-      "italynorth" = "itn",
-      "westeurope" = "weu"
-    })[local.environment.location]
+    prefix          = local.environment.prefix,
+    environment     = local.environment.env_short,
+    location        = local.environment.location
     domain          = local.environment.domain,
     name            = local.environment.app_name,
     instance_number = tonumber(local.environment.instance_number),

--- a/infra/modules/azure_postgres_server/example/complete/locals.tf
+++ b/infra/modules/azure_postgres_server/example/complete/locals.tf
@@ -8,13 +8,37 @@ locals {
     instance_number = "01"
   }
 
-  project = module.naming_convention.project
+  naming_config = {
+    prefix      = local.environment.prefix,
+    environment = local.environment.env_short,
+    location = tomap({
+      "italynorth" = "itn",
+      "westeurope" = "weu"
+    })[local.environment.location]
+    domain          = local.environment.domain,
+    name            = local.environment.app_name,
+    instance_number = tonumber(local.environment.instance_number),
+  }
+
+  virtual_network = {
+    name = provider::dx::resource_name(merge(local.naming_config, {
+      domain        = "",
+      name          = "common",
+      resource_type = "virtual_network"
+    }))
+    resource_group_name = provider::dx::resource_name(merge(local.naming_config, {
+      domain        = "",
+      name          = "network",
+      resource_type = "resource_group"
+    }))
+  }
 
   tags = {
-    CreatedBy   = "Terraform"
-    Environment = "Dev"
-    Owner       = "DevEx"
-    Source      = "https://github.com/pagopa/dx/modules/azure_postgres_server/examples/complete"
-    CostCenter  = "TS700 - ENGINEERING"
+    CostCenter     = "TS000 - Tecnologia e Servizi"
+    CreatedBy      = "Terraform"
+    Environment    = "Dev"
+    BusinessUnit   = "DevEx"
+    Source         = "https://github.com/pagopa/dx/modules/azure_postgres_server/examples/complete"
+    ManagementTeam = "Developer Experience"
   }
 }

--- a/infra/modules/azure_postgres_server/example/complete/main.tf
+++ b/infra/modules/azure_postgres_server/example/complete/main.tf
@@ -16,7 +16,7 @@ resource "azurerm_resource_group" "example" {
 
 data "azurerm_subnet" "pep" {
   name = provider::dx::resource_name(merge(local.naming_config, {
-    domain        = "",
+    domain        = null,
     name          = "pep",
     resource_type = "subnet"
   }))
@@ -31,11 +31,11 @@ resource "random_password" "password" {
 }
 
 resource "azurerm_key_vault" "example" {
-  name = replace(provider::dx::resource_name(merge(local.naming_config, {
-    domain        = "",
-    name          = "key_vault",
+  name = provider::dx::resource_name(merge(local.naming_config, {
+    domain        = null,
+    name          = "example",
     resource_type = "key_vault"
-  })), "-key_vault-", "-")
+  }))
   location            = local.environment.location
   resource_group_name = azurerm_resource_group.example.name
   sku_name            = "standard"

--- a/infra/modules/azure_postgres_server/example/complete/main.tf
+++ b/infra/modules/azure_postgres_server/example/complete/main.tf
@@ -7,14 +7,21 @@ module "naming_convention" {
 data "azurerm_client_config" "current" {}
 
 resource "azurerm_resource_group" "example" {
-  name     = "${local.project}-${local.environment.domain}-rg-${local.environment.instance_number}"
+  name = provider::dx::resource_name(merge(local.naming_config, {
+    name          = "example",
+    resource_type = "resource_group"
+  }))
   location = local.environment.location
 }
 
 data "azurerm_subnet" "pep" {
-  name                 = "${local.project}-pep-snet-01"
-  virtual_network_name = "${local.project}-common-vnet-01"
-  resource_group_name  = "${local.project}-network-rg-01"
+  name = provider::dx::resource_name(merge(local.naming_config, {
+    domain        = "",
+    name          = "pep",
+    resource_type = "subnet"
+  }))
+  virtual_network_name = local.virtual_network.name
+  resource_group_name  = local.virtual_network.resource_group_name
 }
 
 # tflint-ignore: terraform_required_providers
@@ -24,7 +31,11 @@ resource "random_password" "password" {
 }
 
 resource "azurerm_key_vault" "example" {
-  name                = "${local.project}-kv-01"
+  name = replace(provider::dx::resource_name(merge(local.naming_config, {
+    domain        = "",
+    name          = "key_vault",
+    resource_type = "key_vault"
+  })), "-key_vault-", "-")
   location            = local.environment.location
   resource_group_name = azurerm_resource_group.example.name
   sku_name            = "standard"
@@ -51,7 +62,7 @@ resource "azurerm_key_vault" "example" {
 }
 
 resource "azurerm_key_vault_secret" "postgres_username" {
-  name            = "${local.project}-postgres-username"
+  name            = "${provider::dx::resource_name(merge(local.naming_config, { resource_type = "postgresql" }))}-username"
   value           = "test_user"
   key_vault_id    = azurerm_key_vault.example.id
   content_type    = "text"
@@ -59,7 +70,7 @@ resource "azurerm_key_vault_secret" "postgres_username" {
 }
 
 resource "azurerm_key_vault_secret" "postgres_password" {
-  name            = "${local.project}-postgres-password"
+  name            = "${provider::dx::resource_name(merge(local.naming_config, { resource_type = "postgresql" }))}-password"
   value           = random_password.password.result
   key_vault_id    = azurerm_key_vault.example.id
   content_type    = "password"
@@ -71,7 +82,7 @@ module "azure_postgres" {
 
   environment                          = local.environment
   resource_group_name                  = azurerm_resource_group.example.name
-  private_dns_zone_resource_group_name = "${local.project}-network-rg-01"
+  private_dns_zone_resource_group_name = local.virtual_network.resource_group_name
 
   tier = "s"
 

--- a/infra/modules/azure_postgres_server/example/complete/versions.tf
+++ b/infra/modules/azure_postgres_server/example/complete/versions.tf
@@ -12,6 +12,10 @@ terraform {
       source  = "hashicorp/azurerm"
       version = ">= 3.116, < 5.0"
     }
+    dx = {
+      source  = "pagopa-dx/azure"
+      version = "~>0.0"
+    }
   }
 }
 

--- a/infra/modules/azure_postgres_server/example/complete/versions.tf
+++ b/infra/modules/azure_postgres_server/example/complete/versions.tf
@@ -14,7 +14,7 @@ terraform {
     }
     dx = {
       source  = "pagopa-dx/azure"
-      version = "~>0.0"
+      version = ">= 0.0.5, < 1.0.0"
     }
   }
 }

--- a/infra/modules/azure_postgres_server/example/complete/versions.tf
+++ b/infra/modules/azure_postgres_server/example/complete/versions.tf
@@ -14,7 +14,7 @@ terraform {
     }
     dx = {
       source  = "pagopa-dx/azure"
-      version = ">= 0.0.5, < 1.0.0"
+      version = ">= 0.0.6, < 1.0.0"
     }
   }
 }

--- a/infra/modules/azure_postgres_server/locals.tf
+++ b/infra/modules/azure_postgres_server/locals.tf
@@ -1,7 +1,19 @@
 locals {
+  naming_config = {
+    prefix      = var.environment.prefix,
+    environment = var.environment.env_short,
+    location = tomap({
+      "italynorth" = "itn",
+      "westeurope" = "weu"
+    })[var.environment.location]
+    domain          = var.environment.domain,
+    name            = var.environment.app_name,
+    instance_number = tonumber(var.environment.instance_number),
+  }
+
   db = {
-    name         = "${module.naming_convention.prefix}-psql-${module.naming_convention.suffix}"
-    replica_name = var.tier == "l" ? "${module.naming_convention.prefix}-psql-replica-${module.naming_convention.suffix}" : null
+    name         = provider::dx::resource_name(merge(local.naming_config, { resource_type = "postgresql" }))
+    replica_name = var.tier == "l" ? provider::dx::resource_name(merge(local.naming_config, { resource_type = "postgresq_replica" })) : null
     sku_name = lookup(
       {
         "s" = "B_Standard_B1ms",

--- a/infra/modules/azure_postgres_server/locals.tf
+++ b/infra/modules/azure_postgres_server/locals.tf
@@ -13,7 +13,7 @@ locals {
 
   db = {
     name         = provider::dx::resource_name(merge(local.naming_config, { resource_type = "postgresql" }))
-    replica_name = var.tier == "l" ? provider::dx::resource_name(merge(local.naming_config, { resource_type = "postgresq_replica" })) : null
+    replica_name = var.tier == "l" ? provider::dx::resource_name(merge(local.naming_config, { resource_type = "postgresql_replica" })) : null
     sku_name = lookup(
       {
         "s" = "B_Standard_B1ms",

--- a/infra/modules/azure_postgres_server/locals.tf
+++ b/infra/modules/azure_postgres_server/locals.tf
@@ -1,11 +1,8 @@
 locals {
   naming_config = {
-    prefix      = var.environment.prefix,
-    environment = var.environment.env_short,
-    location = tomap({
-      "italynorth" = "itn",
-      "westeurope" = "weu"
-    })[var.environment.location]
+    prefix          = var.environment.prefix,
+    environment     = var.environment.env_short,
+    location        = var.environment.location
     domain          = var.environment.domain,
     name            = var.environment.app_name,
     instance_number = tonumber(var.environment.instance_number),

--- a/infra/modules/azure_postgres_server/main.tf
+++ b/infra/modules/azure_postgres_server/main.tf
@@ -6,7 +6,7 @@ terraform {
     }
     dx = {
       source  = "pagopa-dx/azure"
-      version = ">= 0.0.5, < 1.0.0"
+      version = ">= 0.0.6, < 1.0.0"
     }
 
   }

--- a/infra/modules/azure_postgres_server/main.tf
+++ b/infra/modules/azure_postgres_server/main.tf
@@ -4,20 +4,11 @@ terraform {
       source  = "hashicorp/azurerm"
       version = ">= 3.116, < 5.0"
     }
-  }
-}
+    dx = {
+      source  = "pagopa-dx/azure"
+      version = "~>0.0"
+    }
 
-module "naming_convention" {
-  source  = "pagopa-dx/azure-naming-convention/azurerm"
-  version = "~> 0.0"
-
-  environment = {
-    prefix          = var.environment.prefix
-    env_short       = var.environment.env_short
-    location        = var.environment.location
-    domain          = var.environment.domain
-    app_name        = var.environment.app_name
-    instance_number = var.environment.instance_number
   }
 }
 

--- a/infra/modules/azure_postgres_server/main.tf
+++ b/infra/modules/azure_postgres_server/main.tf
@@ -8,7 +8,6 @@ terraform {
       source  = "pagopa-dx/azure"
       version = ">= 0.0.6, < 1.0.0"
     }
-
   }
 }
 

--- a/infra/modules/azure_postgres_server/main.tf
+++ b/infra/modules/azure_postgres_server/main.tf
@@ -6,7 +6,7 @@ terraform {
     }
     dx = {
       source  = "pagopa-dx/azure"
-      version = "~>0.0"
+      version = ">= 0.0.4, < 1.0.0"
     }
 
   }

--- a/infra/modules/azure_postgres_server/main.tf
+++ b/infra/modules/azure_postgres_server/main.tf
@@ -6,7 +6,7 @@ terraform {
     }
     dx = {
       source  = "pagopa-dx/azure"
-      version = ">= 0.0.4, < 1.0.0"
+      version = ">= 0.0.5, < 1.0.0"
     }
 
   }

--- a/infra/modules/azure_postgres_server/network.tf
+++ b/infra/modules/azure_postgres_server/network.tf
@@ -1,11 +1,11 @@
 resource "azurerm_private_endpoint" "postgre_pep" {
-  name                = "${module.naming_convention.prefix}-psql-pep-${module.naming_convention.suffix}"
+  name                = provider::dx::resource_name(merge(local.naming_config, { resource_type = "postgre_private_endpoint" }))
   location            = var.environment.location
   resource_group_name = var.resource_group_name
   subnet_id           = var.subnet_pep_id
 
   private_service_connection {
-    name                           = "${module.naming_convention.prefix}-psql-pep-${module.naming_convention.suffix}"
+    name                           = provider::dx::resource_name(merge(local.naming_config, { resource_type = "postgre_private_endpoint" }))
     private_connection_resource_id = azurerm_postgresql_flexible_server.this.id
     is_manual_connection           = false
     subresource_names              = ["postgresqlServer"]
@@ -26,13 +26,13 @@ resource "azurerm_private_endpoint" "postgre_pep" {
 resource "azurerm_private_endpoint" "replica_postgre_pep" {
   count = var.tier == "l" ? 1 : 0
 
-  name                = "${module.naming_convention.prefix}-psql-pep-replica-${module.naming_convention.suffix}"
+  name                = provider::dx::resource_name(merge(local.naming_config, { resource_type = "postgre_replica_private_endpoint" }))
   location            = var.environment.location
   resource_group_name = var.resource_group_name
   subnet_id           = var.subnet_pep_id
 
   private_service_connection {
-    name                           = "${module.naming_convention.prefix}-psql-pep-replica-${module.naming_convention.suffix}"
+    name                           = provider::dx::resource_name(merge(local.naming_config, { resource_type = "postgre_replica_private_endpoint" }))
     private_connection_resource_id = azurerm_postgresql_flexible_server.replica[0].id
     is_manual_connection           = false
     subresource_names              = ["postgresqlServer"]

--- a/infra/modules/azure_postgres_server/replica.tf
+++ b/infra/modules/azure_postgres_server/replica.tf
@@ -33,7 +33,7 @@ resource "azurerm_postgresql_flexible_server" "replica" {
 resource "azurerm_postgresql_flexible_server_virtual_endpoint" "endpoint" {
   count = var.tier == "l" ? 1 : 0
 
-  name              = "${module.naming_convention.prefix}-psql-ep-${module.naming_convention.suffix}"
+  name              = replace(provider::dx::resource_name(merge(local.naming_config, { resource_type = "postgre_private_endpoint" })), "psql-pop", "psql-ep")
   source_server_id  = azurerm_postgresql_flexible_server.this.id
   replica_server_id = azurerm_postgresql_flexible_server.replica[0].id
   type              = "ReadWrite"

--- a/infra/modules/azure_postgres_server/replica.tf
+++ b/infra/modules/azure_postgres_server/replica.tf
@@ -33,7 +33,7 @@ resource "azurerm_postgresql_flexible_server" "replica" {
 resource "azurerm_postgresql_flexible_server_virtual_endpoint" "endpoint" {
   count = var.tier == "l" ? 1 : 0
 
-  name              = replace(provider::dx::resource_name(merge(local.naming_config, { resource_type = "postgre_private_endpoint" })), "psql-pop", "psql-ep")
+  name              = provider::dx::resource_name(merge(local.naming_config, { resource_type = "postgre_endpoint" }))
   source_server_id  = azurerm_postgresql_flexible_server.this.id
   replica_server_id = azurerm_postgresql_flexible_server.replica[0].id
   type              = "ReadWrite"

--- a/infra/modules/azure_postgres_server/tests/setup/README.md
+++ b/infra/modules/azure_postgres_server/tests/setup/README.md
@@ -6,12 +6,11 @@
 | Name | Version |
 |------|---------|
 | <a name="requirement_azurerm"></a> [azurerm](#requirement\_azurerm) | >= 3.116, < 5.0 |
+| <a name="requirement_dx"></a> [dx](#requirement\_dx) | ~>0.0 |
 
 ## Modules
 
-| Name | Source | Version |
-|------|--------|---------|
-| <a name="module_naming_convention"></a> [naming\_convention](#module\_naming\_convention) | ../../../azure_naming_convention | n/a |
+No modules.
 
 ## Resources
 

--- a/infra/modules/azure_postgres_server/tests/setup/README.md
+++ b/infra/modules/azure_postgres_server/tests/setup/README.md
@@ -6,7 +6,7 @@
 | Name | Version |
 |------|---------|
 | <a name="requirement_azurerm"></a> [azurerm](#requirement\_azurerm) | >= 3.116, < 5.0 |
-| <a name="requirement_dx"></a> [dx](#requirement\_dx) | ~>0.0 |
+| <a name="requirement_dx"></a> [dx](#requirement\_dx) | >= 0.0.5, < 1.0.0 |
 
 ## Modules
 

--- a/infra/modules/azure_postgres_server/tests/setup/README.md
+++ b/infra/modules/azure_postgres_server/tests/setup/README.md
@@ -6,7 +6,7 @@
 | Name | Version |
 |------|---------|
 | <a name="requirement_azurerm"></a> [azurerm](#requirement\_azurerm) | >= 3.116, < 5.0 |
-| <a name="requirement_dx"></a> [dx](#requirement\_dx) | >= 0.0.5, < 1.0.0 |
+| <a name="requirement_dx"></a> [dx](#requirement\_dx) | >= 0.0.6, < 1.0.0 |
 
 ## Modules
 

--- a/infra/modules/azure_postgres_server/tests/setup/main.tf
+++ b/infra/modules/azure_postgres_server/tests/setup/main.tf
@@ -6,19 +6,16 @@ terraform {
     }
     dx = {
       source  = "pagopa-dx/azure"
-      version = "~>0.0"
+      version = ">= 0.0.5, < 1.0.0"
     }
   }
 }
 
 locals {
   naming_config = {
-    prefix      = var.environment.prefix,
-    environment = var.environment.env_short,
-    location = tomap({
-      "italynorth" = "itn",
-      "westeurope" = "weu"
-    })[var.environment.location]
+    prefix          = var.environment.prefix,
+    environment     = var.environment.env_short,
+    location        = var.environment.location
     name            = var.environment.app_name,
     instance_number = tonumber(var.environment.instance_number),
   }

--- a/infra/modules/azure_postgres_server/tests/setup/main.tf
+++ b/infra/modules/azure_postgres_server/tests/setup/main.tf
@@ -6,7 +6,7 @@ terraform {
     }
     dx = {
       source  = "pagopa-dx/azure"
-      version = ">= 0.0.5, < 1.0.0"
+      version = ">= 0.0.6, < 1.0.0"
     }
   }
 }

--- a/infra/modules/azure_postgres_server/tests/setup/main.tf
+++ b/infra/modules/azure_postgres_server/tests/setup/main.tf
@@ -4,31 +4,51 @@ terraform {
       source  = "hashicorp/azurerm"
       version = ">= 3.116, < 5.0"
     }
+    dx = {
+      source  = "pagopa-dx/azure"
+      version = "~>0.0"
+    }
   }
 }
 
-module "naming_convention" {
-  source = "../../../azure_naming_convention"
-
-  environment = {
-    prefix          = var.environment.prefix
-    env_short       = var.environment.env_short
-    location        = var.environment.location
-    domain          = var.environment.domain
-    app_name        = var.environment.app_name
-    instance_number = var.environment.instance_number
+locals {
+  naming_config = {
+    prefix      = var.environment.prefix,
+    environment = var.environment.env_short,
+    location = tomap({
+      "italynorth" = "itn",
+      "westeurope" = "weu"
+    })[var.environment.location]
+    name            = var.environment.app_name,
+    instance_number = tonumber(var.environment.instance_number),
   }
-}
 
-data "azurerm_subnet" "pep" {
-  name                 = "${module.naming_convention.project}-pep-snet-01"
-  virtual_network_name = "${module.naming_convention.project}-common-vnet-01"
-  resource_group_name  = "${module.naming_convention.project}-network-rg-01"
+  virtual_network = {
+    name = provider::dx::resource_name(merge(local.naming_config, {
+      name          = "common",
+      resource_type = "virtual_network"
+    }))
+    resource_group_name = provider::dx::resource_name(merge(local.naming_config, {
+      name          = "network",
+      resource_type = "resource_group"
+    }))
+  }
 }
 
 data "azurerm_resource_group" "rg" {
-  name = "${var.environment.prefix}-${var.environment.env_short}-itn-test-rg-${module.naming_convention.suffix}"
+  name = provider::dx::resource_name(merge(local.naming_config, {
+    name          = "test",
+    resource_type = "resource_group"
+  }))
+}
 
+data "azurerm_subnet" "pep" {
+  name = provider::dx::resource_name(merge(local.naming_config, {
+    name          = "pep",
+    resource_type = "subnet"
+  }))
+  virtual_network_name = local.virtual_network.name
+  resource_group_name  = local.virtual_network.resource_group_name
 }
 
 output "pep_id" {


### PR DESCRIPTION
This PR removes all instances of the naming_convention module from the PostgreSQL module. The functionality has been replaced with the new naming convention function provided by the pagopa-dx/azure provider.

Resolves: CES-921