### PR TITLE
Fix trivy feature install script

### DIFF
--- a/.devcontainer/features/trivy/devcontainer-feature.json
+++ b/.devcontainer/features/trivy/devcontainer-feature.json
@@ -1,6 +1,6 @@
 {
   "id": "trivy",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "name": "Trivy",
   "description": "Installs Trivy",
   "documentationURL": "https://github.com/pagopa/dx/tree/main/.devcontainer/features/trivy",

--- a/.devcontainer/features/trivy/install.sh
+++ b/.devcontainer/features/trivy/install.sh
@@ -2,7 +2,7 @@
 
 set -e
 
-sudo apt-get install wget gnupg
+sudo apt-get install -y wget gnupg
 wget -qO - https://aquasecurity.github.io/trivy-repo/deb/public.key | gpg --dearmor | sudo tee /usr/share/keyrings/trivy.gpg > /dev/null
 echo "deb [signed-by=/usr/share/keyrings/trivy.gpg] https://aquasecurity.github.io/trivy-repo/deb generic main" | sudo tee -a /etc/apt/sources.list.d/trivy.list
 sudo apt-get update


### PR DESCRIPTION
Update `install.sh` script to be run in a non-interactive shell