### PR TITLE
add rules to nsg

### DIFF
--- a/.changeset/tame-yaks-shout.md
+++ b/.changeset/tame-yaks-shout.md
@@ -1,0 +1,5 @@
+---
+"azure_api_management": minor
+---
+
+Add recommended rules to APIM NSG

--- a/infra/modules/azure_api_management/network.tf
+++ b/infra/modules/azure_api_management/network.tf
@@ -37,7 +37,7 @@ resource "azurerm_network_security_group" "nsg_apim" {
   location            = var.environment.location
 
   security_rule {
-    name                       = "managementapim"
+    name                       = "apim-management"
     priority                   = 200
     direction                  = "Inbound"
     access                     = "Allow"

--- a/infra/modules/azure_api_management/network.tf
+++ b/infra/modules/azure_api_management/network.tf
@@ -46,6 +46,7 @@ resource "azurerm_network_security_group" "nsg_apim" {
     destination_port_range     = "3443"
     source_address_prefix      = "ApiManagement"
     destination_address_prefix = "VirtualNetwork"
+    description                = "Management endpoint for Azure portal and PowerShell"
   }
 
   security_rule {
@@ -58,6 +59,7 @@ resource "azurerm_network_security_group" "nsg_apim" {
     destination_port_range     = "6390"
     source_address_prefix      = "AzureLoadBalancer"
     destination_address_prefix = "VirtualNetwork"
+    description                = "Azure Infrastructure Load Balancer"
   }
 
   security_rule {
@@ -70,6 +72,7 @@ resource "azurerm_network_security_group" "nsg_apim" {
     destination_port_range     = "443"
     source_address_prefix      = "VirtualNetwork"
     destination_address_prefix = "Storage"
+    description                = "Dependency on Azure Storage for core service functionality"
   }
 
   security_rule {
@@ -82,6 +85,7 @@ resource "azurerm_network_security_group" "nsg_apim" {
     destination_port_range     = "1433"
     source_address_prefix      = "VirtualNetwork"
     destination_address_prefix = "SQL"
+    description                = "Access to Azure SQL endpoints for core service functionality"
   }
 
   security_rule {
@@ -94,6 +98,7 @@ resource "azurerm_network_security_group" "nsg_apim" {
     destination_port_range     = "443"
     source_address_prefix      = "VirtualNetwork"
     destination_address_prefix = "AzureKeyVault"
+    description                = "Access to Azure Key Vault for core service functionality"
   }
 
   security_rule {
@@ -106,6 +111,7 @@ resource "azurerm_network_security_group" "nsg_apim" {
     destination_port_range     = "1886, 443"
     source_address_prefix      = "VirtualNetwork"
     destination_address_prefix = "AzureMonitor"
+    description                = "Publish Diagnostics Logs and Metrics, Resource Health, and Application Insights"
   }
 
   tags = local.tags

--- a/infra/modules/azure_api_management/network.tf
+++ b/infra/modules/azure_api_management/network.tf
@@ -38,7 +38,7 @@ resource "azurerm_network_security_group" "nsg_apim" {
 
   security_rule {
     name                       = "managementapim"
-    priority                   = 100
+    priority                   = 200
     direction                  = "Inbound"
     access                     = "Allow"
     protocol                   = "Tcp"
@@ -46,6 +46,66 @@ resource "azurerm_network_security_group" "nsg_apim" {
     destination_port_range     = "3443"
     source_address_prefix      = "ApiManagement"
     destination_address_prefix = "VirtualNetwork"
+  }
+
+  security_rule {
+    name                       = "azure-load-balancer"
+    priority                   = 201
+    direction                  = "Inbound"
+    access                     = "Allow"
+    protocol                   = "Tcp"
+    source_port_range          = "*"
+    destination_port_range     = "6390"
+    source_address_prefix      = "AzureLoadBalancer"
+    destination_address_prefix = "VirtualNetwork"
+  }
+
+  security_rule {
+    name                       = "storage"
+    priority                   = 200
+    direction                  = "Outbound"
+    access                     = "Allow"
+    protocol                   = "Tcp"
+    source_port_range          = "*"
+    destination_port_range     = "443"
+    source_address_prefix      = "VirtualNetwork"
+    destination_address_prefix = "Storage"
+  }
+
+  security_rule {
+    name                       = "sql"
+    priority                   = 201
+    direction                  = "Outbound"
+    access                     = "Allow"
+    protocol                   = "Tcp"
+    source_port_range          = "*"
+    destination_port_range     = "1433"
+    source_address_prefix      = "VirtualNetwork"
+    destination_address_prefix = "SQL"
+  }
+
+  security_rule {
+    name                       = "azure-keyvault"
+    priority                   = 202
+    direction                  = "Outbound"
+    access                     = "Allow"
+    protocol                   = "Tcp"
+    source_port_range          = "*"
+    destination_port_range     = "443"
+    source_address_prefix      = "VirtualNetwork"
+    destination_address_prefix = "AzureKeyVault"
+  }
+
+  security_rule {
+    name                       = "azure-monitor"
+    priority                   = 203
+    direction                  = "Outbound"
+    access                     = "Allow"
+    protocol                   = "Tcp"
+    source_port_range          = "*"
+    destination_port_range     = "1886, 443"
+    source_address_prefix      = "VirtualNetwork"
+    destination_address_prefix = "AzureMonitor"
   }
 
   tags = local.tags


### PR DESCRIPTION
Add [recommended rules](https://learn.microsoft.com/en-us/azure/api-management/api-management-using-with-internal-vnet#configure-nsg-rules) to APIM's NSG.
Default settings put restrictions over components connectivity (e.g. inbounds are allowed only from VNET and load balancer), but the new rules restrict inbounds ports and the outbound services. 

Close CES-1017