### PR TITLE
Update provider with Null value support for domain parameter

### DIFF
--- a/.changeset/shaggy-lies-mate.md
+++ b/.changeset/shaggy-lies-mate.md
@@ -1,0 +1,5 @@
+---
+"provider-azure": patch
+---
+
+Fix resource_name function domain parameter adding null value support


### PR DESCRIPTION
Update the provider to fix the handling of the domain parameter in the `resource_name` function. Previously, the domain parameter could not be explicitly defined; using an empty string (`""`) was allowed, but passing `null` would result in an error. With this update, the domain parameter now supports `null` values without causing errors.

Resolves: CES-934