### PR TITLE
Remove `naming_convention` inside EventHub module in favor of `pagopa-dx/azure` provider function

### DIFF
--- a/.changeset/olive-teachers-sneeze.md
+++ b/.changeset/olive-teachers-sneeze.md
@@ -1,0 +1,5 @@
+---
+"azure_event_hub": patch
+---
+
+Replace naming convention module with DX provider functions

--- a/infra/modules/azure_event_hub/README.md
+++ b/infra/modules/azure_event_hub/README.md
@@ -30,12 +30,11 @@ For a complete example of how to use this module, refer to the [example/complete
 | Name | Version |
 |------|---------|
 | <a name="requirement_azurerm"></a> [azurerm](#requirement\_azurerm) | >= 3.111.0, < 5.0 |
+| <a name="requirement_dx"></a> [dx](#requirement\_dx) | >= 0.0.6, < 1.0.0 |
 
 ## Modules
 
-| Name | Source | Version |
-|------|--------|---------|
-| <a name="module_naming_convention"></a> [naming\_convention](#module\_naming\_convention) | pagopa-dx/azure-naming-convention/azurerm | ~> 0.0 |
+No modules.
 
 ## Resources
 

--- a/infra/modules/azure_event_hub/example/complete/README.md
+++ b/infra/modules/azure_event_hub/example/complete/README.md
@@ -6,13 +6,13 @@
 | Name | Version |
 |------|---------|
 | <a name="requirement_azurerm"></a> [azurerm](#requirement\_azurerm) | >= 3.111.0, < 5.0 |
+| <a name="requirement_dx"></a> [dx](#requirement\_dx) | >= 0.0.6, < 1.0.0 |
 
 ## Modules
 
 | Name | Source | Version |
 |------|--------|---------|
 | <a name="module_azure_event_hub"></a> [azure\_event\_hub](#module\_azure\_event\_hub) | ../../ | n/a |
-| <a name="module_naming_convention"></a> [naming\_convention](#module\_naming\_convention) | ../../../azure_naming_convention | n/a |
 
 ## Resources
 
@@ -20,7 +20,6 @@
 |------|------|
 | [azurerm_resource_group.example](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/resource_group) | resource |
 | [azurerm_subnet.example](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/subnet) | resource |
-| [azurerm_monitor_action_group.example](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/data-sources/monitor_action_group) | data source |
 | [azurerm_subnet.pep](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/data-sources/subnet) | data source |
 
 ## Inputs

--- a/infra/modules/azure_event_hub/example/complete/locals.tf
+++ b/infra/modules/azure_event_hub/example/complete/locals.tf
@@ -8,7 +8,24 @@ locals {
     instance_number = "01"
   }
 
-  project = module.naming_convention.project
+  naming_config = {
+    prefix          = local.environment.prefix,
+    environment     = local.environment.env_short,
+    location        = local.environment.location
+    name            = local.environment.app_name,
+    instance_number = tonumber(local.environment.instance_number),
+  }
+
+  virtual_network = {
+    name = provider::dx::resource_name(merge(local.naming_config, {
+      name          = "common",
+      resource_type = "virtual_network"
+    }))
+    resource_group_name = provider::dx::resource_name(merge(local.naming_config, {
+      name          = "network",
+      resource_type = "resource_group"
+    }))
+  }
 
   tags = {
     CreatedBy   = "Terraform"

--- a/infra/modules/azure_event_hub/example/complete/versions.tf
+++ b/infra/modules/azure_event_hub/example/complete/versions.tf
@@ -12,6 +12,10 @@ terraform {
       source  = "hashicorp/azurerm"
       version = ">= 3.111.0, < 5.0"
     }
+    dx = {
+      source  = "pagopa-dx/azure"
+      version = ">= 0.0.6, < 1.0.0"
+    }
   }
 }
 

--- a/infra/modules/azure_event_hub/locals.tf
+++ b/infra/modules/azure_event_hub/locals.tf
@@ -1,6 +1,14 @@
 locals {
+  naming_config = {
+    prefix          = var.environment.prefix,
+    environment     = var.environment.env_short,
+    location        = var.environment.location
+    domain          = var.environment.domain,
+    name            = var.environment.app_name,
+    instance_number = tonumber(var.environment.instance_number),
+  }
   eventhub = {
-    name = "${module.naming_convention.prefix}-evhns-${module.naming_convention.suffix}"
+    name = provider::dx::resource_name(merge(local.naming_config, { resource_type = "eventhub_namespace" }))
     sku_name = lookup(
       {
         "s" = "Standard",
@@ -16,17 +24,17 @@ locals {
   # Events configuration
   consumers = { for hc in flatten([for h in var.eventhubs :
     [for c in h.consumers : {
-      hub  = "${module.naming_convention.prefix}-${h.name}-${module.naming_convention.suffix}"
+      hub  = replace(local.eventhub.name, "${var.environment.app_name}-evhns", h.name)
       name = c
   }]]) : "${hc.hub}.${hc.name}" => hc }
 
   keys = { for hk in flatten([for h in var.eventhubs :
     [for k in h.keys : {
-      hub = "${module.naming_convention.prefix}-${h.name}-${module.naming_convention.suffix}"
+      hub = replace(local.eventhub.name, "${var.environment.app_name}-evhns", h.name)
       key = k
   }]]) : "${hk.hub}.${hk.key.name}" => hk }
 
-  hubs = { for h in var.eventhubs : "${module.naming_convention.prefix}-${h.name}-${module.naming_convention.suffix}" => h }
+  hubs = { for h in var.eventhubs : replace(local.eventhub.name, "${var.environment.app_name}-evhns", h.name) => h }
 
   # Network
   private_dns_zone_resource_group_name = var.private_dns_zone_resource_group_name == null ? var.resource_group_name : var.private_dns_zone_resource_group_name

--- a/infra/modules/azure_event_hub/main.tf
+++ b/infra/modules/azure_event_hub/main.tf
@@ -4,20 +4,10 @@ terraform {
       source  = "hashicorp/azurerm"
       version = ">= 3.111.0, < 5.0"
     }
-  }
-}
-
-module "naming_convention" {
-  source  = "pagopa-dx/azure-naming-convention/azurerm"
-  version = "~> 0.0"
-
-  environment = {
-    prefix          = var.environment.prefix
-    env_short       = var.environment.env_short
-    location        = var.environment.location
-    domain          = var.environment.domain
-    app_name        = var.environment.app_name
-    instance_number = var.environment.instance_number
+    dx = {
+      source  = "pagopa-dx/azure"
+      version = ">= 0.0.6, < 1.0.0"
+    }
   }
 }
 

--- a/infra/modules/azure_event_hub/network.tf
+++ b/infra/modules/azure_event_hub/network.tf
@@ -1,11 +1,11 @@
 resource "azurerm_private_endpoint" "event_hub_pep" {
-  name                = "${module.naming_convention.prefix}-evhns-pep-${module.naming_convention.suffix}"
+  name                = provider::dx::resource_name(merge(local.naming_config, { resource_type = "eventhub_private_endpoint" }))
   location            = var.environment.location
   resource_group_name = var.resource_group_name
   subnet_id           = var.subnet_pep_id
 
   private_service_connection {
-    name                           = "${module.naming_convention.prefix}-evhns-pep-${module.naming_convention.suffix}"
+    name                           = provider::dx::resource_name(merge(local.naming_config, { resource_type = "eventhub_private_endpoint" }))
     private_connection_resource_id = azurerm_eventhub_namespace.this.id
     is_manual_connection           = false
     subresource_names              = ["namespace"]


### PR DESCRIPTION
This PR removes all instances of the naming_convention module from the EventHub module. The functionality has been replaced with the new naming convention function provided by the pagopa-dx/azure provider.

Resolves: CES-919