### PR TITLE
Add Azure best practices guideline for code generation

### DIFF
--- a/.github/copilot/code-instructions.md
+++ b/.github/copilot/code-instructions.md
@@ -28,3 +28,7 @@
 
 - Respect the monorepo structure managed by Turborepo (see `turbo.json`)
 - Place new packages in the appropriate directory under `packages/`
+
+## Tools
+
+- @azure Rule - Use Azure Best Practices: When generating code for Azure, running terminal commands for Azure, or performing operations related to Azure, invoke your `get_azure_best_practices` tool if available.


### PR DESCRIPTION
Introduce a guideline for utilizing Azure best practices when generating code or performing Azure-related operations with GitHub Copilot.