### PR TITLE
Fix peer dependency version

### DIFF
--- a/.changeset/cute-masks-brush.md
+++ b/.changeset/cute-masks-brush.md
@@ -1,0 +1,5 @@
+---
+"@pagopa/eslint-config": patch
+---
+
+Fix peerDependencies semver requirement

--- a/packages/eslint-config/package.json
+++ b/packages/eslint-config/package.json
@@ -28,6 +28,6 @@
     "prettier": "3.2.5"
   },
   "peerDependencies": {
-    "eslint": "8.57.0"
+    "eslint": "^8.57.0"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -4176,7 +4176,7 @@ __metadata:
     typescript: "npm:~5.2.2"
     typescript-eslint: "npm:^7.6.0"
   peerDependencies:
-    eslint: 8.57.0
+    eslint: ^8.57.0
   languageName: unknown
   linkType: soft
 


### PR DESCRIPTION
The `eslint-config` package required an exact version of `eslint` instead of the previous major (`8.x`)