### PR TITLE
TLS 1.3 Upgrade for Azure App Services modules

### DIFF
--- a/.changeset/fast-olives-call.md
+++ b/.changeset/fast-olives-call.md
@@ -1,0 +1,6 @@
+---
+"azure_app_service_exposed": minor
+"azure_app_service": minor
+---
+
+TLS 1.3 Upgrade for Azure App Services

--- a/infra/modules/azure_app_service/app_service.tf
+++ b/infra/modules/azure_app_service/app_service.tf
@@ -20,6 +20,7 @@ resource "azurerm_linux_web_app" "this" {
     health_check_path                 = var.health_check_path
     health_check_eviction_time_in_min = 2
     ip_restriction_default_action     = "Deny"
+    minimum_tls_version               = 1.3
 
     application_stack {
       node_version        = var.stack == "node" ? "${var.node_version}-lts" : null

--- a/infra/modules/azure_app_service/app_service_slot.tf
+++ b/infra/modules/azure_app_service/app_service_slot.tf
@@ -20,6 +20,7 @@ resource "azurerm_linux_web_app_slot" "this" {
     health_check_path                 = var.health_check_path
     health_check_eviction_time_in_min = 2
     ip_restriction_default_action     = "Deny"
+    minimum_tls_version               = 1.3
 
     application_stack {
       node_version        = var.stack == "node" ? "${var.node_version}-lts" : null

--- a/infra/modules/azure_app_service/tests/appservice.tftest.hcl
+++ b/infra/modules/azure_app_service/tests/appservice.tftest.hcl
@@ -85,6 +85,16 @@ run "app_service_is_correct_plan" {
   }
 
   assert {
+    condition     = azurerm_linux_web_app.this.site_config[0].minimum_tls_version == "1.3"
+    error_message = "The App Service must use TLS version 1.3"
+  }
+
+  assert {
+    condition     = azurerm_linux_web_app_slot.this[0].site_config[0].minimum_tls_version == "1.3"
+    error_message = "The App Service staging slot must use TLS version 1.3"
+  }
+
+  assert {
     condition     = length(azurerm_subnet.this) == 1
     error_message = "Subnet should be created"
   }

--- a/infra/modules/azure_app_service_exposed/app_service.tf
+++ b/infra/modules/azure_app_service_exposed/app_service.tf
@@ -18,6 +18,7 @@ resource "azurerm_linux_web_app" "this" {
     vnet_route_all_enabled            = true
     health_check_path                 = var.health_check_path
     health_check_eviction_time_in_min = 2
+    minimum_tls_version               = 1.3
 
     application_stack {
       node_version        = var.stack == "node" ? "${var.node_version}-lts" : null

--- a/infra/modules/azure_app_service_exposed/app_service_slot.tf
+++ b/infra/modules/azure_app_service_exposed/app_service_slot.tf
@@ -18,6 +18,7 @@ resource "azurerm_linux_web_app_slot" "this" {
     vnet_route_all_enabled            = true
     health_check_path                 = var.health_check_path
     health_check_eviction_time_in_min = 2
+    minimum_tls_version               = 1.3
 
     application_stack {
       node_version        = var.stack == "node" ? "${var.node_version}-lts" : null

--- a/infra/modules/azure_app_service_exposed/tests/appservice.tftest.hcl
+++ b/infra/modules/azure_app_service_exposed/tests/appservice.tftest.hcl
@@ -79,4 +79,14 @@ run "app_service_is_correct_plan" {
     condition     = azurerm_linux_web_app.this.site_config[0].always_on == true
     error_message = "The App Service should have Always On enabled"
   }
+
+  assert {
+    condition     = azurerm_linux_web_app.this.site_config[0].minimum_tls_version == "1.3"
+    error_message = "The App Service must use TLS version 1.3"
+  }
+
+  assert {
+    condition     = azurerm_linux_web_app_slot.this[0].site_config[0].minimum_tls_version == "1.3"
+    error_message = "The App Service staging slot must use TLS version 1.3"
+  }
 }


### PR DESCRIPTION
Upgrade minimum TLS version from 1.2 to 1.3 for App Services and Slots for policy alignment.
This change affects both standard and exposed modules.

Resolves: CES-982