### PR TITLE
Add Documentation and use pagopa-dx/azure provider inside federated identity module

### DIFF
--- a/.changeset/tough-pets-retire.md
+++ b/.changeset/tough-pets-retire.md
@@ -1,0 +1,5 @@
+---
+"azure_federated_identity_with_github": patch
+---
+
+Update Documentation README and for naming used provider function instead of naming_convention module

--- a/infra/modules/azure_federated_identity_with_github/README.md
+++ b/infra/modules/azure_federated_identity_with_github/README.md
@@ -2,6 +2,65 @@
 
 ![Terraform Module Downloads](https://img.shields.io/terraform/module/dm/pagopa-dx/azure-federated-identity-with-github/azurerm?logo=terraform&label=downloads&cacheSeconds=5000&link=https%3A%2F%2Fregistry.terraform.io%2Fmodules%2Fpagopa-dx%2Fazure-federated-identity-with-github%2Fazurerm%2Flatest)
 
+This Terraform module provisions Azure Federated Identities for GitHub Actions, enabling secure and seamless integration between Azure and GitHub repositories.
+
+## Features
+
+- **Continuous Integration (CI) Identity**: Creates a managed identity for CI pipelines with customizable RBAC roles.
+- **Continuous Delivery (CD) Identity**: Creates a managed identity for CD pipelines with customizable RBAC roles.
+- **Flexible Role Assignments**: Supports role assignments at both subscription and resource group levels.
+- **GitHub Federation**: Configures federated identity credentials for GitHub repositories.
+- **Dynamic Configuration**: Allows enabling/disabling CI/CD identities and customizing their roles.
+
+## Usage Example
+
+Below is an example of how to use this module to create federated identities for both CI and CD pipelines:
+
+```hcl
+module "azure_federated_identity_with_github" {
+  source  = "pagopa-dx/azure-federated-identity-with-github/azurerm"
+  version = "~> 0.0"
+
+  environment = {
+    prefix          = "dx"
+    env_short       = "d"
+    location        = "italynorth"
+    domain          = "example"
+    instance_number = "01"
+  }
+
+  resource_group_name = "dx-d-itn-example-rg-01"
+  subscription_id     = data.azurerm_subscription.current.id
+
+  repository = {
+    name  = "dx"
+    owner = "example"
+  }
+
+  continuos_integration = {
+    enable = true
+    roles = {
+      subscription = ["Reader"]
+      resource_groups = {
+        "dx-d-itn-example-rg-01" = ["Storage Blob Data Contributor"]
+      }
+    }
+  }
+
+  continuos_delivery = {
+    enable = true
+    roles = {
+      subscription = ["Contributor"]
+      resource_groups = {
+        "dx-d-itn-example-rg-01" = ["Storage Blob Data Contributor"]
+      }
+    }
+  }
+
+  tags = {}
+}
+```
+
 <!-- markdownlint-disable -->
 <!-- BEGIN_TF_DOCS -->
 ## Requirements
@@ -9,12 +68,11 @@
 | Name | Version |
 |------|---------|
 | <a name="requirement_azurerm"></a> [azurerm](#requirement\_azurerm) | ~>4 |
+| <a name="requirement_dx"></a> [dx](#requirement\_dx) | >= 0.0.7, < 1.0.0 |
 
 ## Modules
 
-| Name | Source | Version |
-|------|--------|---------|
-| <a name="module_naming_convention"></a> [naming\_convention](#module\_naming\_convention) | pagopa-dx/azure-naming-convention/azurerm | ~> 0.0 |
+No modules.
 
 ## Resources
 
@@ -35,14 +93,14 @@
 
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
-| <a name="input_continuos_delivery"></a> [continuos\_delivery](#input\_continuos\_delivery) | Continuos Delivery identity properties, such as repositories to federated with and RBAC roles | <pre>object({<br/>    enable = bool<br/>    roles = optional(object({<br/>      subscription    = set(string)<br/>      resource_groups = map(list(string))<br/>    }))<br/>  })</pre> | <pre>{<br/>  "enable": true,<br/>  "roles": {<br/>    "resource_groups": {<br/>      "terraform-state-rg": [<br/>        "Storage Blob Data Contributor"<br/>      ]<br/>    },<br/>    "subscription": [<br/>      "Contributor"<br/>    ]<br/>  }<br/>}</pre> | no |
-| <a name="input_continuos_integration"></a> [continuos\_integration](#input\_continuos\_integration) | Continuos Integration identity properties, such as repositories to federated with and RBAC roles | <pre>object({<br/>    enable = bool<br/>    roles = optional(object({<br/>      subscription    = set(string)<br/>      resource_groups = map(list(string))<br/>    }))<br/>  })</pre> | <pre>{<br/>  "enable": true,<br/>  "roles": {<br/>    "resource_groups": {<br/>      "terraform-state-rg": [<br/>        "Storage Blob Data Contributor"<br/>      ]<br/>    },<br/>    "subscription": [<br/>      "Reader",<br/>      "Reader and Data Access",<br/>      "PagoPA IaC Reader",<br/>      "DocumentDB Account Contributor",<br/>      "PagoPA API Management Service List Secrets"<br/>    ]<br/>  }<br/>}</pre> | no |
-| <a name="input_environment"></a> [environment](#input\_environment) | Values which are used to generate resource names and location short names. They are all mandatory except for domain, which should not be used only in the case of a resource used by multiple domains. | <pre>object({<br/>    prefix          = string<br/>    env_short       = string<br/>    location        = string<br/>    domain          = string<br/>    instance_number = string<br/>  })</pre> | n/a | yes |
-| <a name="input_identity_type"></a> [identity\_type](#input\_identity\_type) | Scope of the identities to create | `string` | `"infra"` | no |
-| <a name="input_repository"></a> [repository](#input\_repository) | Repositories to federate | <pre>object({<br/>    owner = optional(string, "pagopa")<br/>    name  = string<br/>  })</pre> | n/a | yes |
-| <a name="input_resource_group_name"></a> [resource\_group\_name](#input\_resource\_group\_name) | Resource group to deploy resources to | `string` | n/a | yes |
-| <a name="input_subscription_id"></a> [subscription\_id](#input\_subscription\_id) | Id of the current subscription | `string` | n/a | yes |
-| <a name="input_tags"></a> [tags](#input\_tags) | Resources tags | `map(any)` | n/a | yes |
+| <a name="input_continuos_delivery"></a> [continuos\_delivery](#input\_continuos\_delivery) | Continuos Delivery (CD) identity properties, such as repositories to federated with and RBAC roles at the subscription and resource group levels. | <pre>object({<br/>    enable = bool<br/>    roles = optional(object({<br/>      subscription    = set(string)<br/>      resource_groups = map(list(string))<br/>    }))<br/>  })</pre> | <pre>{<br/>  "enable": true,<br/>  "roles": {<br/>    "resource_groups": {<br/>      "terraform-state-rg": [<br/>        "Storage Blob Data Contributor"<br/>      ]<br/>    },<br/>    "subscription": [<br/>      "Contributor"<br/>    ]<br/>  }<br/>}</pre> | no |
+| <a name="input_continuos_integration"></a> [continuos\_integration](#input\_continuos\_integration) | Continuos Integration (CI) identity properties, such as repositories to federated with and RBAC roles at the subscription and resource group levels. | <pre>object({<br/>    enable = bool<br/>    roles = optional(object({<br/>      subscription    = set(string)<br/>      resource_groups = map(list(string))<br/>    }))<br/>  })</pre> | <pre>{<br/>  "enable": true,<br/>  "roles": {<br/>    "resource_groups": {<br/>      "terraform-state-rg": [<br/>        "Storage Blob Data Contributor"<br/>      ]<br/>    },<br/>    "subscription": [<br/>      "Reader",<br/>      "Reader and Data Access",<br/>      "PagoPA IaC Reader",<br/>      "DocumentDB Account Contributor",<br/>      "PagoPA API Management Service List Secrets"<br/>    ]<br/>  }<br/>}</pre> | no |
+| <a name="input_environment"></a> [environment](#input\_environment) | Environment-specific values used to generate resource names and location short names. | <pre>object({<br/>    prefix          = string<br/>    env_short       = string<br/>    location        = string<br/>    domain          = string<br/>    instance_number = string<br/>  })</pre> | n/a | yes |
+| <a name="input_identity_type"></a> [identity\_type](#input\_identity\_type) | Specifies the scope of the identities to create. Supported values are 'infra', 'opex', and 'app'. | `string` | `"infra"` | no |
+| <a name="input_repository"></a> [repository](#input\_repository) | Details of the GitHub repository to federate with. 'owner' defaults to 'pagopa' if not specified. | <pre>object({<br/>    owner = optional(string, "pagopa")<br/>    name  = string<br/>  })</pre> | n/a | yes |
+| <a name="input_resource_group_name"></a> [resource\_group\_name](#input\_resource\_group\_name) | The name of the resource group where resources will be deployed. | `string` | n/a | yes |
+| <a name="input_subscription_id"></a> [subscription\_id](#input\_subscription\_id) | The ID of the Azure subscription where resources will be deployed. | `string` | n/a | yes |
+| <a name="input_tags"></a> [tags](#input\_tags) | Resources tags. | `map(any)` | n/a | yes |
 
 ## Outputs
 

--- a/infra/modules/azure_federated_identity_with_github/locals.tf
+++ b/infra/modules/azure_federated_identity_with_github/locals.tf
@@ -1,10 +1,26 @@
 locals {
+  naming_config = {
+    prefix          = var.environment.prefix,
+    environment     = var.environment.env_short,
+    location        = var.environment.location
+    instance_number = tonumber(var.environment.instance_number),
+  }
+
+  env_name = {
+    "d" = "dev"
+    "u" = "uat"
+    "p" = "prod"
+  }[var.environment.env_short]
 
   resource_group_name = var.resource_group_name
   #e.g. dx-d-itn-test-app-github-cd-id-01
-  identity_name = "${module.naming_convention.prefix}-%s-github-%s-id-${module.naming_convention.suffix}"
+  identity_name = provider::dx::resource_name(merge(local.naming_config, {
+    domain        = var.environment.domain
+    name          = "%s-github-%s"
+    resource_type = "managed_identity"
+  }))
   #e.g. dx-environment-app-prod-cd
-  federation_prefix = "${var.repository.name}-environment-%s-${module.naming_convention.env_name}-%s"
+  federation_prefix = "${var.repository.name}-environment-%s-${local.env_name}-%s"
 
   is_ci_enabled = var.continuos_integration.enable ? 1 : 0
   is_cd_enabled = var.continuos_delivery.enable ? 1 : 0
@@ -13,14 +29,14 @@ locals {
     audience = ["api://AzureADTokenExchange"]
     issuer   = "https://token.actions.githubusercontent.com"
     # repo:pagopa/dx:environment:app-prod-ci
-    subject = format("repo:${var.repository.owner}/${var.repository.name}:environment:%s-${module.naming_convention.env_name}-ci", var.identity_type)
+    subject = format("repo:${var.repository.owner}/${var.repository.name}:environment:%s-${local.env_name}-ci", var.identity_type)
   } : null
 
   cd_github_federations = local.is_cd_enabled == 1 ? {
     audience = ["api://AzureADTokenExchange"]
     issuer   = "https://token.actions.githubusercontent.com"
     # repo:pagopa/dx:environment:app-prod-cd
-    subject = format("repo:${var.repository.owner}/${var.repository.name}:environment:%s-${module.naming_convention.env_name}-cd", var.identity_type)
+    subject = format("repo:${var.repository.owner}/${var.repository.name}:environment:%s-${local.env_name}-cd", var.identity_type)
   } : null
 
   ci_rg_roles = var.continuos_integration.enable ? tolist(flatten([

--- a/infra/modules/azure_federated_identity_with_github/main.tf
+++ b/infra/modules/azure_federated_identity_with_github/main.tf
@@ -4,19 +4,9 @@ terraform {
       source  = "hashicorp/azurerm"
       version = "~>4"
     }
-  }
-}
-
-module "naming_convention" {
-  source  = "pagopa-dx/azure-naming-convention/azurerm"
-  version = "~> 0.0"
-
-  environment = {
-    prefix          = var.environment.prefix
-    env_short       = var.environment.env_short
-    location        = var.environment.location
-    domain          = null
-    app_name        = var.environment.domain # app_name is mandatory for any resource except resource groups
-    instance_number = var.environment.instance_number
+    dx = {
+      source  = "pagopa-dx/azure"
+      version = ">= 0.0.7, < 1.0.0"
+    }
   }
 }

--- a/infra/modules/azure_federated_identity_with_github/tests/identities.tftest.hcl
+++ b/infra/modules/azure_federated_identity_with_github/tests/identities.tftest.hcl
@@ -123,6 +123,26 @@ run "ids_default" {
     condition     = azurerm_role_assignment.cd_rg[0].role_definition_name == "Storage Blob Data Contributor"
     error_message = "CD identity must have Storage Blob Data Contributor role at terraform-state-rg resource group scope"
   }
+
+  assert {
+    condition     = azurerm_user_assigned_identity.ci[0].name == "dx-d-itn-modules-infra-github-ci-id-01"
+    error_message = "CI identity name must be dx-d-itn-modules-infra-github-ci-id-01"
+  }
+
+  assert {
+    condition     = azurerm_user_assigned_identity.cd[0].name == "dx-d-itn-modules-infra-github-cd-id-01"
+    error_message = "CD identity name must be dx-d-itn-modules-infra-github-cd-id-01"
+  }
+
+  assert {
+    condition     = azurerm_federated_identity_credential.ci_github[0].name == "dx-environment-infra-dev-ci"
+    error_message = "CI identity credential name must be dx-environment-infra-dev-ci"
+  }
+
+  assert {
+    condition     = azurerm_federated_identity_credential.cd_github[0].name == "dx-environment-infra-dev-cd"
+    error_message = "CD identity credential name must be dx-environment-infra-dev-cd"
+  }
 }
 
 run "ids_custom_roles" {

--- a/infra/modules/azure_federated_identity_with_github/tests/setup/README.md
+++ b/infra/modules/azure_federated_identity_with_github/tests/setup/README.md
@@ -9,9 +9,7 @@
 
 ## Modules
 
-| Name | Source | Version |
-|------|--------|---------|
-| <a name="module_naming_convention"></a> [naming\_convention](#module\_naming\_convention) | ../../../azure_naming_convention | n/a |
+No modules.
 
 ## Resources
 

--- a/infra/modules/azure_federated_identity_with_github/tests/setup/main.tf
+++ b/infra/modules/azure_federated_identity_with_github/tests/setup/main.tf
@@ -9,21 +9,8 @@ terraform {
 
 data "azurerm_subscription" "current" {}
 
-module "naming_convention" {
-  source = "../../../azure_naming_convention"
-
-  environment = {
-    prefix          = var.environment.prefix
-    env_short       = var.environment.env_short
-    location        = var.environment.location
-    domain          = var.environment.domain
-    app_name        = var.environment.app_name
-    instance_number = var.environment.instance_number
-  }
-}
-
 data "azurerm_resource_group" "rg" {
-  name = "${var.environment.prefix}-${var.environment.env_short}-itn-test-rg-${module.naming_convention.suffix}"
+  name = "${var.environment.prefix}-${var.environment.env_short}-itn-test-rg-${var.environment.instance_number}"
 }
 
 output "resource_group_name" {

--- a/infra/modules/azure_federated_identity_with_github/variables.tf
+++ b/infra/modules/azure_federated_identity_with_github/variables.tf
@@ -7,28 +7,28 @@ variable "environment" {
     instance_number = string
   })
 
-  description = "Values which are used to generate resource names and location short names. They are all mandatory except for domain, which should not be used only in the case of a resource used by multiple domains."
+  description = "Environment-specific values used to generate resource names and location short names."
 }
 
 variable "tags" {
   type        = map(any)
-  description = "Resources tags"
+  description = "Resources tags."
 }
 
 variable "identity_type" {
   type        = string
   default     = "infra"
-  description = "Scope of the identities to create"
+  description = "Specifies the scope of the identities to create. Supported values are 'infra', 'opex', and 'app'."
 
   validation {
     condition     = contains(["infra", "opex", "app"], var.identity_type)
-    error_message = "Supported values are \"infra\", \"opex\" and \"app\""
+    error_message = "Supported values are 'infra', 'opex', and 'app'."
   }
 }
 
 variable "resource_group_name" {
   type        = string
-  description = "Resource group to deploy resources to"
+  description = "The name of the resource group where resources will be deployed."
 }
 
 variable "repository" {
@@ -36,7 +36,7 @@ variable "repository" {
     owner = optional(string, "pagopa")
     name  = string
   })
-  description = "Repositories to federate"
+  description = "Details of the GitHub repository to federate with. 'owner' defaults to 'pagopa' if not specified."
 }
 
 variable "continuos_integration" {
@@ -66,7 +66,7 @@ variable "continuos_integration" {
     }
   }
 
-  description = "Continuos Integration identity properties, such as repositories to federated with and RBAC roles"
+  description = "Continuos Integration (CI) identity properties, such as repositories to federated with and RBAC roles at the subscription and resource group levels."
 }
 
 variable "continuos_delivery" {
@@ -90,10 +90,10 @@ variable "continuos_delivery" {
     }
   }
 
-  description = "Continuos Delivery identity properties, such as repositories to federated with and RBAC roles"
+  description = "Continuos Delivery (CD) identity properties, such as repositories to federated with and RBAC roles at the subscription and resource group levels."
 }
 
 variable "subscription_id" {
   type        = string
-  description = "Id of the current subscription"
+  description = "The ID of the Azure subscription where resources will be deployed."
 }


### PR DESCRIPTION
Update the README.md with documentation and variables description for `azure_federated_identity_with_github` module, in addition remove the `naming_convention` module in favour of new `resource_name` function.

Resolves: CES-182 CES-947