### PR TITLE
Add Renovate configuration for automated dependency updates

### DIFF
--- a/.github/actions/azure-login/action.yaml
+++ b/.github/actions/azure-login/action.yaml
@@ -6,7 +6,7 @@ runs:
 
   steps:
     - name: Azure Login
-      uses: azure/login@a65d910e8af852a8061c627c456678983e180302 # v2
+      uses: azure/login@a65d910e8af852a8061c627c456678983e180302 # v2.2.0
       with:
         client-id: ${{ env.ARM_CLIENT_ID }}
         tenant-id: ${{ env.ARM_TENANT_ID }}

--- a/.github/actions/node-setup/action.yaml
+++ b/.github/actions/node-setup/action.yaml
@@ -19,7 +19,7 @@ runs:
       shell: bash
       run: corepack enable
 
-    - uses: actions/setup-node@1e60f620b9541d16bece96c5465dc8ee9832be0b #v4.0.3
+    - uses: actions/setup-node@1e60f620b9541d16bece96c5465dc8ee9832be0b # v4.0.3
       with:
         node-version-file: ".node-version"
         cache: yarn
@@ -27,7 +27,7 @@ runs:
 
     - name: Setup turbo cache
       if: ${{ env.TURBO_CACHE_DIR != '' }}
-      uses: actions/cache@1bd1e32a3bdc45362d1e726936510720a7c30a57 #v4.2.0
+      uses: actions/cache@1bd1e32a3bdc45362d1e726936510720a7c30a57 # v4.2.0
       with:
         path: ${{ env.TURBO_CACHE_DIR }}
         key: ${{ runner.os }}-turbo-${{ github.sha }}

--- a/.github/actions/slack-notification/action.yaml
+++ b/.github/actions/slack-notification/action.yaml
@@ -38,7 +38,7 @@ runs:
 
     # Reference: https://github.com/slackapi/slack-github-action
     - name: Slack Notification
-      uses: slackapi/slack-github-action@70cd7be8e40a46e8b0eced40b0de447bdb42f68e # pin@v1.26.0
+      uses: slackapi/slack-github-action@70cd7be8e40a46e8b0eced40b0de447bdb42f68e # v1.26.0
       with:
         payload: |
           {

--- a/.github/actions/terraform-setup/action.yaml
+++ b/.github/actions/terraform-setup/action.yaml
@@ -22,7 +22,7 @@ runs:
       with:
         override_version: ${{ inputs.terraform_version }}
 
-    - uses: hashicorp/setup-terraform@a1502cd9e758c50496cc9ac5308c4843bcd56d36 # pin@v3.0.0
+    - uses: hashicorp/setup-terraform@a1502cd9e758c50496cc9ac5308c4843bcd56d36 # v3.0.0
       name: Setup Terraform
       with:
         terraform_version: ${{ steps.get-version.outputs.terraform_version }}

--- a/renovate.json
+++ b/renovate.json
@@ -1,0 +1,13 @@
+{
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "extends": [
+    "config:recommended"
+  ],
+  "packageRules": [
+    {
+      "matchManagers": ["github-actions"],
+      "groupName": "GitHub Actions",
+      "schedule": ["* 0-8 * * 1"]
+    }
+  ]
+}

--- a/renovate.json
+++ b/renovate.json
@@ -6,7 +6,14 @@
   "packageRules": [
     {
       "matchManagers": ["github-actions"],
+      "separateMultipleMajor": true,
       "groupName": "GitHub Actions",
+      "schedule": ["* 0-8 * * 1"]
+    },
+    {
+      "matchManagers": ["terraform", "terraform-version"],
+      "separateMultipleMajor": true,
+      "groupName": "Terraform providers and modules",
       "schedule": ["* 0-8 * * 1"]
     }
   ]


### PR DESCRIPTION
This PR introduces Renovate bot configuration to automate dependency management across the project. Key features:

- Sets up separate grouping for GitHub Actions updates
- Configures scheduled updates for Terraform providers and modules
- Schedules updates to run on Monday before 8AM
- Uses separate PR for major version updates

Resolves: CES-977 CES-978