### PR TITLE
Remove app insights private dns zones

### DIFF
--- a/.changeset/open-dingos-prove.md
+++ b/.changeset/open-dingos-prove.md
@@ -1,0 +1,5 @@
+---
+"azure_core_infra": patch
+---
+
+Remove Application Insights private DNS zones

--- a/.changeset/open-dingos-prove.md
+++ b/.changeset/open-dingos-prove.md
@@ -2,4 +2,4 @@
 "azure_core_infra": patch
 ---
 
-Remove Application Insights private DNS zones
+Remove Application Insights private DNS zones. The simple addition of these dns zones makes public application insights unreachable.

--- a/infra/modules/azure_core_infra/locals.tf
+++ b/infra/modules/azure_core_infra/locals.tf
@@ -34,9 +34,5 @@ locals {
     "management_azure_api_net" = "management.azure-api.net"
     "scm_azure_api_net"        = "scm.azure-api.net"
     "container_app"            = "privatelink.italynorth.azurecontainerapps.io"
-    "monitor"                  = "privatelink.monitor.azure.com"
-    "monitor_oms"              = "privatelink.oms.opinsights.azure.com"
-    "monitor_ods"              = "privatelink.ods.opinsights.azure.com"
-    "monitor_agents"           = "privatelink.agentsvc.azure-automation.net"
   }
 }


### PR DESCRIPTION
The simple addition of these dns zones makes public application insights unreachable.