### PR TITLE
Revert TLS from 1.3 to 1.2 for App Service and Function App modules

### DIFF
--- a/.changeset/plain-bees-sit.md
+++ b/.changeset/plain-bees-sit.md
@@ -1,8 +1,8 @@
 ---
-"azure_function_app_exposed": minor
-"azure_app_service_exposed": minor
-"azure_function_app": minor
-"azure_app_service": minor
+"azure_function_app_exposed": patch
+"azure_app_service_exposed": patch
+"azure_function_app": patch
+"azure_app_service": patch
 ---
 
 Revert from TLS 1.3 to TLS 1.2 for app service and function app modules, added new variable named tls_version with default 1.2

--- a/.changeset/plain-bees-sit.md
+++ b/.changeset/plain-bees-sit.md
@@ -5,4 +5,6 @@
 "azure_app_service": patch
 ---
 
-Revert from TLS 1.3 to TLS 1.2 for app service and function app modules, added new variable named tls_version with default 1.2
+Revert from TLS `1.3` to TLS `1.2` for app service and function app modules, added new variable named tls_version with default `1.2`.
+
+Ref.: [Azure API Management throwing error in connecting to backend which requires minimum TLS 1.3](https://learn.microsoft.com/en-us/answers/questions/2125989/azure-api-management-throwing-error-in-connecting)

--- a/.changeset/plain-bees-sit.md
+++ b/.changeset/plain-bees-sit.md
@@ -1,0 +1,8 @@
+---
+"azure_function_app_exposed": minor
+"azure_app_service_exposed": minor
+"azure_function_app": minor
+"azure_app_service": minor
+---
+
+Revert from TLS 1.3 to TLS 1.2 for app service and function app modules, added new variable named tls_version with default 1.2

--- a/infra/modules/azure_app_service/README.md
+++ b/infra/modules/azure_app_service/README.md
@@ -74,6 +74,7 @@ No modules.
 | <a name="input_subnet_service_endpoints"></a> [subnet\_service\_endpoints](#input\_subnet\_service\_endpoints) | Enable service endpoints for the underlying subnet. Should only be set if dependencies do not use private endpoints. | <pre>object({<br/>    cosmos  = optional(bool, false)<br/>    storage = optional(bool, false)<br/>    web     = optional(bool, false)<br/>  })</pre> | `null` | no |
 | <a name="input_tags"></a> [tags](#input\_tags) | Map of tags to apply to all created resources. | `map(any)` | n/a | yes |
 | <a name="input_tier"></a> [tier](#input\_tier) | Resource tier based on workload. Allowed values: 's', 'm', 'l', 'xl'. Legacy values: 'premium', 'standard', 'test'. | `string` | `"l"` | no |
+| <a name="input_tls_version"></a> [tls\_version](#input\_tls\_version) | Minimum TLS version for the App Service. | `number` | `1.2` | no |
 | <a name="input_virtual_network"></a> [virtual\_network](#input\_virtual\_network) | Virtual network where the subnet will be created. | <pre>object({<br/>    name                = string<br/>    resource_group_name = string<br/>  })</pre> | n/a | yes |
 
 ## Outputs

--- a/infra/modules/azure_app_service/app_service.tf
+++ b/infra/modules/azure_app_service/app_service.tf
@@ -20,7 +20,7 @@ resource "azurerm_linux_web_app" "this" {
     health_check_path                 = var.health_check_path
     health_check_eviction_time_in_min = 2
     ip_restriction_default_action     = "Deny"
-    minimum_tls_version               = 1.3
+    minimum_tls_version               = var.tls_version
 
     application_stack {
       node_version        = var.stack == "node" ? "${var.node_version}-lts" : null

--- a/infra/modules/azure_app_service/app_service_slot.tf
+++ b/infra/modules/azure_app_service/app_service_slot.tf
@@ -20,7 +20,7 @@ resource "azurerm_linux_web_app_slot" "this" {
     health_check_path                 = var.health_check_path
     health_check_eviction_time_in_min = 2
     ip_restriction_default_action     = "Deny"
-    minimum_tls_version               = 1.3
+    minimum_tls_version               = var.tls_version
 
     application_stack {
       node_version        = var.stack == "node" ? "${var.node_version}-lts" : null

--- a/infra/modules/azure_app_service/tests/appservice.tftest.hcl
+++ b/infra/modules/azure_app_service/tests/appservice.tftest.hcl
@@ -85,13 +85,13 @@ run "app_service_is_correct_plan" {
   }
 
   assert {
-    condition     = azurerm_linux_web_app.this.site_config[0].minimum_tls_version == "1.3"
-    error_message = "The App Service must use TLS version 1.3"
+    condition     = azurerm_linux_web_app.this.site_config[0].minimum_tls_version == "1.2"
+    error_message = "The App Service must use TLS version 1.2"
   }
 
   assert {
-    condition     = azurerm_linux_web_app_slot.this[0].site_config[0].minimum_tls_version == "1.3"
-    error_message = "The App Service staging slot must use TLS version 1.3"
+    condition     = azurerm_linux_web_app_slot.this[0].site_config[0].minimum_tls_version == "1.2"
+    error_message = "The App Service staging slot must use TLS version 1.2"
   }
 
   assert {

--- a/infra/modules/azure_app_service/variables.tf
+++ b/infra/modules/azure_app_service/variables.tf
@@ -143,3 +143,9 @@ variable "subnet_service_endpoints" {
   description = "Enable service endpoints for the underlying subnet. Should only be set if dependencies do not use private endpoints."
   default     = null
 }
+
+variable "tls_version" {
+  type        = number
+  default     = 1.2
+  description = "Minimum TLS version for the App Service."
+}

--- a/infra/modules/azure_app_service_exposed/README.md
+++ b/infra/modules/azure_app_service_exposed/README.md
@@ -63,6 +63,7 @@ No modules.
 | <a name="input_sticky_app_setting_names"></a> [sticky\_app\_setting\_names](#input\_sticky\_app\_setting\_names) | List of application setting names that are not swapped between slots. | `list(string)` | `[]` | no |
 | <a name="input_tags"></a> [tags](#input\_tags) | Map of tags to apply to all created resources. | `map(any)` | n/a | yes |
 | <a name="input_tier"></a> [tier](#input\_tier) | Resource tier based on workload. Allowed values: 'xs', 's', 'm', 'l', 'xl'. Legacy values: 'premium', 'standard', 'test'. | `string` | `"l"` | no |
+| <a name="input_tls_version"></a> [tls\_version](#input\_tls\_version) | Minimum TLS version for the App Service. | `number` | `1.2` | no |
 
 ## Outputs
 

--- a/infra/modules/azure_app_service_exposed/app_service.tf
+++ b/infra/modules/azure_app_service_exposed/app_service.tf
@@ -18,7 +18,7 @@ resource "azurerm_linux_web_app" "this" {
     vnet_route_all_enabled            = true
     health_check_path                 = var.health_check_path
     health_check_eviction_time_in_min = 2
-    minimum_tls_version               = 1.3
+    minimum_tls_version               = var.tls_version
 
     application_stack {
       node_version        = var.stack == "node" ? "${var.node_version}-lts" : null

--- a/infra/modules/azure_app_service_exposed/app_service_slot.tf
+++ b/infra/modules/azure_app_service_exposed/app_service_slot.tf
@@ -18,7 +18,7 @@ resource "azurerm_linux_web_app_slot" "this" {
     vnet_route_all_enabled            = true
     health_check_path                 = var.health_check_path
     health_check_eviction_time_in_min = 2
-    minimum_tls_version               = 1.3
+    minimum_tls_version               = var.tls_version
 
     application_stack {
       node_version        = var.stack == "node" ? "${var.node_version}-lts" : null

--- a/infra/modules/azure_app_service_exposed/tests/appservice.tftest.hcl
+++ b/infra/modules/azure_app_service_exposed/tests/appservice.tftest.hcl
@@ -81,12 +81,12 @@ run "app_service_is_correct_plan" {
   }
 
   assert {
-    condition     = azurerm_linux_web_app.this.site_config[0].minimum_tls_version == "1.3"
-    error_message = "The App Service must use TLS version 1.3"
+    condition     = azurerm_linux_web_app.this.site_config[0].minimum_tls_version == "1.2"
+    error_message = "The App Service must use TLS version 1.2"
   }
 
   assert {
-    condition     = azurerm_linux_web_app_slot.this[0].site_config[0].minimum_tls_version == "1.3"
-    error_message = "The App Service staging slot must use TLS version 1.3"
+    condition     = azurerm_linux_web_app_slot.this[0].site_config[0].minimum_tls_version == "1.2"
+    error_message = "The App Service staging slot must use TLS version 1.2"
   }
 }

--- a/infra/modules/azure_app_service_exposed/variables.tf
+++ b/infra/modules/azure_app_service_exposed/variables.tf
@@ -100,3 +100,9 @@ variable "sticky_app_setting_names" {
   description = "List of application setting names that are not swapped between slots."
   default     = []
 }
+
+variable "tls_version" {
+  type        = number
+  default     = 1.2
+  description = "Minimum TLS version for the App Service."
+}

--- a/infra/modules/azure_function_app/README.md
+++ b/infra/modules/azure_function_app/README.md
@@ -83,6 +83,7 @@ No modules.
 | <a name="input_subnet_service_endpoints"></a> [subnet\_service\_endpoints](#input\_subnet\_service\_endpoints) | Enable service endpoints for the subnet used by the Function App. Set this only if dependencies do not use private endpoints. | <pre>object({<br/>    cosmos  = optional(bool, false)<br/>    storage = optional(bool, false)<br/>    web     = optional(bool, false)<br/>  })</pre> | `null` | no |
 | <a name="input_tags"></a> [tags](#input\_tags) | A map of tags to assign to the resources. | `map(any)` | n/a | yes |
 | <a name="input_tier"></a> [tier](#input\_tier) | Resource tiers depending on workload. Allowed values are 's', 'm', 'l', 'xl'. Legacy values 'premium', 'standard', 'test' are also supported for backward compatibility. | `string` | `"l"` | no |
+| <a name="input_tls_version"></a> [tls\_version](#input\_tls\_version) | Minimum TLS version for the App Service. | `number` | `1.2` | no |
 | <a name="input_virtual_network"></a> [virtual\_network](#input\_virtual\_network) | Details of the virtual network where the subnet for the Function App will be created. | <pre>object({<br/>    name                = string<br/>    resource_group_name = string<br/>  })</pre> | n/a | yes |
 
 ## Outputs

--- a/infra/modules/azure_function_app/function_app.tf
+++ b/infra/modules/azure_function_app/function_app.tf
@@ -26,7 +26,7 @@ resource "azurerm_linux_function_app" "this" {
     health_check_eviction_time_in_min      = 2
     ip_restriction_default_action          = "Deny"
     application_insights_key               = var.application_insights_key
-    minimum_tls_version                    = 1.3
+    minimum_tls_version                    = var.tls_version
 
     application_stack {
       node_version = var.stack == "node" ? var.node_version : null

--- a/infra/modules/azure_function_app/function_app_slot.tf
+++ b/infra/modules/azure_function_app/function_app_slot.tf
@@ -25,7 +25,7 @@ resource "azurerm_linux_function_app_slot" "this" {
     health_check_eviction_time_in_min      = 2
     ip_restriction_default_action          = "Deny"
     application_insights_key               = var.application_insights_key
-    minimum_tls_version                    = 1.3
+    minimum_tls_version                    = var.tls_version
 
     application_stack {
       node_version = var.stack == "node" ? var.node_version : null

--- a/infra/modules/azure_function_app/tests/functionapp.tftest.hcl
+++ b/infra/modules/azure_function_app/tests/functionapp.tftest.hcl
@@ -86,8 +86,8 @@ run "function_app_is_correct_plan" {
   }
 
   assert {
-    condition     = azurerm_linux_function_app.this.site_config[0].minimum_tls_version == "1.3"
-    error_message = "The Function App must use TLS version 1.3"
+    condition     = azurerm_linux_function_app.this.site_config[0].minimum_tls_version == "1.2"
+    error_message = "The Function App must use TLS version 1.2"
   }
 
   assert {
@@ -96,8 +96,8 @@ run "function_app_is_correct_plan" {
   }
 
   assert {
-    condition     = azurerm_linux_function_app_slot.this[0].site_config[0].minimum_tls_version == "1.3"
-    error_message = "The Function App staging slot must use TLS version 1.3"
+    condition     = azurerm_linux_function_app_slot.this[0].site_config[0].minimum_tls_version == "1.2"
+    error_message = "The Function App staging slot must use TLS version 1.2"
   }
 
   assert {

--- a/infra/modules/azure_function_app/variables.tf
+++ b/infra/modules/azure_function_app/variables.tf
@@ -188,3 +188,9 @@ variable "has_durable_functions" {
   description = "Set to true if the Function App hosts Durable Functions."
   default     = false
 }
+
+variable "tls_version" {
+  type        = number
+  default     = 1.2
+  description = "Minimum TLS version for the App Service."
+}

--- a/infra/modules/azure_function_app_exposed/README.md
+++ b/infra/modules/azure_function_app_exposed/README.md
@@ -56,6 +56,7 @@ No modules.
 | <a name="input_sticky_app_setting_names"></a> [sticky\_app\_setting\_names](#input\_sticky\_app\_setting\_names) | A list of application setting names that should remain constant and not be swapped between slots. | `list(string)` | `[]` | no |
 | <a name="input_tags"></a> [tags](#input\_tags) | A map of tags to assign to the resources. | `map(any)` | n/a | yes |
 | <a name="input_tier"></a> [tier](#input\_tier) | Resource tiers depending on workload. Allowed values are 's', 'm', 'l', 'xl', 'xxl'. Legacy values 'premium', 'standard', 'test' are also supported for backward compatibility. | `string` | `"l"` | no |
+| <a name="input_tls_version"></a> [tls\_version](#input\_tls\_version) | Minimum TLS version for the App Service. | `number` | `1.2` | no |
 
 ## Outputs
 

--- a/infra/modules/azure_function_app_exposed/function_app.tf
+++ b/infra/modules/azure_function_app_exposed/function_app.tf
@@ -22,7 +22,7 @@ resource "azurerm_linux_function_app" "this" {
     application_insights_connection_string = local.application_insights.enable ? var.application_insights_connection_string : null
     health_check_path                      = var.health_check_path
     health_check_eviction_time_in_min      = 2
-    minimum_tls_version                    = 1.3
+    minimum_tls_version                    = var.tls_version
 
     application_stack {
       node_version = var.stack == "node" ? var.node_version : null

--- a/infra/modules/azure_function_app_exposed/function_app_slot.tf
+++ b/infra/modules/azure_function_app_exposed/function_app_slot.tf
@@ -21,7 +21,7 @@ resource "azurerm_linux_function_app_slot" "this" {
     application_insights_connection_string = local.application_insights.enable ? var.application_insights_connection_string : null
     health_check_path                      = var.health_check_path
     health_check_eviction_time_in_min      = 2
-    minimum_tls_version                    = 1.3
+    minimum_tls_version                    = var.tls_version
 
     application_stack {
       node_version = var.stack == "node" ? var.node_version : null

--- a/infra/modules/azure_function_app_exposed/tests/functionapp.tftest.hcl
+++ b/infra/modules/azure_function_app_exposed/tests/functionapp.tftest.hcl
@@ -71,8 +71,8 @@ run "function_app_is_correct_plan" {
   }
 
   assert {
-    condition     = azurerm_linux_function_app.this.site_config[0].minimum_tls_version == "1.3"
-    error_message = "The Function App must use TLS version 1.3"
+    condition     = azurerm_linux_function_app.this.site_config[0].minimum_tls_version == "1.2"
+    error_message = "The Function App must use TLS version 1.2"
   }
 
   assert {

--- a/infra/modules/azure_function_app_exposed/variables.tf
+++ b/infra/modules/azure_function_app_exposed/variables.tf
@@ -129,3 +129,9 @@ variable "has_durable_functions" {
   description = "Set to true if the Function App hosts Durable Functions."
   default     = false
 }
+
+variable "tls_version" {
+  type        = number
+  default     = 1.2
+  description = "Minimum TLS version for the App Service."
+}


### PR DESCRIPTION
This pull request reverts the TLS protocol version from 1.3 back to 1.2 for our App Service and Function App infrastructure modules. The change was necessary due to compatibility issues discovered with certain client applications that don't fully support TLS 1.3 yet.

Added new `tls_version` variable to allow flexible selection of TLS version.

Resolves: CES-1024