### PR TITLE
Remove `naming_convention` inside GitHub Self Hosted module in favor of `pagopa-dx/azure` provider function

### DIFF
--- a/.changeset/polite-seas-clean.md
+++ b/.changeset/polite-seas-clean.md
@@ -1,0 +1,5 @@
+---
+"github_selfhosted_runner_on_container_app_jobs": patch
+---
+
+Replace naming convention module with DX provider functions

--- a/infra/modules/github_selfhosted_runner_on_container_app_jobs/README.md
+++ b/infra/modules/github_selfhosted_runner_on_container_app_jobs/README.md
@@ -7,12 +7,11 @@
 | Name | Version |
 |------|---------|
 | <a name="requirement_azurerm"></a> [azurerm](#requirement\_azurerm) | >= 3.110, < 5.0 |
+| <a name="requirement_dx"></a> [dx](#requirement\_dx) | >= 0.0.6, < 1.0.0 |
 
 ## Modules
 
-| Name | Source | Version |
-|------|--------|---------|
-| <a name="module_naming_convention"></a> [naming\_convention](#module\_naming\_convention) | pagopa-dx/azure-naming-convention/azurerm | ~> 0.0 |
+No modules.
 
 ## Resources
 

--- a/infra/modules/github_selfhosted_runner_on_container_app_jobs/locals.tf
+++ b/infra/modules/github_selfhosted_runner_on_container_app_jobs/locals.tf
@@ -1,13 +1,22 @@
 locals {
+  naming_config = {
+    prefix          = var.environment.prefix,
+    environment     = var.environment.env_short,
+    location        = var.environment.location
+    name            = length(var.repository.name) > 16 ? substr(var.repository.name, 0, 16) : var.repository.name,
+    instance_number = tonumber(var.environment.instance_number),
+  }
   env = {
     "d" = "dev",
     "u" = "uat",
     "p" = "prod"
   }
-
   container_apps = {
-    job_name            = "${module.naming_convention.prefix}-caj-${module.naming_convention.suffix}"
-    resource_group_name = var.resource_group_name == null ? "${module.naming_convention.prefix}-github-runner-rg-01" : var.resource_group_name
+    job_name = provider::dx::resource_name(merge(local.naming_config, { resource_type = "container_app_job" }))
+    resource_group_name = var.resource_group_name == null ? provider::dx::resource_name(merge(local.naming_config, {
+      name          = "github-runner",
+      resource_type = "resource_group"
+    })) : var.resource_group_name
   }
 
   labels = join(",", coalescelist(var.container_app_environment.override_labels, [local.env[var.environment.env_short]]))

--- a/infra/modules/github_selfhosted_runner_on_container_app_jobs/main.tf
+++ b/infra/modules/github_selfhosted_runner_on_container_app_jobs/main.tf
@@ -5,19 +5,9 @@ terraform {
       source  = "hashicorp/azurerm"
       version = ">= 3.110, < 5.0"
     }
-  }
-}
-
-module "naming_convention" {
-  source  = "pagopa-dx/azure-naming-convention/azurerm"
-  version = "~> 0.0"
-
-  environment = {
-    prefix          = var.environment.prefix
-    env_short       = var.environment.env_short
-    location        = var.environment.location
-    domain          = null
-    app_name        = length(var.repository.name) > 16 ? substr(var.repository.name, 0, 16) : var.repository.name
-    instance_number = var.environment.instance_number
+    dx = {
+      source  = "pagopa-dx/azure"
+      version = ">= 0.0.6, < 1.0.0"
+    }
   }
 }


### PR DESCRIPTION
This PR removes all instances of the naming_convention module from the GitHub Self Hosted module. The functionality has been replaced with the new naming convention function provided by the pagopa-dx/azure provider.

Resolves: CES-928