### PR TITLE
Remove `naming_convention` inside APIM module in favor of `pagopa-dx/azure` provider function

### DIFF
--- a/.changeset/polite-eels-train.md
+++ b/.changeset/polite-eels-train.md
@@ -1,0 +1,5 @@
+---
+"azure_api_management": patch
+---
+
+Replace naming convention module with DX provider functions

--- a/infra/modules/azure_api_management/README.md
+++ b/infra/modules/azure_api_management/README.md
@@ -33,12 +33,11 @@ For a complete example of how to use this module, refer to the [example/complete
 | Name | Version |
 |------|---------|
 | <a name="requirement_azurerm"></a> [azurerm](#requirement\_azurerm) | >= 4.1.0, < 5.0 |
+| <a name="requirement_dx"></a> [dx](#requirement\_dx) | >= 0.0.6, < 1.0.0 |
 
 ## Modules
 
-| Name | Source | Version |
-|------|--------|---------|
-| <a name="module_naming_convention"></a> [naming\_convention](#module\_naming\_convention) | pagopa-dx/azure-naming-convention/azurerm | ~> 0.0 |
+No modules.
 
 ## Resources
 

--- a/infra/modules/azure_api_management/example/complete/README.md
+++ b/infra/modules/azure_api_management/example/complete/README.md
@@ -6,6 +6,7 @@
 | Name | Version |
 |------|---------|
 | <a name="requirement_azurerm"></a> [azurerm](#requirement\_azurerm) | >= 3.111.0, < 5.0 |
+| <a name="requirement_dx"></a> [dx](#requirement\_dx) | >= 0.0.6, < 1.0.0 |
 
 ## Modules
 

--- a/infra/modules/azure_api_management/example/complete/locals.tf
+++ b/infra/modules/azure_api_management/example/complete/locals.tf
@@ -8,7 +8,24 @@ locals {
     instance_number = "01"
   }
 
-  project = module.naming_convention.project
+  naming_config = {
+    prefix          = local.environment.prefix,
+    environment     = local.environment.env_short,
+    location        = local.environment.location
+    name            = local.environment.app_name,
+    instance_number = tonumber(local.environment.instance_number),
+  }
+
+  virtual_network = {
+    name = provider::dx::resource_name(merge(local.naming_config, {
+      name          = "common",
+      resource_type = "virtual_network"
+    }))
+    resource_group_name = provider::dx::resource_name(merge(local.naming_config, {
+      name          = "network",
+      resource_type = "resource_group"
+    }))
+  }
 
   tags = {
     CreatedBy   = "Terraform"

--- a/infra/modules/azure_api_management/example/complete/main.tf
+++ b/infra/modules/azure_api_management/example/complete/main.tf
@@ -5,14 +5,17 @@ module "naming_convention" {
 }
 
 resource "azurerm_resource_group" "example" {
-  name     = "${local.project}-${local.environment.domain}-rg-${local.environment.instance_number}"
+  name = provider::dx::resource_name(merge(local.naming_config, {
+    name          = local.environment.app_name,
+    resource_type = "resource_group"
+  }))
   location = local.environment.location
 }
 
 resource "azurerm_subnet" "example" {
   name                 = "example-subnet"
-  virtual_network_name = "${local.project}-common-vnet-01"
-  resource_group_name  = "${local.project}-network-rg-01"
+  virtual_network_name = local.virtual_network.name
+  resource_group_name  = local.virtual_network.resource_group_name
   address_prefixes     = ["10.50.250.0/24"]
 }
 
@@ -28,8 +31,8 @@ module "azure_apim" {
   publisher_name  = "Example Publisher"
 
   virtual_network = {
-    name                = "${local.project}-common-vnet-01"
-    resource_group_name = "${local.project}-network-rg-01"
+    name                = local.virtual_network.name
+    resource_group_name = local.virtual_network.resource_group_name
   }
   subnet_id                     = azurerm_subnet.example.id
   virtual_network_type_internal = true

--- a/infra/modules/azure_api_management/example/complete/versions.tf
+++ b/infra/modules/azure_api_management/example/complete/versions.tf
@@ -12,6 +12,10 @@ terraform {
       source  = "hashicorp/azurerm"
       version = ">= 3.111.0, < 5.0"
     }
+    dx = {
+      source  = "pagopa-dx/azure"
+      version = ">= 0.0.6, < 1.0.0"
+    }
   }
 }
 

--- a/infra/modules/azure_api_management/main.tf
+++ b/infra/modules/azure_api_management/main.tf
@@ -4,20 +4,10 @@ terraform {
       source  = "hashicorp/azurerm"
       version = ">= 4.1.0, < 5.0"
     }
-  }
-}
-
-module "naming_convention" {
-  source  = "pagopa-dx/azure-naming-convention/azurerm"
-  version = "~> 0.0"
-
-  environment = {
-    prefix          = var.environment.prefix
-    env_short       = var.environment.env_short
-    location        = var.environment.location
-    domain          = var.environment.domain
-    app_name        = var.environment.app_name
-    instance_number = var.environment.instance_number
+    dx = {
+      source  = "pagopa-dx/azure"
+      version = ">= 0.0.6, < 1.0.0"
+    }
   }
 }
 

--- a/infra/modules/azure_api_management/network.tf
+++ b/infra/modules/azure_api_management/network.tf
@@ -32,7 +32,7 @@ resource "azurerm_private_dns_a_record" "apim_scm_azure_api_net" {
 
 # Define security group
 resource "azurerm_network_security_group" "nsg_apim" {
-  name                = "${local.prefix}-apim-nsg-${module.naming_convention.suffix}"
+  name                = replace(provider::dx::resource_name(merge(local.naming_config, { resource_type = "apim_network_security_group" })), "-apim-apim-", "-apim-")
   resource_group_name = data.azurerm_virtual_network.this.resource_group_name
   location            = var.environment.location
 

--- a/infra/modules/azure_api_management/tests/setup/README.md
+++ b/infra/modules/azure_api_management/tests/setup/README.md
@@ -6,12 +6,11 @@
 | Name | Version |
 |------|---------|
 | <a name="requirement_azurerm"></a> [azurerm](#requirement\_azurerm) | >= 3.111.0, < 5.0 |
+| <a name="requirement_dx"></a> [dx](#requirement\_dx) | >= 0.0.6, < 1.0.0 |
 
 ## Modules
 
-| Name | Source | Version |
-|------|--------|---------|
-| <a name="module_naming_convention"></a> [naming\_convention](#module\_naming\_convention) | ../../../azure_naming_convention | n/a |
+No modules.
 
 ## Resources
 


### PR DESCRIPTION
This PR removes all instances of the naming_convention module from the APIM module. The functionality has been replaced with the new naming convention function provided by the pagopa-dx/azure provider.

Resolves: CES-920