### PR TITLE
Disable local authentication for Cosmos DB accounts

### DIFF
--- a/.changeset/rotten-taxes-slide.md
+++ b/.changeset/rotten-taxes-slide.md
@@ -1,0 +1,5 @@
+---
+"azure_cosmos_account": minor
+---
+
+Added `local_authentication_disabled = true` to Azure Cosmos DB module

--- a/infra/modules/azure_cosmos_account/cosmos.tf
+++ b/infra/modules/azure_cosmos_account/cosmos.tf
@@ -7,6 +7,7 @@ resource "azurerm_cosmosdb_account" "this" {
   automatic_failover_enabled    = true
   key_vault_key_id              = var.customer_managed_key.enabled ? var.customer_managed_key.key_vault_key_id : null
   public_network_access_enabled = var.force_public_network_access_enabled
+  local_authentication_disabled = true
 
   geo_location {
     location          = local.primary_location

--- a/infra/modules/azure_cosmos_account/tests/cosmos.tftest.hcl
+++ b/infra/modules/azure_cosmos_account/tests/cosmos.tftest.hcl
@@ -85,6 +85,11 @@ run "cosmos_is_correct_plan" {
   }
 
   assert {
+    condition     = azurerm_cosmosdb_account.this.local_authentication_disabled == true
+    error_message = "The Cosmos DB account must have local authentication disabled"
+  }
+
+  assert {
     condition     = azurerm_cosmosdb_account.this.consistency_policy[0].consistency_level == "BoundedStaleness"
     error_message = "The Cosmos DB consistency level must be Bounded Staleness"
   }
@@ -102,6 +107,14 @@ run "cosmos_is_correct_plan" {
   assert {
     condition     = [ for value in azurerm_cosmosdb_account.this.capabilities : value.name ][0] == "EnableServerless"
     error_message = "The Cosmos DB account must have serverless enabled"
+  }
+
+  assert {
+    condition = length(setintersection(
+      [for value in azurerm_cosmosdb_account.this.capabilities : value.name],
+      ["EnableMongo", "EnableCassandra", "EnableTable", "EnableGremlin"]
+    )) == 0
+    error_message = "The Cosmos DB account must not have capabilities EnableMongo, EnableCassandra, EnableTable, or EnableGremlin"
   }
 
   assert {


### PR DESCRIPTION
This PR disables local authentication for Cosmos DB accounts by setting `local_authentication_disabled = true`. This security enhancement aligns with Technology policies.

Resolves: CES-980