### PR TITLE
TLS 1.3 Upgrade for Azure App Services modules Major

### DIFF
--- a/.changeset/fast-olives-call.md
+++ b/.changeset/fast-olives-call.md
@@ -1,6 +1,6 @@
 ---
-"azure_app_service_exposed": minor
-"azure_app_service": minor
+"azure_app_service_exposed": major
+"azure_app_service": major
 ---
 
-TLS 1.3 Upgrade for Azure App Services
+TLS 1.3 Upgrade for Azure App Services. This change requires azurerm provider version 4.8.0 or higher.

--- a/.changeset/fast-olives-call.md
+++ b/.changeset/fast-olives-call.md
@@ -1,0 +1,6 @@
+---
+"azure_app_service_exposed": minor
+"azure_app_service": minor
+---
+
+TLS 1.3 Upgrade for Azure App Services

--- a/infra/modules/azure_app_service/README.md
+++ b/infra/modules/azure_app_service/README.md
@@ -31,7 +31,7 @@ For a complete example of how to use this module, refer to the [examples/complet
 
 | Name | Version |
 |------|---------|
-| <a name="requirement_azurerm"></a> [azurerm](#requirement\_azurerm) | >= 3.100.0, < 5.0 |
+| <a name="requirement_azurerm"></a> [azurerm](#requirement\_azurerm) | >= 4.8.0, < 5.0 |
 | <a name="requirement_dx"></a> [dx](#requirement\_dx) | >= 0.0.6, < 1.0.0 |
 
 ## Modules

--- a/infra/modules/azure_app_service/app_service.tf
+++ b/infra/modules/azure_app_service/app_service.tf
@@ -20,6 +20,7 @@ resource "azurerm_linux_web_app" "this" {
     health_check_path                 = var.health_check_path
     health_check_eviction_time_in_min = 2
     ip_restriction_default_action     = "Deny"
+    minimum_tls_version               = 1.3
 
     application_stack {
       node_version        = var.stack == "node" ? "${var.node_version}-lts" : null

--- a/infra/modules/azure_app_service/app_service_slot.tf
+++ b/infra/modules/azure_app_service/app_service_slot.tf
@@ -20,6 +20,7 @@ resource "azurerm_linux_web_app_slot" "this" {
     health_check_path                 = var.health_check_path
     health_check_eviction_time_in_min = 2
     ip_restriction_default_action     = "Deny"
+    minimum_tls_version               = 1.3
 
     application_stack {
       node_version        = var.stack == "node" ? "${var.node_version}-lts" : null

--- a/infra/modules/azure_app_service/examples/complete/README.md
+++ b/infra/modules/azure_app_service/examples/complete/README.md
@@ -5,7 +5,7 @@
 
 | Name | Version |
 |------|---------|
-| <a name="requirement_azurerm"></a> [azurerm](#requirement\_azurerm) | >= 3.100.0, < 5.0 |
+| <a name="requirement_azurerm"></a> [azurerm](#requirement\_azurerm) | >= 4.8.0, < 5.0 |
 | <a name="requirement_dx"></a> [dx](#requirement\_dx) | >= 0.0.6, < 1.0.0 |
 
 ## Modules

--- a/infra/modules/azure_app_service/examples/complete/versions.tf
+++ b/infra/modules/azure_app_service/examples/complete/versions.tf
@@ -10,7 +10,7 @@ terraform {
   required_providers {
     azurerm = {
       source  = "hashicorp/azurerm"
-      version = ">= 3.100.0, < 5.0"
+      version = ">= 4.8.0, < 5.0"
     }
     dx = {
       source  = "pagopa-dx/azure"

--- a/infra/modules/azure_app_service/main.tf
+++ b/infra/modules/azure_app_service/main.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     azurerm = {
       source  = "hashicorp/azurerm"
-      version = ">= 3.100.0, < 5.0"
+      version = ">= 4.8.0, < 5.0"
     }
     dx = {
       source  = "pagopa-dx/azure"

--- a/infra/modules/azure_app_service/tests/appservice.tftest.hcl
+++ b/infra/modules/azure_app_service/tests/appservice.tftest.hcl
@@ -85,6 +85,16 @@ run "app_service_is_correct_plan" {
   }
 
   assert {
+    condition     = azurerm_linux_web_app.this.site_config[0].minimum_tls_version == "1.3"
+    error_message = "The App Service must use TLS version 1.3"
+  }
+
+  assert {
+    condition     = azurerm_linux_web_app_slot.this[0].site_config[0].minimum_tls_version == "1.3"
+    error_message = "The App Service staging slot must use TLS version 1.3"
+  }
+
+  assert {
     condition     = length(azurerm_subnet.this) == 1
     error_message = "Subnet should be created"
   }

--- a/infra/modules/azure_app_service/tests/setup/README.md
+++ b/infra/modules/azure_app_service/tests/setup/README.md
@@ -5,7 +5,7 @@
 
 | Name | Version |
 |------|---------|
-| <a name="requirement_azurerm"></a> [azurerm](#requirement\_azurerm) | >= 3.100.0, < 5.0 |
+| <a name="requirement_azurerm"></a> [azurerm](#requirement\_azurerm) | >= 4.8.0, < 5.0 |
 | <a name="requirement_dx"></a> [dx](#requirement\_dx) | >= 0.0.6, < 1.0.0 |
 
 ## Modules

--- a/infra/modules/azure_app_service/tests/setup/main.tf
+++ b/infra/modules/azure_app_service/tests/setup/main.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     azurerm = {
       source  = "hashicorp/azurerm"
-      version = ">= 3.100.0, < 5.0"
+      version = ">= 4.8.0, < 5.0"
     }
     dx = {
       source  = "pagopa-dx/azure"

--- a/infra/modules/azure_app_service_exposed/README.md
+++ b/infra/modules/azure_app_service_exposed/README.md
@@ -30,7 +30,7 @@ For a complete example of how to use this module, refer to the [examples/complet
 
 | Name | Version |
 |------|---------|
-| <a name="requirement_azurerm"></a> [azurerm](#requirement\_azurerm) | >= 3.111.0, < 5.0 |
+| <a name="requirement_azurerm"></a> [azurerm](#requirement\_azurerm) | >= 4.8.0, < 5.0 |
 | <a name="requirement_dx"></a> [dx](#requirement\_dx) | >= 0.0.6, < 1.0.0 |
 
 ## Modules

--- a/infra/modules/azure_app_service_exposed/app_service.tf
+++ b/infra/modules/azure_app_service_exposed/app_service.tf
@@ -18,6 +18,7 @@ resource "azurerm_linux_web_app" "this" {
     vnet_route_all_enabled            = true
     health_check_path                 = var.health_check_path
     health_check_eviction_time_in_min = 2
+    minimum_tls_version               = 1.3
 
     application_stack {
       node_version        = var.stack == "node" ? "${var.node_version}-lts" : null

--- a/infra/modules/azure_app_service_exposed/app_service_slot.tf
+++ b/infra/modules/azure_app_service_exposed/app_service_slot.tf
@@ -18,6 +18,7 @@ resource "azurerm_linux_web_app_slot" "this" {
     vnet_route_all_enabled            = true
     health_check_path                 = var.health_check_path
     health_check_eviction_time_in_min = 2
+    minimum_tls_version               = 1.3
 
     application_stack {
       node_version        = var.stack == "node" ? "${var.node_version}-lts" : null

--- a/infra/modules/azure_app_service_exposed/examples/complete/README.md
+++ b/infra/modules/azure_app_service_exposed/examples/complete/README.md
@@ -5,7 +5,7 @@
 
 | Name | Version |
 |------|---------|
-| <a name="requirement_azurerm"></a> [azurerm](#requirement\_azurerm) | >= 3.111.0, < 5.0 |
+| <a name="requirement_azurerm"></a> [azurerm](#requirement\_azurerm) | >= 4.8.0, < 5.0 |
 | <a name="requirement_dx"></a> [dx](#requirement\_dx) | >= 0.0.6, < 1.0.0 |
 
 ## Modules

--- a/infra/modules/azure_app_service_exposed/examples/complete/versions.tf
+++ b/infra/modules/azure_app_service_exposed/examples/complete/versions.tf
@@ -10,7 +10,7 @@ terraform {
   required_providers {
     azurerm = {
       source  = "hashicorp/azurerm"
-      version = ">= 3.111.0, < 5.0"
+      version = ">= 4.8.0, < 5.0"
     }
     dx = {
       source  = "pagopa-dx/azure"

--- a/infra/modules/azure_app_service_exposed/main.tf
+++ b/infra/modules/azure_app_service_exposed/main.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     azurerm = {
       source  = "hashicorp/azurerm"
-      version = ">= 3.111.0, < 5.0"
+      version = ">= 4.8.0, < 5.0"
     }
     dx = {
       source  = "pagopa-dx/azure"

--- a/infra/modules/azure_app_service_exposed/tests/appservice.tftest.hcl
+++ b/infra/modules/azure_app_service_exposed/tests/appservice.tftest.hcl
@@ -79,4 +79,14 @@ run "app_service_is_correct_plan" {
     condition     = azurerm_linux_web_app.this.site_config[0].always_on == true
     error_message = "The App Service should have Always On enabled"
   }
+
+  assert {
+    condition     = azurerm_linux_web_app.this.site_config[0].minimum_tls_version == "1.3"
+    error_message = "The App Service must use TLS version 1.3"
+  }
+
+  assert {
+    condition     = azurerm_linux_web_app_slot.this[0].site_config[0].minimum_tls_version == "1.3"
+    error_message = "The App Service staging slot must use TLS version 1.3"
+  }
 }

--- a/infra/modules/azure_app_service_exposed/tests/setup/README.md
+++ b/infra/modules/azure_app_service_exposed/tests/setup/README.md
@@ -5,7 +5,7 @@
 
 | Name | Version |
 |------|---------|
-| <a name="requirement_azurerm"></a> [azurerm](#requirement\_azurerm) | >= 3.111.0, < 5.0 |
+| <a name="requirement_azurerm"></a> [azurerm](#requirement\_azurerm) | >= 4.8.0, < 5.0 |
 | <a name="requirement_dx"></a> [dx](#requirement\_dx) | >= 0.0.6, < 1.0.0 |
 
 ## Modules

--- a/infra/modules/azure_app_service_exposed/tests/setup/main.tf
+++ b/infra/modules/azure_app_service_exposed/tests/setup/main.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     azurerm = {
       source  = "hashicorp/azurerm"
-      version = ">= 3.111.0, < 5.0"
+      version = ">= 4.8.0, < 5.0"
     }
     dx = {
       source  = "pagopa-dx/azure"


### PR DESCRIPTION
Upgrade minimum TLS version from 1.2 to 1.3 for App Services and Slots for policy alignment.
This change affects both standard and exposed modules.

Resolves: CES-982