### PR TITLE
Remove custom `APPINSIGHTS_CONNECTION_STRING` environment variable

### DIFF
--- a/.changeset/hip-seas-beg.md
+++ b/.changeset/hip-seas-beg.md
@@ -1,0 +1,5 @@
+---
+"@pagopa/azure-tracing": patch
+---
+
+Rename `APPINSIGHTS_CONNECTION_STRING` to `APPLICATIONINSIGHTS_CONNECTION_STRING`

--- a/.changeset/khaki-taxis-happen.md
+++ b/.changeset/khaki-taxis-happen.md
@@ -1,0 +1,10 @@
+---
+"azure_app_service": patch
+"azure_app_service_exposed": patch
+"azure_function_app": patch
+"azure_function_app_exposed": patch
+---
+
+Rename `APPINSIGHTS_CONNECTION_STRING` environment variable.
+
+This was previously introduced to let the `@pagopa/azure-tracing` package work.

--- a/infra/modules/azure_app_service/app_service.tf
+++ b/infra/modules/azure_app_service/app_service.tf
@@ -46,8 +46,6 @@ resource "azurerm_linux_web_app" "this" {
     local.application_insights.enable ? {
       # https://learn.microsoft.com/en-us/azure/azure-functions/functions-app-settings#applicationinsights_connection_string
       APPLICATIONINSIGHTS_CONNECTION_STRING = var.application_insights_connection_string
-      # Add environment variable used by the `@pagopa/azure-tracing` package
-      APPINSIGHTS_CONNECTION_STRING = var.application_insights_connection_string
       # https://docs.microsoft.com/en-us/azure/azure-monitor/app/sampling
       APPINSIGHTS_SAMPLING_PERCENTAGE = var.application_insights_sampling_percentage
     } : {}

--- a/infra/modules/azure_app_service/app_service_slot.tf
+++ b/infra/modules/azure_app_service/app_service_slot.tf
@@ -46,8 +46,6 @@ resource "azurerm_linux_web_app_slot" "this" {
     local.application_insights.enable ? {
       # https://learn.microsoft.com/en-us/azure/azure-functions/functions-app-settings#applicationinsights_connection_string
       APPLICATIONINSIGHTS_CONNECTION_STRING = var.application_insights_connection_string
-      # Add environment variable used by the `@pagopa/azure-tracing` package
-      APPINSIGHTS_CONNECTION_STRING = var.application_insights_connection_string
       # https://docs.microsoft.com/en-us/azure/azure-monitor/app/sampling
       APPINSIGHTS_SAMPLING_PERCENTAGE = var.application_insights_sampling_percentage
     } : {}

--- a/infra/modules/azure_app_service_exposed/app_service.tf
+++ b/infra/modules/azure_app_service_exposed/app_service.tf
@@ -44,8 +44,6 @@ resource "azurerm_linux_web_app" "this" {
     local.application_insights.enable ? {
       # https://learn.microsoft.com/en-us/azure/azure-functions/functions-app-settings#applicationinsights_connection_string
       APPLICATIONINSIGHTS_CONNECTION_STRING = var.application_insights_connection_string
-      # Add environment variable used by the `@pagopa/azure-tracing` package
-      APPINSIGHTS_CONNECTION_STRING = var.application_insights_connection_string
       # https://docs.microsoft.com/en-us/azure/azure-monitor/app/sampling
       APPINSIGHTS_SAMPLING_PERCENTAGE = var.application_insights_sampling_percentage
     } : {}

--- a/infra/modules/azure_app_service_exposed/app_service_slot.tf
+++ b/infra/modules/azure_app_service_exposed/app_service_slot.tf
@@ -44,8 +44,6 @@ resource "azurerm_linux_web_app_slot" "this" {
     local.application_insights.enable ? {
       # https://learn.microsoft.com/en-us/azure/azure-functions/functions-app-settings#applicationinsights_connection_string
       APPLICATIONINSIGHTS_CONNECTION_STRING = var.application_insights_connection_string
-      # Add environment variable used by the `@pagopa/azure-tracing` package
-      APPINSIGHTS_CONNECTION_STRING = var.application_insights_connection_string
       # https://docs.microsoft.com/en-us/azure/azure-monitor/app/sampling
       APPINSIGHTS_SAMPLING_PERCENTAGE = var.application_insights_sampling_percentage
     } : {}

--- a/infra/modules/azure_function_app/function_app.tf
+++ b/infra/modules/azure_function_app/function_app.tf
@@ -57,8 +57,6 @@ resource "azurerm_linux_function_app" "this" {
       # AI SDK Sampling, to be used programmatically
       # https://docs.microsoft.com/en-us/azure/azure-monitor/app/sampling
       APPINSIGHTS_SAMPLING_PERCENTAGE = var.application_insights_sampling_percentage,
-      # Add environment variable used by the `@pagopa/azure-tracing` package
-      APPINSIGHTS_CONNECTION_STRING = var.application_insights_connection_string,
 
       # Azure Function Host (runtime) AI Sampling
       # https://learn.microsoft.com/en-us/azure/azure-functions/configure-monitoring?tabs=v2#overriding-monitoring-configuration-at-runtime

--- a/infra/modules/azure_function_app/function_app_slot.tf
+++ b/infra/modules/azure_function_app/function_app_slot.tf
@@ -53,8 +53,6 @@ resource "azurerm_linux_function_app_slot" "this" {
       # AI SDK Sampling, to be used programmatically
       # https://docs.microsoft.com/en-us/azure/azure-monitor/app/sampling
       APPINSIGHTS_SAMPLING_PERCENTAGE = "100",
-      # Add environment variable used by the `@pagopa/azure-tracing` package
-      APPINSIGHTS_CONNECTION_STRING = var.application_insights_connection_string,
 
       # Azure Function Host (runtime) AI Sampling
       # https://learn.microsoft.com/en-us/azure/azure-functions/configure-monitoring?tabs=v2#overriding-monitoring-configuration-at-runtime

--- a/infra/modules/azure_function_app_exposed/function_app.tf
+++ b/infra/modules/azure_function_app_exposed/function_app.tf
@@ -53,8 +53,6 @@ resource "azurerm_linux_function_app" "this" {
       # AI SDK Sampling, to be used programmatically
       # https://docs.microsoft.com/en-us/azure/azure-monitor/app/sampling
       APPINSIGHTS_SAMPLING_PERCENTAGE = var.application_insights_sampling_percentage,
-      # Add environment variable used by the `@pagopa/azure-tracing` package
-      APPINSIGHTS_CONNECTION_STRING = var.application_insights_connection_string,
 
       # Azure Function Host (runtime) AI Sampling
       # https://learn.microsoft.com/en-us/azure/azure-functions/configure-monitoring?tabs=v2#overriding-monitoring-configuration-at-runtime

--- a/infra/modules/azure_function_app_exposed/function_app_slot.tf
+++ b/infra/modules/azure_function_app_exposed/function_app_slot.tf
@@ -49,8 +49,6 @@ resource "azurerm_linux_function_app_slot" "this" {
       # AI SDK Sampling, to be used programmatically
       # https://docs.microsoft.com/en-us/azure/azure-monitor/app/sampling
       APPINSIGHTS_SAMPLING_PERCENTAGE = "100",
-      # Add environment variable used by the `@pagopa/azure-tracing` package
-      APPINSIGHTS_CONNECTION_STRING = var.application_insights_connection_string,
 
       # Azure Function Host (runtime) AI Sampling
       # https://learn.microsoft.com/en-us/azure/azure-functions/configure-monitoring?tabs=v2#overriding-monitoring-configuration-at-runtime

--- a/packages/azure-tracing/README.md
+++ b/packages/azure-tracing/README.md
@@ -43,10 +43,10 @@ For more background on this workaround, see:
 
 In order to enable tracing, you also need to set the following environment variables:
 
-| **Name**                            | **Required** | **Default** |
-| ----------------------------------- | ------------ | ----------- |
-| **APPINSIGHTS_SAMPLING_PERCENTAGE** | false        | 5           |
-| **APPLICATIONINSIGHTS_CONNECTION_STRING**   | true         | -           |
+| **Name**                                  | **Required** | **Default** |
+| ----------------------------------------- | ------------ | ----------- |
+| **APPINSIGHTS_SAMPLING_PERCENTAGE**       | false        | 5           |
+| **APPLICATIONINSIGHTS_CONNECTION_STRING** | true         | -           |
 
 #### Step 2: Register Azure Function Lifecycle Hooks
 

--- a/packages/azure-tracing/README.md
+++ b/packages/azure-tracing/README.md
@@ -46,7 +46,7 @@ In order to enable tracing, you also need to set the following environment varia
 | **Name**                            | **Required** | **Default** |
 | ----------------------------------- | ------------ | ----------- |
 | **APPINSIGHTS_SAMPLING_PERCENTAGE** | false        | 5           |
-| **APPINSIGHTS_CONNECTION_STRING**   | true         | -           |
+| **APPLICATIONINSIGHTS_CONNECTION_STRING**   | true         | -           |
 
 #### Step 2: Register Azure Function Lifecycle Hooks
 

--- a/packages/azure-tracing/src/azure/monitor/env.ts
+++ b/packages/azure-tracing/src/azure/monitor/env.ts
@@ -16,9 +16,6 @@ export const loadEnv = () =>
     },
     runtimeEnv: process.env,
     server: {
-      APPINSIGHTS_CONNECTION_STRING: z
-        .string()
-        .describe("The connection string for Application Insights."),
       APPINSIGHTS_SAMPLING_PERCENTAGE: z
         .optional(
           z.coerce
@@ -35,5 +32,8 @@ export const loadEnv = () =>
           return isNaN(percentage) ? 5 : percentage;
         })
         .transform((value) => value / 100),
+      APPLICATIONINSIGHTS_CONNECTION_STRING: z
+        .string()
+        .describe("The connection string for Application Insights."),
     },
   });

--- a/packages/azure-tracing/src/azure/monitor/index.ts
+++ b/packages/azure-tracing/src/azure/monitor/index.ts
@@ -12,21 +12,45 @@ import { registerUndiciInstrumentation } from "../opentelemetry/azure-undici-ins
 import { initFromEnv } from "./start-from-env";
 
 /**
- * Initialize the Azure Monitor with the given instrumentations.
- * Call this function to register the instrumentations with the Azure Monitor.
- * By default, the Undici instrumentation is included; if you need to add more,
- * you can pass them as an array of instrumentations.
+ * Initialize the Azure Monitor with the given instrumentations and options.
+ * This function sets up telemetry collection for your application by registering
+ * the provided instrumentations and configuring Azure Monitor OpenTelemetry.
+ *
+ * By default, the Undici instrumentation is included. You can extend the functionality
+ * by passing additional instrumentations as an array.
  *
  * @remarks
- * This function will register the given instrumentations with the Azure Monitor.
- * It is recommended to call this function at the beginning of your application.
+ * - This function should be called at the start of your application to ensure
+ *   telemetry is collected from the beginning.
+ * - If `azureMonitorOptions` is not provided, the configuration will be initialized
+ *   using environment variables. @see README for more details.
  *
  * @example
+ * // Basic usage with default settings
+ * import { initAzureMonitor } from "@pagopa/azure-tracing/azure-monitor";
+ * initAzureMonitor();
+ *
+ * @example
+ * // Usage with custom instrumentations
+ * import { initAzureMonitor } from "@pagopa/azure-tracing/azure-monitor";
+ * import { MyCustomInstrumentation } from "my-custom-instrumentation";
+ *
+ * initAzureMonitor([new MyCustomInstrumentation()]);
+ *
+ * @example
+ * // Usage with custom Azure Monitor options
  * import { initAzureMonitor } from "@pagopa/azure-tracing/azure-monitor";
  *
- * initAzureMonitor();
- * @param instrumentations the list of instrumentations to register with the Azure Monitor.
- * @param azureMonitorOptions custom configuration for Azure Monitor. If not provided, then it will be initialized using the environment variables.
+ * initAzureMonitor([], {
+ *   azureMonitorExporterOptions: {
+ *    connectionString: "theConnectionString",
+ *   },
+ *   // other options...
+ * });
+ *
+ * @param instrumentations - The list of instrumentations to register with the Azure Monitor.
+ * @param azureMonitorOptions - Custom configuration for Azure Monitor. If not provided,
+ *   it will be initialized using environment variables.
  */
 export const initAzureMonitor = (
   instrumentations: readonly Instrumentation[] = [],

--- a/packages/azure-tracing/src/azure/monitor/start-from-env.ts
+++ b/packages/azure-tracing/src/azure/monitor/start-from-env.ts
@@ -7,7 +7,7 @@ export const initFromEnv = () => {
 
   return useAzureMonitor({
     azureMonitorExporterOptions: {
-      connectionString: env.APPINSIGHTS_CONNECTION_STRING,
+      connectionString: env.APPLICATIONINSIGHTS_CONNECTION_STRING,
     },
     enableLiveMetrics: true,
     samplingRatio: env.APPINSIGHTS_SAMPLING_PERCENTAGE,


### PR DESCRIPTION
Decouple the `@pagopa/azure-tracing` package from the DX modules.

Fixes CES-967