### PR TITLE
Add typescript as dependency

### DIFF
--- a/.changeset/six-eagles-lie.md
+++ b/.changeset/six-eagles-lie.md
@@ -1,0 +1,7 @@
+---
+"@pagopa/eslint-config": patch
+---
+
+Add `typescript` as dependency.
+
+`typescript-eslint` package requires `typescript` as dependency starging from version 8.

--- a/packages/eslint-config/package.json
+++ b/packages/eslint-config/package.json
@@ -20,6 +20,7 @@
     "eslint-plugin-perfectionist": "^2.9.0",
     "eslint-plugin-prettier": "^5.1.3",
     "eslint-plugin-vitest": "^0.5.3",
+    "typescript": "~5.2.2",
     "typescript-eslint": "^7.6.0"
   },
   "devDependencies": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -4993,6 +4993,7 @@ __metadata:
     eslint-plugin-prettier: "npm:^5.1.3"
     eslint-plugin-vitest: "npm:^0.5.3"
     prettier: "npm:3.2.5"
+    typescript: "npm:~5.2.2"
     typescript-eslint: "npm:^7.6.0"
   peerDependencies:
     eslint: 8.57.0


### PR DESCRIPTION
This removes the yarn warning '@pagopa/eslint-config@workspace:packages/eslint-config [db966] doesn't provide typescript (paf7fa), requested by typescript-eslint.' and prepare the package to be ready to the migration to the new major of typescript-eslint package.