### PR TITLE
Remove `naming_convention` inside CDN module in favor of `pagopa-dx/azure` provider function

### DIFF
--- a/.changeset/tiny-rules-drum.md
+++ b/.changeset/tiny-rules-drum.md
@@ -1,0 +1,5 @@
+---
+"azure_cdn": patch
+---
+
+Replace naming convention module with DX provider functions

--- a/infra/modules/azure_cdn/README.md
+++ b/infra/modules/azure_cdn/README.md
@@ -71,12 +71,11 @@ terraform test
 | Name | Version |
 |------|---------|
 | <a name="requirement_azurerm"></a> [azurerm](#requirement\_azurerm) | >= 3.100.0, < 5.0 |
+| <a name="requirement_dx"></a> [dx](#requirement\_dx) | >= 0.0.6, < 1.0.0 |
 
 ## Modules
 
-| Name | Source | Version |
-|------|--------|---------|
-| <a name="module_naming_convention"></a> [naming\_convention](#module\_naming\_convention) | pagopa-dx/azure-naming-convention/azurerm | ~> 0.0 |
+No modules.
 
 ## Resources
 

--- a/infra/modules/azure_cdn/examples/basic/README.md
+++ b/infra/modules/azure_cdn/examples/basic/README.md
@@ -6,13 +6,13 @@
 | Name | Version |
 |------|---------|
 | <a name="requirement_azurerm"></a> [azurerm](#requirement\_azurerm) | ~>4 |
+| <a name="requirement_dx"></a> [dx](#requirement\_dx) | >= 0.0.6, < 1.0.0 |
 
 ## Modules
 
 | Name | Source | Version |
 |------|--------|---------|
 | <a name="module_azure_cdn"></a> [azure\_cdn](#module\_azure\_cdn) | ../../ | n/a |
-| <a name="module_naming_convention"></a> [naming\_convention](#module\_naming\_convention) | pagopa-dx/azure-naming-convention/azurerm | ~> 0.0 |
 | <a name="module_storage_account"></a> [storage\_account](#module\_storage\_account) | ../../../azure_storage_account | n/a |
 
 ## Resources

--- a/infra/modules/azure_cdn/examples/basic/locals.tf
+++ b/infra/modules/azure_cdn/examples/basic/locals.tf
@@ -8,6 +8,25 @@ locals {
     instance_number = "01"
   }
 
+  naming_config = {
+    prefix          = local.environment.prefix,
+    environment     = local.environment.env_short,
+    location        = local.environment.location
+    name            = local.environment.app_name,
+    instance_number = tonumber(local.environment.instance_number),
+  }
+
+  virtual_network = {
+    name = provider::dx::resource_name(merge(local.naming_config, {
+      name          = "common",
+      resource_type = "virtual_network"
+    }))
+    resource_group_name = provider::dx::resource_name(merge(local.naming_config, {
+      name          = "network",
+      resource_type = "resource_group"
+    }))
+  }
+
   tags = {
     CostCenter     = "TS000 - Tecnologia e Servizi"
     CreatedBy      = "Terraform"

--- a/infra/modules/azure_cdn/examples/basic/main.tf
+++ b/infra/modules/azure_cdn/examples/basic/main.tf
@@ -1,13 +1,19 @@
 
 resource "azurerm_resource_group" "example" {
-  name     = "${module.naming_convention.project}-cdn-rg-${local.environment.instance_number}"
+  name = provider::dx::resource_name(merge(local.naming_config, {
+    name          = "cdn",
+    resource_type = "resource_group"
+  }))
   location = local.environment.location
 }
 
 data "azurerm_subnet" "pep" {
-  name                 = "${module.naming_convention.project}-pep-snet-01"
-  virtual_network_name = "${module.naming_convention.project}-common-vnet-01"
-  resource_group_name  = "${module.naming_convention.project}-network-rg-01"
+  name = provider::dx::resource_name(merge(local.naming_config, {
+    name          = "pep",
+    resource_type = "subnet"
+  }))
+  virtual_network_name = local.virtual_network.name
+  resource_group_name  = local.virtual_network.resource_group_name
 }
 
 

--- a/infra/modules/azure_cdn/examples/basic/versions.tf
+++ b/infra/modules/azure_cdn/examples/basic/versions.tf
@@ -12,23 +12,13 @@ terraform {
       source  = "hashicorp/azurerm"
       version = "~>4"
     }
+    dx = {
+      source  = "pagopa-dx/azure"
+      version = ">= 0.0.6, < 1.0.0"
+    }
   }
 }
 
 provider "azurerm" {
   features {}
-}
-
-module "naming_convention" {
-  source  = "pagopa-dx/azure-naming-convention/azurerm"
-  version = "~> 0.0"
-
-  environment = {
-    prefix          = local.environment.prefix
-    env_short       = local.environment.env_short
-    location        = local.environment.location
-    domain          = local.environment.domain
-    app_name        = local.environment.app_name
-    instance_number = local.environment.instance_number
-  }
 }

--- a/infra/modules/azure_cdn/locals.tf
+++ b/infra/modules/azure_cdn/locals.tf
@@ -1,0 +1,10 @@
+locals {
+  naming_config = {
+    prefix          = var.environment.prefix,
+    environment     = var.environment.env_short,
+    location        = var.environment.location
+    domain          = var.environment.domain,
+    name            = var.environment.app_name,
+    instance_number = tonumber(var.environment.instance_number),
+  }
+}

--- a/infra/modules/azure_cdn/main.tf
+++ b/infra/modules/azure_cdn/main.tf
@@ -4,19 +4,9 @@ terraform {
       source  = "hashicorp/azurerm"
       version = ">= 3.100.0, < 5.0"
     }
-  }
-}
-
-module "naming_convention" {
-  source  = "pagopa-dx/azure-naming-convention/azurerm"
-  version = "~> 0.0"
-
-  environment = {
-    prefix          = var.environment.prefix
-    env_short       = var.environment.env_short
-    location        = var.environment.location
-    domain          = var.environment.domain
-    app_name        = var.environment.app_name
-    instance_number = var.environment.instance_number
+    dx = {
+      source  = "pagopa-dx/azure"
+      version = ">= 0.0.6, < 1.0.0"
+    }
   }
 }

--- a/infra/modules/azure_cdn/tests/setup/README.md
+++ b/infra/modules/azure_cdn/tests/setup/README.md
@@ -6,12 +6,12 @@
 | Name | Version |
 |------|---------|
 | <a name="requirement_azurerm"></a> [azurerm](#requirement\_azurerm) | >= 3.110, < 5.0 |
+| <a name="requirement_dx"></a> [dx](#requirement\_dx) | >= 0.0.6, < 1.0.0 |
 
 ## Modules
 
 | Name | Source | Version |
 |------|--------|---------|
-| <a name="module_naming_convention"></a> [naming\_convention](#module\_naming\_convention) | ../../../azure_naming_convention | n/a |
 | <a name="module_storage_account"></a> [storage\_account](#module\_storage\_account) | ../../../azure_storage_account | n/a |
 
 ## Resources

--- a/infra/modules/azure_cdn/tests/setup/main.tf
+++ b/infra/modules/azure_cdn/tests/setup/main.tf
@@ -36,7 +36,7 @@ resource "azurerm_subnet" "snet" {
   name = provider::dx::resource_name(merge(local.naming_config, {
     domain        = var.environment.domain,
     name          = "sa",
-    resource_type = "snet"
+    resource_type = "subnet"
   }))
   virtual_network_name = local.virtual_network.name
   resource_group_name  = local.virtual_network.resource_group_name

--- a/infra/modules/azure_cdn/tests/setup/main.tf
+++ b/infra/modules/azure_cdn/tests/setup/main.tf
@@ -4,38 +4,59 @@ terraform {
       source  = "hashicorp/azurerm"
       version = ">= 3.110, < 5.0"
     }
+    dx = {
+      source  = "pagopa-dx/azure"
+      version = ">= 0.0.6, < 1.0.0"
+    }
   }
 }
 
-module "naming_convention" {
-  source = "../../../azure_naming_convention"
-
-  environment = {
-    prefix          = var.environment.prefix
-    env_short       = var.environment.env_short
+locals {
+  naming_config = {
+    prefix          = var.environment.prefix,
+    environment     = var.environment.env_short,
     location        = var.environment.location
-    domain          = var.environment.domain
-    app_name        = var.environment.app_name
-    instance_number = var.environment.instance_number
+    name            = var.environment.app_name,
+    instance_number = tonumber(var.environment.instance_number),
+  }
+
+  virtual_network = {
+    name = provider::dx::resource_name(merge(local.naming_config, {
+      name          = "common",
+      resource_type = "virtual_network"
+    }))
+    resource_group_name = provider::dx::resource_name(merge(local.naming_config, {
+      name          = "network",
+      resource_type = "resource_group"
+    }))
   }
 }
 
 resource "azurerm_subnet" "snet" {
-  name                 = "${module.naming_convention.prefix}-snet-sa-${module.naming_convention.suffix}"
-  virtual_network_name = "${module.naming_convention.project}-common-vnet-01"
-  resource_group_name  = "${module.naming_convention.project}-network-rg-01"
+  name = provider::dx::resource_name(merge(local.naming_config, {
+    domain        = var.environment.domain,
+    name          = "sa",
+    resource_type = "snet"
+  }))
+  virtual_network_name = local.virtual_network.name
+  resource_group_name  = local.virtual_network.resource_group_name
   address_prefixes     = ["10.50.200.0/24"]
 }
 
 data "azurerm_subnet" "pep" {
-  name                 = "${module.naming_convention.project}-pep-snet-01"
-  virtual_network_name = "${module.naming_convention.project}-common-vnet-01"
-  resource_group_name  = "${module.naming_convention.project}-network-rg-01"
+  name = provider::dx::resource_name(merge(local.naming_config, {
+    name          = "pep",
+    resource_type = "subnet"
+  }))
+  virtual_network_name = local.virtual_network.name
+  resource_group_name  = local.virtual_network.resource_group_name
 }
 
 data "azurerm_resource_group" "rg" {
-  name = "${var.environment.prefix}-${var.environment.env_short}-itn-test-rg-${module.naming_convention.suffix}"
-
+  name = provider::dx::resource_name(merge(local.naming_config, {
+    name          = "test",
+    resource_type = "resource_group"
+  }))
 }
 
 module "storage_account" {


### PR DESCRIPTION
This PR removes all instances of the naming_convention module from the CDN module. The functionality has been replaced with the new naming convention function provided by the pagopa-dx/azure provider.

Resolves: CES-916