### PR TITLE
Remove `naming_convention` inside bootstrap module in favor of `pagopa-dx/azure` provider function

### DIFF
--- a/.changeset/empty-dancers-sniff.md
+++ b/.changeset/empty-dancers-sniff.md
@@ -1,0 +1,5 @@
+---
+"azure_github_environment_bootstrap": patch
+---
+
+Replace naming convention module with DX provider functions

--- a/infra/modules/azure_github_environment_bootstrap/README.md
+++ b/infra/modules/azure_github_environment_bootstrap/README.md
@@ -103,6 +103,7 @@ resource "github_repository_environment_deployment_policy" "release_branch" {
 | Name | Version |
 |------|---------|
 | <a name="requirement_azurerm"></a> [azurerm](#requirement\_azurerm) | ~>4 |
+| <a name="requirement_dx"></a> [dx](#requirement\_dx) | >= 0.0.7, < 1.0.0 |
 | <a name="requirement_github"></a> [github](#requirement\_github) | ~>6 |
 
 ## Modules
@@ -110,7 +111,6 @@ resource "github_repository_environment_deployment_policy" "release_branch" {
 | Name | Source | Version |
 |------|--------|---------|
 | <a name="module_github_runner"></a> [github\_runner](#module\_github\_runner) | pagopa-dx/github-selfhosted-runner-on-container-app-jobs/azurerm | ~> 1.0 |
-| <a name="module_naming_convention"></a> [naming\_convention](#module\_naming\_convention) | pagopa-dx/azure-naming-convention/azurerm | ~> 0.0 |
 
 ## Resources
 

--- a/infra/modules/azure_github_environment_bootstrap/locals.tf
+++ b/infra/modules/azure_github_environment_bootstrap/locals.tf
@@ -3,22 +3,20 @@ locals {
     prefix          = var.environment.prefix,
     environment     = var.environment.env_short,
     location        = var.environment.location
-    domain          = null
-    name            = var.environment.domain, # app_name is mandatory for any resource except resource groups
     instance_number = tonumber(var.environment.instance_number),
   }
 
-  env_name = lookup(
-    {
-      "d" = "dev"
-      "u" = "uat"
-      "p" = "prod"
-    },
-    var.environment.env_short
-  )
+  env_name = {
+    "d" = "dev"
+    "u" = "uat"
+    "p" = "prod"
+  }[var.environment.env_short]
 
   resource_group = {
-    name     = provider::dx::resource_name(merge(local.naming_config, { resource_type = "resource_group" }))
+    name = provider::dx::resource_name(merge(local.naming_config, {
+      name          = var.environment.domain # app_name is mandatory for any resource except resource groups
+      resource_type = "resource_group"
+    }))
     location = var.environment.location
   }
 
@@ -38,16 +36,19 @@ locals {
   ids = {
     #e.g. io-p-itn-ipatente-app-github-cd-id-01
     infra_name = provider::dx::resource_name(merge(local.naming_config, {
-      name = "infra-github-%s"
-      resource_type = "managed_identity" 
+      domain        = var.environment.domain
+      name          = "infra-github-%s"
+      resource_type = "managed_identity"
     }))
-    app_name   = provider::dx::resource_name(merge(local.naming_config, {
-      name = "app-github-%s"
-      resource_type = "managed_identity" 
+    app_name = provider::dx::resource_name(merge(local.naming_config, {
+      domain        = var.environment.domain
+      name          = "app-github-%s"
+      resource_type = "managed_identity"
     }))
-    opex_name  = provider::dx::resource_name(merge(local.naming_config, {
-      name = "opex-github-%s"
-      resource_type = "managed_identity" 
+    opex_name = provider::dx::resource_name(merge(local.naming_config, {
+      domain        = var.environment.domain
+      name          = "opex-github-%s"
+      resource_type = "managed_identity"
     }))
 
     # e.g. infra-prod-cd

--- a/infra/modules/azure_github_environment_bootstrap/locals.tf
+++ b/infra/modules/azure_github_environment_bootstrap/locals.tf
@@ -14,7 +14,7 @@ locals {
 
   resource_group = {
     name = provider::dx::resource_name(merge(local.naming_config, {
-      name          = var.environment.domain # app_name is mandatory for any resource except resource groups
+      name          = var.environment.domain
       resource_type = "resource_group"
     }))
     location = var.environment.location

--- a/infra/modules/azure_github_environment_bootstrap/main.tf
+++ b/infra/modules/azure_github_environment_bootstrap/main.tf
@@ -9,19 +9,10 @@ terraform {
       source  = "integrations/github"
       version = "~>6"
     }
-  }
-}
 
-module "naming_convention" {
-  source  = "pagopa-dx/azure-naming-convention/azurerm"
-  version = "~> 0.0"
-
-  environment = {
-    prefix          = var.environment.prefix
-    env_short       = var.environment.env_short
-    location        = var.environment.location
-    domain          = null
-    app_name        = var.environment.domain # app_name is mandatory for any resource except resource groups
-    instance_number = var.environment.instance_number
+    dx = {
+      source  = "pagopa-dx/azure"
+      version = ">= 0.0.7, < 1.0.0"
+    }
   }
 }


### PR DESCRIPTION
This PR removes all instances of the naming_convention module from the Azure github Bootstrap module. The functionality has been replaced with the new naming convention function provided by the pagopa-dx/azure provider.

Resolves: CES-929