### PR TITLE
TLS 1.3 Upgrade for Azure Function Apps modules

### DIFF
--- a/.changeset/twelve-turtles-grin.md
+++ b/.changeset/twelve-turtles-grin.md
@@ -1,0 +1,6 @@
+---
+"azure_function_app_exposed": minor
+"azure_function_app": minor
+---
+
+TLS 1.3 Upgrade for Azure Function Apps

--- a/infra/modules/azure_function_app/function_app.tf
+++ b/infra/modules/azure_function_app/function_app.tf
@@ -26,6 +26,7 @@ resource "azurerm_linux_function_app" "this" {
     health_check_eviction_time_in_min      = 2
     ip_restriction_default_action          = "Deny"
     application_insights_key               = var.application_insights_key
+    minimum_tls_version                    = 1.3
 
     application_stack {
       node_version = var.stack == "node" ? var.node_version : null

--- a/infra/modules/azure_function_app/function_app_slot.tf
+++ b/infra/modules/azure_function_app/function_app_slot.tf
@@ -25,6 +25,7 @@ resource "azurerm_linux_function_app_slot" "this" {
     health_check_eviction_time_in_min      = 2
     ip_restriction_default_action          = "Deny"
     application_insights_key               = var.application_insights_key
+    minimum_tls_version                    = 1.3
 
     application_stack {
       node_version = var.stack == "node" ? var.node_version : null

--- a/infra/modules/azure_function_app/tests/functionapp.tftest.hcl
+++ b/infra/modules/azure_function_app/tests/functionapp.tftest.hcl
@@ -84,10 +84,18 @@ run "function_app_is_correct_plan" {
     condition     = azurerm_linux_function_app.this.site_config[0].application_stack[0].node_version == "20"
     error_message = "The Function App must use Node version 20"
   }
-
+  assert {
+    condition     = azurerm_linux_function_app.this.site_config[0].minimum_tls_version == "1.3"
+    error_message = "The Function App must use TLS version 1.3"
+  }
   assert {
     condition     = azurerm_linux_function_app_slot.this[0].site_config[0].application_stack[0].node_version == "20"
     error_message = "The Function App staging slot must use Node version 20"
+  }
+
+  assert {
+    condition     = azurerm_linux_function_app_slot.this[0].site_config[0].minimum_tls_version == "1.3"
+    error_message = "The Function App staging slot must use TLS version 1.3"
   }
 
   assert {

--- a/infra/modules/azure_function_app/tests/functionapp.tftest.hcl
+++ b/infra/modules/azure_function_app/tests/functionapp.tftest.hcl
@@ -84,10 +84,12 @@ run "function_app_is_correct_plan" {
     condition     = azurerm_linux_function_app.this.site_config[0].application_stack[0].node_version == "20"
     error_message = "The Function App must use Node version 20"
   }
+
   assert {
     condition     = azurerm_linux_function_app.this.site_config[0].minimum_tls_version == "1.3"
     error_message = "The Function App must use TLS version 1.3"
   }
+  
   assert {
     condition     = azurerm_linux_function_app_slot.this[0].site_config[0].application_stack[0].node_version == "20"
     error_message = "The Function App staging slot must use Node version 20"

--- a/infra/modules/azure_function_app_exposed/function_app.tf
+++ b/infra/modules/azure_function_app_exposed/function_app.tf
@@ -22,6 +22,7 @@ resource "azurerm_linux_function_app" "this" {
     application_insights_connection_string = local.application_insights.enable ? var.application_insights_connection_string : null
     health_check_path                      = var.health_check_path
     health_check_eviction_time_in_min      = 2
+    minimum_tls_version                    = 1.3
 
     application_stack {
       node_version = var.stack == "node" ? var.node_version : null

--- a/infra/modules/azure_function_app_exposed/function_app_slot.tf
+++ b/infra/modules/azure_function_app_exposed/function_app_slot.tf
@@ -21,6 +21,7 @@ resource "azurerm_linux_function_app_slot" "this" {
     application_insights_connection_string = local.application_insights.enable ? var.application_insights_connection_string : null
     health_check_path                      = var.health_check_path
     health_check_eviction_time_in_min      = 2
+    minimum_tls_version                    = 1.3
 
     application_stack {
       node_version = var.stack == "node" ? var.node_version : null

--- a/infra/modules/azure_function_app_exposed/tests/functionapp.tftest.hcl
+++ b/infra/modules/azure_function_app_exposed/tests/functionapp.tftest.hcl
@@ -57,22 +57,27 @@ run "function_app_is_correct_plan" {
 
   assert {
     condition     = azurerm_service_plan.this[0].sku_name == "P0v3"
-    error_message = "The App Service Plan is incorrect, have to be P0v3"
+    error_message = "The Function App Plan is incorrect, have to be P0v3"
   }
 
   assert {
     condition     = azurerm_linux_function_app.this.https_only == true
-    error_message = "The App Service should enforce HTTPS"
+    error_message = "The Function App should enforce HTTPS"
   }
 
   assert {
     condition     = azurerm_linux_function_app.this.site_config[0].application_stack[0].node_version == "20"
-    error_message = "The App Service must use Node version 20"
+    error_message = "The Function App must use Node version 20"
+  }
+
+  assert {
+    condition     = azurerm_linux_function_app.this.site_config[0].minimum_tls_version == "1.3"
+    error_message = "The Function App must use TLS version 1.3"
   }
 
   assert {
     condition     = azurerm_linux_function_app.this.site_config[0].always_on == true
-    error_message = "The App Service should have Always On enabled"
+    error_message = "The Function App should have Always On enabled"
   }
 
   assert {

--- a/infra/modules/azure_function_app_exposed/tests/functionapp.tftest.hcl
+++ b/infra/modules/azure_function_app_exposed/tests/functionapp.tftest.hcl
@@ -57,7 +57,7 @@ run "function_app_is_correct_plan" {
 
   assert {
     condition     = azurerm_service_plan.this[0].sku_name == "P0v3"
-    error_message = "The Function App Plan is incorrect, have to be P0v3"
+    error_message = "The App Service Plan is incorrect, have to be P0v3"
   }
 
   assert {


### PR DESCRIPTION
Upgrade minimum TLS version from 1.2 to 1.3 for Function Apps and Slots for policy alignment. 
This change affects both standard and exposed modules.

Resolves: CES-836