### PR TITLE
Make subnet_pep_id optional only when force public is true in storage account module

### DIFF
--- a/.changeset/seven-moments-turn.md
+++ b/.changeset/seven-moments-turn.md
@@ -1,0 +1,5 @@
+---
+"azure_storage_account": minor
+---
+
+Make subnet pep id optional if force public access is true

--- a/infra/modules/azure_storage_account/README.md
+++ b/infra/modules/azure_storage_account/README.md
@@ -67,21 +67,21 @@ No modules.
 | <a name="input_force_public_network_access_enabled"></a> [force\_public\_network\_access\_enabled](#input\_force\_public\_network\_access\_enabled) | Allows public network access. Defaults to 'false'. | `bool` | `false` | no |
 | <a name="input_network_rules"></a> [network\_rules](#input\_network\_rules) | Defines network rules for the storage account:<br/>- `default_action`: Default action when no rules match ('Deny' or 'Allow').<br/>- `bypass`: Services bypassing restrictions (valid values: 'Logging', 'Metrics', 'AzureServices').<br/>- `ip_rules`: List of IPv4 addresses or CIDR ranges.<br/>- `virtual_network_subnet_ids`: List of subnet resource IDs.<br/>Defaults to denying all traffic unless explicitly allowed. | <pre>object({<br/>    default_action             = string<br/>    bypass                     = list(string)<br/>    ip_rules                   = list(string)<br/>    virtual_network_subnet_ids = list(string)<br/>  })</pre> | <pre>{<br/>  "bypass": [],<br/>  "default_action": "Deny",<br/>  "ip_rules": [],<br/>  "virtual_network_subnet_ids": []<br/>}</pre> | no |
 | <a name="input_private_dns_zone_resource_group_name"></a> [private\_dns\_zone\_resource\_group\_name](#input\_private\_dns\_zone\_resource\_group\_name) | Resource group for the private DNS zone. Defaults to the virtual network's resource group. | `string` | `null` | no |
-| <a name="input_resource_group_name"></a> [resource\_group\_name](#input\_resource\_group\_name) | Name of the resource group for deployment. | `string` | n/a | yes |
+| <a name="input_resource_group_name"></a> [resource\_group\_name](#input\_resource\_group\_name) | The name of the resource group where the storage account and related resources will be deployed. | `string` | n/a | yes |
 | <a name="input_static_website"></a> [static\_website](#input\_static\_website) | Configures static website hosting with index and error documents. | <pre>object({<br/>    enabled            = optional(bool, false)<br/>    index_document     = optional(string, null)<br/>    error_404_document = optional(string, null)<br/>  })</pre> | <pre>{<br/>  "enabled": false,<br/>  "error_404_document": null,<br/>  "index_document": null<br/>}</pre> | no |
-| <a name="input_subnet_pep_id"></a> [subnet\_pep\_id](#input\_subnet\_pep\_id) | ID of the subnet for private endpoints. | `string` | n/a | yes |
-| <a name="input_subservices_enabled"></a> [subservices\_enabled](#input\_subservices\_enabled) | Enables subservices (blob, file, queue, table). Creates Private Endpoints for enabled services. Defaults to 'blob' only. | <pre>object({<br/>    blob  = optional(bool, true)<br/>    file  = optional(bool, false)<br/>    queue = optional(bool, false)<br/>    table = optional(bool, false)<br/>  })</pre> | n/a | yes |
-| <a name="input_tags"></a> [tags](#input\_tags) | Tags to assign to all resources. | `map(any)` | n/a | yes |
+| <a name="input_subnet_pep_id"></a> [subnet\_pep\_id](#input\_subnet\_pep\_id) | The ID of the subnet used for private endpoints. Required only if `force_public_network_access_enabled` is set to false. | `string` | `null` | no |
+| <a name="input_subservices_enabled"></a> [subservices\_enabled](#input\_subservices\_enabled) | Enables subservices (blob, file, queue, table). Creates Private Endpoints for enabled services. Defaults to 'blob' only. Used only if force\_public\_network\_access\_enabled is false. | <pre>object({<br/>    blob  = optional(bool, true)<br/>    file  = optional(bool, false)<br/>    queue = optional(bool, false)<br/>    table = optional(bool, false)<br/>  })</pre> | `{}` | no |
+| <a name="input_tags"></a> [tags](#input\_tags) | A map of tags to assign to all resources created by this module. | `map(any)` | n/a | yes |
 | <a name="input_tier"></a> [tier](#input\_tier) | Storage account tier depending on demanding workload. Allowed values: 's', 'l'. | `string` | n/a | yes |
 
 ## Outputs
 
 | Name | Description |
 |------|-------------|
-| <a name="output_id"></a> [id](#output\_id) | n/a |
-| <a name="output_name"></a> [name](#output\_name) | n/a |
-| <a name="output_primary_connection_string"></a> [primary\_connection\_string](#output\_primary\_connection\_string) | n/a |
-| <a name="output_primary_web_host"></a> [primary\_web\_host](#output\_primary\_web\_host) | n/a |
-| <a name="output_principal_id"></a> [principal\_id](#output\_principal\_id) | n/a |
-| <a name="output_resource_group_name"></a> [resource\_group\_name](#output\_resource\_group\_name) | n/a |
+| <a name="output_id"></a> [id](#output\_id) | The ID of the Azure Storage Account. |
+| <a name="output_name"></a> [name](#output\_name) | The name of the Azure Storage Account. |
+| <a name="output_primary_connection_string"></a> [primary\_connection\_string](#output\_primary\_connection\_string) | The primary connection string for the Azure Storage Account. |
+| <a name="output_primary_web_host"></a> [primary\_web\_host](#output\_primary\_web\_host) | The primary web host URL for the Azure Storage Account. |
+| <a name="output_principal_id"></a> [principal\_id](#output\_principal\_id) | The principal ID of the managed identity associated with the Azure Storage Account. |
+| <a name="output_resource_group_name"></a> [resource\_group\_name](#output\_resource\_group\_name) | The name of the resource group containing the Azure Storage Account. |
 <!-- END_TF_DOCS -->

--- a/infra/modules/azure_storage_account/data.tf
+++ b/infra/modules/azure_storage_account/data.tf
@@ -1,7 +1,8 @@
 # This data block retrieves information only about Azure Private DNS Zones
 # regarding the subservices enabled by the user in var.subservices_enabled
+# if force_public_network_access_enabled is set to false.
 data "azurerm_private_dns_zone" "storage_account" {
-  for_each            = { for subservice, status in var.subservices_enabled : subservice => status if status == true }
+  for_each            = { for subservice, status in local.peps.create_subservices : subservice => status if status == true }
   name                = local.peps[each.key].dns_zone
   resource_group_name = var.private_dns_zone_resource_group_name
 }

--- a/infra/modules/azure_storage_account/locals.tf
+++ b/infra/modules/azure_storage_account/locals.tf
@@ -28,6 +28,13 @@ locals {
   tier_features = local.tiers[var.tier]
 
   peps = {
+    create_subservices = var.force_public_network_access_enabled ? {
+      blob  = false
+      file  = false
+      queue = false
+      table = false
+    } : var.subservices_enabled
+
     blob = {
       name     = provider::dx::resource_name(merge(local.naming_config, { resource_type = "blob_private_endpoint" }))
       dns_zone = "privatelink.blob.core.windows.net"

--- a/infra/modules/azure_storage_account/networking.tf
+++ b/infra/modules/azure_storage_account/networking.tf
@@ -8,7 +8,8 @@ resource "azurerm_storage_account_network_rules" "network_rules" {
 }
 
 resource "azurerm_private_endpoint" "this" {
-  for_each            = { for subservice, status in var.subservices_enabled : subservice => status if status }
+  for_each = { for subservice, status in local.peps.create_subservices : subservice => status if status }
+
   name                = local.peps[each.key].name
   location            = var.environment.location
   resource_group_name = var.resource_group_name

--- a/infra/modules/azure_storage_account/outputs.tf
+++ b/infra/modules/azure_storage_account/outputs.tf
@@ -1,24 +1,30 @@
 output "name" {
-  value = azurerm_storage_account.this.name
+  value       = azurerm_storage_account.this.name
+  description = "The name of the Azure Storage Account."
 }
 
 output "id" {
-  value = azurerm_storage_account.this.id
+  value       = azurerm_storage_account.this.id
+  description = "The ID of the Azure Storage Account."
 }
 
 output "resource_group_name" {
-  value = azurerm_storage_account.this.resource_group_name
+  value       = azurerm_storage_account.this.resource_group_name
+  description = "The name of the resource group containing the Azure Storage Account."
 }
 
 output "principal_id" {
-  value = azurerm_storage_account.this.identity[0].principal_id
+  value       = azurerm_storage_account.this.identity[0].principal_id
+  description = "The principal ID of the managed identity associated with the Azure Storage Account."
 }
 
 output "primary_connection_string" {
-  value     = azurerm_storage_account.this.primary_connection_string
-  sensitive = true
+  value       = azurerm_storage_account.this.primary_connection_string
+  sensitive   = true
+  description = "The primary connection string for the Azure Storage Account."
 }
 
 output "primary_web_host" {
-  value = azurerm_storage_account.this.primary_web_host
+  value       = azurerm_storage_account.this.primary_web_host
+  description = "The primary web host URL for the Azure Storage Account."
 }

--- a/infra/modules/azure_storage_account/tests/storageaccount.tftest.hcl
+++ b/infra/modules/azure_storage_account/tests/storageaccount.tftest.hcl
@@ -142,4 +142,91 @@ run "storage_account_is_correct_plan" {
     condition     = azurerm_storage_account_customer_managed_key.kv["kv"].user_assigned_identity_id == null
     error_message = "The storage account's managed identity should be used instead of user assigned identity"
   }
+
+  assert {
+    condition     = local.peps.create_subservices.blob == true
+    error_message = "The Storage Account must have blob private endpoint disabled"
+  }
+}
+
+run "public_storage_account_is_correct_plan" {
+  command = plan
+
+  variables {
+    environment = {
+      prefix          = "dx"
+      env_short       = "d"
+      location        = "italynorth"
+      domain          = "modules"
+      app_name        = "test"
+      instance_number = "01"
+    }
+
+    tags = {
+      CostCenter     = "TS000 - Tecnologia e Servizi"
+      CreatedBy      = "Terraform"
+      Environment    = "Dev"
+      BusinessUnit   = "DevEx"
+      ManagementTeam = "Developer Experience"
+      Source      = "https://github.com/pagopa/dx/blob/main/infra/modules/azure_storage_account/tests"
+      Test        = "true"
+      TestName    ="Create Storage Account for test"
+    }
+
+    resource_group_name = run.setup_tests.resource_group_name
+    tier                = "l"
+
+    customer_managed_key = {
+      enabled = true
+      type    = "kv"
+      key_vault_id = "/subscriptions/d7de83e0-0571-40ad-b63a-64c942385eae/resourceGroups/dx-d-itn-common-rg-01/providers/Microsoft.KeyVault/vaults/dx-d-itn-common-kv-01"
+    }
+
+    blob_features = {
+      immutability_policy = {
+        enabled                       = true
+        allow_protected_append_writes = true
+        period_since_creation_in_days = 730
+      }
+      delete_retention_days = 14
+      versioning            = true
+      last_access_time      = true
+      change_feed = {
+        enabled           = true
+        retention_in_days = 30
+      }
+    }
+
+    force_public_network_access_enabled = true
+
+    network_rules = {
+      default_action             = "Deny"
+      bypass                     = ["AzureServices"]
+      ip_rules                   = ["203.0.113.0/24"]
+      virtual_network_subnet_ids = [run.setup_tests.subnet_id]
+    }
+
+    static_website = {
+      enabled            = true
+      index_document     = "index.html"
+      error_404_document = "404.html"
+    }
+
+    custom_domain = {
+      name          = "example.com"
+      use_subdomain = true
+    }
+
+  }
+
+  # Checks some assertions
+  assert {
+    condition     = azurerm_storage_account.this.public_network_access_enabled == true
+    error_message = "The Storage Account must have public network access enabled"
+  }
+
+  assert {
+    condition     = local.peps.create_subservices.blob == false
+    error_message = "The Storage Account must have blob private endpoint disabled"
+  }
 }

--- a/infra/modules/azure_storage_account/variables.tf
+++ b/infra/modules/azure_storage_account/variables.tf
@@ -1,7 +1,7 @@
 # ------------ GENERAL ------------ #
 variable "tags" {
   type        = map(any)
-  description = "Tags to assign to all resources."
+  description = "A map of tags to assign to all resources created by this module."
 }
 
 variable "environment" {
@@ -19,7 +19,7 @@ variable "environment" {
 
 variable "resource_group_name" {
   type        = string
-  description = "Name of the resource group for deployment."
+  description = "The name of the resource group where the storage account and related resources will be deployed."
 }
 
 # ------------ STORAGE ACCOUNT ------------ #
@@ -35,7 +35,13 @@ variable "tier" {
 
 variable "subnet_pep_id" {
   type        = string
-  description = "ID of the subnet for private endpoints."
+  description = "The ID of the subnet used for private endpoints. Required only if `force_public_network_access_enabled` is set to false."
+  default     = null
+
+  validation {
+    condition     = var.force_public_network_access_enabled || (var.subnet_pep_id != null && var.subnet_pep_id != "")
+    error_message = "subnet_pep_id is required when force_public_network_access_enabled is false."
+  }
 }
 
 variable "customer_managed_key" {
@@ -69,7 +75,8 @@ variable "subservices_enabled" {
     queue = optional(bool, false)
     table = optional(bool, false)
   })
-  description = "Enables subservices (blob, file, queue, table). Creates Private Endpoints for enabled services. Defaults to 'blob' only."
+  description = "Enables subservices (blob, file, queue, table). Creates Private Endpoints for enabled services. Defaults to 'blob' only. Used only if force_public_network_access_enabled is false."
+  default     = {}
 }
 
 variable "blob_features" {


### PR DESCRIPTION
This PR updates the Storage Account terraform module logic to make the `subnet_pep_id` variable optional when `force_public_network_access_enabled` is set to true. This change ensures that public network access can be enabled without requiring a private endpoint subnet ID, aligning with scenarios where private endpoints are not needed.

Resolves: CES-893