### PR TITLE
Prevent terraform plan from acquiring lock in drift detection

### DIFF
--- a/.github/workflows/infra_drift_detection.yml
+++ b/.github/workflows/infra_drift_detection.yml
@@ -104,7 +104,7 @@ jobs:
         working-directory: ${{ steps.directory.outputs.dir }}
         run: |
           set -uo pipefail
-          terraform plan -no-color -detailed-exitcode -out=plan.tfplan | grep -v "hidden-link:"
+          terraform plan -lock=false -no-color -detailed-exitcode -out=plan.tfplan | grep -v "hidden-link:"
 
           EXIT_CODE=${PIPESTATUS[0]}
           if [ "$EXIT_CODE" -eq 1 ]; then


### PR DESCRIPTION
This PR updates the `terraform plan` command within the drift detection workflow to include the `-lock=false` flag.

This change prevents the `plan` operation from attempting to acquire a lock on the Terraform state file. In scenarios where another Terraform operation (e.g., `apply`) might be holding the lock, the `plan` command would previously wait, potentially blocking the CI pipeline.

By adding `-lock=false`, the plan can proceed without locking, ensuring the drift detection workflow does not get stuck and cause pipeline delays or failures due to lock contention. This is a safe operation for a read-only command like `plan`.

Resolves: CES-1028