### PR TITLE
Set network access property to false for Service Bus Namespace

### DIFF
--- a/.changeset/ready-goats-bathe.md
+++ b/.changeset/ready-goats-bathe.md
@@ -1,0 +1,5 @@
+---
+"azure_service_bus_namespace": patch
+---
+
+Set public network access property to false to comply with Terarform provider suggestions

--- a/infra/modules/azure_service_bus_namespace/service_bus.tf
+++ b/infra/modules/azure_service_bus_namespace/service_bus.tf
@@ -8,6 +8,8 @@ resource "azurerm_servicebus_namespace" "this" {
   capacity                     = local.capacity
   premium_messaging_partitions = local.partitions
 
+  public_network_access_enabled = false
+
   network_rule_set {
     public_network_access_enabled = false
     default_action                = local.default_action


### PR DESCRIPTION
Match what [documentation suggests](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/servicebus_namespace#public_network_access_enabled-2), even though no practical change was noticed

Close CES-1031