### PR TITLE
Add support to Azure Function with programming model v3

### DIFF
--- a/.changeset/great-tips-jump.md
+++ b/.changeset/great-tips-jump.md
@@ -1,0 +1,5 @@
+---
+"@pagopa/azure-tracing": minor
+---
+
+Enhance support for legacy Azure Function (v3) to ensure the requests are properly correlated.

--- a/.changeset/great-tips-jump.md
+++ b/.changeset/great-tips-jump.md
@@ -3,3 +3,21 @@
 ---
 
 Enhance support for legacy Azure Function (v3) to ensure the requests are properly correlated.
+
+## Usage
+
+For legacy Azure Functions, you can use the wrap the Azure Function within the `withOtelContextFunctionV3` to make sure the requests are properly correlated.
+
+```typescript
+import { AzureFunction, Context as FunctionContext } from "@azure/functions"; // "@azure/functions": "^3"
+import createAzureFunctionHandler from "@pagopa/express-azure-functions/dist/src/createAzureFunctionsHandler.js";
+
+import { withOtelContextFunctionV3 } from "@pagopa/azure-tracing/azure-functions/v3"; // from version ^0.4.0
+
+export const expressToAzureFunction =
+  (app: Express): AzureFunction =>
+  (context: FunctionContext): void => {
+    app.set("context", context);
+    withOtelContextFunctionV3(context)(createAzureFunctionHandler(app)); // wrap the function execution in the OpenTelemetry context
+  };
+```

--- a/.changeset/great-tips-jump.md
+++ b/.changeset/great-tips-jump.md
@@ -12,7 +12,7 @@ For legacy Azure Functions, you can use the wrap the Azure Function within the `
 import { AzureFunction, Context as FunctionContext } from "@azure/functions"; // "@azure/functions": "^3"
 import createAzureFunctionHandler from "@pagopa/express-azure-functions/dist/src/createAzureFunctionsHandler.js";
 
-import { withOtelContextFunctionV3 } from "@pagopa/azure-tracing/azure-functions/v3"; // from version ^0.4.0
+import { withOtelContextFunctionV3 } from "@pagopa/azure-tracing/azure-functions/v3"; // "@pagopa/azure-tracing": "^0.4"
 
 export const expressToAzureFunction =
   (app: Express): AzureFunction =>

--- a/.changeset/loud-dryers-travel.md
+++ b/.changeset/loud-dryers-travel.md
@@ -1,0 +1,5 @@
+---
+"@pagopa/azure-tracing": patch
+---
+
+Upgrade dependencies

--- a/packages/azure-tracing/README.md
+++ b/packages/azure-tracing/README.md
@@ -72,13 +72,7 @@ registerAzureFunctionHooks(app);
 
 For Azure Functions using the v3 programming model, you can use the `withOtelContextFunctionV3` helper function to wrap your handlers and ensure OpenTelemetry context propagation. This function works with the v3 `Context` object structure.
 
-First, import the function:
-
-```ts
-import { withOtelContextFunctionV3 } from "@pagopa/azure-tracing/functions/v3";
-```
-
-Then, wrap your v3 function handler with `withOtelContextFunctionV3`:
+To wrap the execution of the Azure function in the Otel context, take inspiration from the following code snippet:
 
 ```ts
 import { AzureFunction, Context as FunctionContext } from "@azure/functions"; // "@azure/functions": "^3"

--- a/packages/azure-tracing/README.md
+++ b/packages/azure-tracing/README.md
@@ -68,6 +68,35 @@ registerAzureFunctionHooks(app);
 ...
 ```
 
+### Instrumenting Azure Functions v3 Handlers
+
+For Azure Functions using the v3 programming model, you can use the `withOtelContextFunctionV3` helper function to wrap your handlers and ensure OpenTelemetry context propagation. This function works with the v3 `Context` object structure.
+
+First, import the function:
+
+```ts
+import { withOtelContextFunctionV3 } from "@pagopa/azure-tracing/functions/v3";
+```
+
+Then, wrap your v3 function handler with `withOtelContextFunctionV3`:
+
+```ts
+import { AzureFunction, Context as FunctionContext } from "@azure/functions"; // "@azure/functions": "^3"
+import createAzureFunctionHandler from "@pagopa/express-azure-functions/dist/src/createAzureFunctionsHandler.js";
+
+import { withOtelContextFunctionV3 } from "@pagopa/azure-tracing/azure-functions/v3"; // from version ^0.4.0
+
+export const expressToAzureFunction =
+  (app: Express): AzureFunction =>
+  (context: FunctionContext): void => {
+    app.set("context", context);
+    withOtelContextFunctionV3(context)(createAzureFunctionHandler(app)); // wrap the function execution in the OpenTelemetry context
+  };
+```
+
+> [!NOTE]
+> The `withOtelContextFunctionV3` function is designed based on the structure of the v3 `Context` object, specifically its `traceContext` property. While this package primarily uses the v4 `@azure/functions` library, this function provides a way to apply the same OpenTelemetry context propagation logic to your existing v3 handlers.
+
 ### Enabling Azure Monitor Telemetry
 
 If you want to enable Azure Monitor telemetry in your application, and you don't have those issues previously described, you can do so in the following ways:

--- a/packages/azure-tracing/README.md
+++ b/packages/azure-tracing/README.md
@@ -70,15 +70,20 @@ registerAzureFunctionHooks(app);
 
 ### Instrumenting Azure Functions v3 Handlers
 
-For Azure Functions using the v3 programming model, you can use the `withOtelContextFunctionV3` helper function to wrap your handlers and ensure OpenTelemetry context propagation. This function works with the v3 `Context` object structure.
+For Azure Functions using the v3 programming model, the recommended way to enable OpenTelemetry tracing is to use the `NODE_OPTIONS` environment variable, just like for v4 functions:
 
-To wrap the execution of the Azure function in the Otel context, take inspiration from the following code snippet:
+```bash
+NODE_OPTIONS=--import @pagopa/azure-tracing
+```
+
+This will automatically enable OpenTelemetry tracing and route telemetry to Azure Monitor.
+
+Then, wrap the execution of the Azure function in the OpenTelemetry context; take inspiration from the following code snippet:
 
 ```ts
 import { AzureFunction, Context as FunctionContext } from "@azure/functions"; // "@azure/functions": "^3"
 import createAzureFunctionHandler from "@pagopa/express-azure-functions/dist/src/createAzureFunctionsHandler.js";
-
-import { withOtelContextFunctionV3 } from "@pagopa/azure-tracing/azure-functions/v3"; // from version ^0.4.0
+import { withOtelContextFunctionV3 } from "@pagopa/azure-tracing/azure-functions/v3"; // "@pagopa/azure-tracing": "^0.4"
 
 export const expressToAzureFunction =
   (app: Express): AzureFunction =>

--- a/packages/azure-tracing/README.md
+++ b/packages/azure-tracing/README.md
@@ -88,9 +88,6 @@ export const expressToAzureFunction =
   };
 ```
 
-> [!NOTE]
-> The `withOtelContextFunctionV3` function is designed based on the structure of the v3 `Context` object, specifically its `traceContext` property. While this package primarily uses the v4 `@azure/functions` library, this function provides a way to apply the same OpenTelemetry context propagation logic to your existing v3 handlers.
-
 ### Enabling Azure Monitor Telemetry
 
 If you want to enable Azure Monitor telemetry in your application, and you don't have those issues previously described, you can do so in the following ways:

--- a/packages/azure-tracing/package.json
+++ b/packages/azure-tracing/package.json
@@ -24,6 +24,9 @@
     },
     "./azure-functions": {
       "import": "./dist/functions/hooks.js"
+    },
+    "./azure-functions/v3": {
+      "import": "./dist/functions/v3/index.js"
     }
   },
   "dependencies": {

--- a/packages/azure-tracing/package.json
+++ b/packages/azure-tracing/package.json
@@ -30,23 +30,23 @@
     }
   },
   "dependencies": {
-    "@azure/functions": "^4.7.0",
+    "@azure/functions": "^4.7.2",
     "@azure/monitor-opentelemetry": "^1.11.0",
     "@azure/monitor-opentelemetry-exporter": "^1.0.0-beta.31",
     "@opentelemetry/api": "^1.9.0",
-    "@opentelemetry/api-logs": "^0.200.0",
-    "@opentelemetry/instrumentation": "^0.200.0",
-    "@opentelemetry/instrumentation-undici": "^0.11.0",
-    "@t3-oss/env-core": "^0.13.0",
-    "import-in-the-middle": "^1.13.1",
-    "zod": "^3.24.3"
+    "@opentelemetry/api-logs": "^0.201.1",
+    "@opentelemetry/instrumentation": "^0.201.1",
+    "@opentelemetry/instrumentation-undici": "^0.12.0",
+    "@t3-oss/env-core": "^0.13.4",
+    "import-in-the-middle": "^1.13.2",
+    "zod": "^3.25.28"
   },
   "devDependencies": {
     "@pagopa/eslint-config": "workspace:^",
     "@tsconfig/node20": "^20.1.5",
     "@types/node": "^20.12.2",
     "eslint": "8.57.0",
-    "tsup": "^8.4.0",
+    "tsup": "^8.5.0",
     "typescript": "~5.8.3"
   },
   "scripts": {

--- a/packages/azure-tracing/src/azure/functions/v3/index.ts
+++ b/packages/azure-tracing/src/azure/functions/v3/index.ts
@@ -1,0 +1,38 @@
+import { context as otelContext, propagation } from "@opentelemetry/api";
+
+/**
+ * Interface representing the necessary parts of the Azure Functions v3 Context
+ * for OpenTelemetry trace context propagation.
+ */
+interface FunctionContextV3 {
+  traceContext?: {
+    traceparent?: string;
+    tracestate?: string;
+  };
+}
+
+/**
+ * Wraps an Azure Function v3 handler to propagate OpenTelemetry context.
+ *
+ * This function extracts trace context from a v3-like context object (simulated via `FunctionContextV3` interface)
+ * and runs the provided `v3Function` within that context, ensuring OpenTelemetry trace propagation.
+ *
+ * @param context The Azure Function v3 context object (or an object conforming to `FunctionContextV3`).
+ * @param v3Function The original Azure Function v3 handler function.
+ * @returns A new function that, when called with the v3 context, executes the original handler with OpenTelemetry context propagation.
+ */
+export const withOtelContextFunctionV3 =
+  <T extends FunctionContextV3>(context: T) =>
+  (v3Function: (context: T) => void) => {
+    const traceContext = context.traceContext ?? {};
+    const headers = {
+      traceparent: traceContext.traceparent,
+      tracestate: traceContext.tracestate,
+    };
+
+    const ctx = propagation.extract(otelContext.active(), headers);
+
+    return otelContext.with(ctx, () => {
+      v3Function(context);
+    });
+  }; 

--- a/packages/azure-tracing/src/azure/functions/v3/index.ts
+++ b/packages/azure-tracing/src/azure/functions/v3/index.ts
@@ -6,8 +6,8 @@ import { context as otelContext, propagation } from "@opentelemetry/api";
  */
 interface FunctionContextV3 {
   traceContext?: {
-    traceparent?: string;
-    tracestate?: string;
+    traceparent?: null | string;
+    tracestate?: null | string;
   };
 }
 
@@ -31,8 +31,5 @@ export const withOtelContextFunctionV3 =
     };
 
     const ctx = propagation.extract(otelContext.active(), headers);
-
-    return otelContext.with(ctx, () => {
-      v3Function(context);
-    });
+    return otelContext.with(ctx, () => v3Function(context));
   };

--- a/packages/azure-tracing/src/azure/functions/v3/index.ts
+++ b/packages/azure-tracing/src/azure/functions/v3/index.ts
@@ -35,4 +35,4 @@ export const withOtelContextFunctionV3 =
     return otelContext.with(ctx, () => {
       v3Function(context);
     });
-  }; 
+  };

--- a/yarn.lock
+++ b/yarn.lock
@@ -277,14 +277,14 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@azure/functions@npm:^4.7.0":
-  version: 4.7.0
-  resolution: "@azure/functions@npm:4.7.0"
+"@azure/functions@npm:^4.7.2":
+  version: 4.7.2
+  resolution: "@azure/functions@npm:4.7.2"
   dependencies:
     cookie: "npm:^0.7.0"
     long: "npm:^4.0.0"
-    undici: "npm:^5.13.0"
-  checksum: 10c0/5283e94545abf121baad2ca19d860ed68593c052bf0e25101c25c5a9f4a713e08121db30f1de8864b3e68a660f95f7a3b8a4aa5350f178f94698643cc0a7bf93
+    undici: "npm:^5.29.0"
+  checksum: 10c0/c18a5acb132b7ee4f7b8ffebfa38026c438ee9b818175f34461b66e6971fdee5a4f21e71c24635d1012fac1db1a564bca1737a393b52a8213d72e2259a2bf131
   languageName: node
   linkType: hard
 
@@ -3444,7 +3444,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@jridgewell/sourcemap-codec@npm:^1.4.10, @jridgewell/sourcemap-codec@npm:^1.4.14":
+"@jridgewell/sourcemap-codec@npm:^1.4.10, @jridgewell/sourcemap-codec@npm:^1.4.14, @jridgewell/sourcemap-codec@npm:^1.5.0":
   version: 1.5.0
   resolution: "@jridgewell/sourcemap-codec@npm:1.5.0"
   checksum: 10c0/2eb864f276eb1096c3c11da3e9bb518f6d9fc0023c78344cdc037abadc725172c70314bdb360f2d4b7bffec7f5d657ce006816bc5d4ecb35e61b66132db00c18
@@ -3763,12 +3763,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@opentelemetry/api-logs@npm:0.200.0, @opentelemetry/api-logs@npm:^0.200.0":
-  version: 0.200.0
-  resolution: "@opentelemetry/api-logs@npm:0.200.0"
+"@opentelemetry/api-logs@npm:0.201.1, @opentelemetry/api-logs@npm:^0.201.1":
+  version: 0.201.1
+  resolution: "@opentelemetry/api-logs@npm:0.201.1"
   dependencies:
     "@opentelemetry/api": "npm:^1.3.0"
-  checksum: 10c0/c6bc3cfba35c69411f294519d93d0ff9f603517030d1162839ee42ac22ed1b0235edaf71d00cabc40125f813d8b4dc830d14315afcebcef138c1df560eaa5c91
+  checksum: 10c0/f5652a7d1dbfcba9d9a9b0e53a1debb428c99f859e833f14c09e471c0f01614245558bf3a4c0e9bda39c2031c10fa172ba3a564509aad56e5c8a30550a488170
   languageName: node
   linkType: hard
 
@@ -4085,15 +4085,15 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@opentelemetry/instrumentation-undici@npm:^0.11.0":
-  version: 0.11.0
-  resolution: "@opentelemetry/instrumentation-undici@npm:0.11.0"
+"@opentelemetry/instrumentation-undici@npm:^0.12.0":
+  version: 0.12.0
+  resolution: "@opentelemetry/instrumentation-undici@npm:0.12.0"
   dependencies:
     "@opentelemetry/core": "npm:^2.0.0"
-    "@opentelemetry/instrumentation": "npm:^0.200.0"
+    "@opentelemetry/instrumentation": "npm:^0.201.0"
   peerDependencies:
     "@opentelemetry/api": ^1.7.0
-  checksum: 10c0/2e34029e92bda50bb9f024bcebdc116f66c57b68de82391e026e1b88026e506149910f5c4d735452297e6297745003125339f7cfc1f203ef8a6ba5e07265f4c3
+  checksum: 10c0/97411490bae3d508332d8a71eed688bc4e56530502031e8aa92b60f1663c9be66ddd6c88b6b3d5dbc40822d4d64bc67d869fc8626442c2f1905d147fcc0dd22b
   languageName: node
   linkType: hard
 
@@ -4125,18 +4125,18 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@opentelemetry/instrumentation@npm:^0.200.0":
-  version: 0.200.0
-  resolution: "@opentelemetry/instrumentation@npm:0.200.0"
+"@opentelemetry/instrumentation@npm:^0.201.0, @opentelemetry/instrumentation@npm:^0.201.1":
+  version: 0.201.1
+  resolution: "@opentelemetry/instrumentation@npm:0.201.1"
   dependencies:
-    "@opentelemetry/api-logs": "npm:0.200.0"
+    "@opentelemetry/api-logs": "npm:0.201.1"
     "@types/shimmer": "npm:^1.2.0"
     import-in-the-middle: "npm:^1.8.1"
     require-in-the-middle: "npm:^7.1.1"
     shimmer: "npm:^1.2.1"
   peerDependencies:
     "@opentelemetry/api": ^1.3.0
-  checksum: 10c0/b7e6e0382231e7d0b113a2916511f5da24f80795e6904e32c2386a1e0856a0ad8592fb46bf8c3846447396a51aeed8c1664572af8728323a3266aecc3a33edd8
+  checksum: 10c0/b78e4e4225c7eb62f5ba8b5f70c078dc2e3a8d3685286ae3e025365c1ea69de520df2770a96510958be58e6fc93549085fd6431df38865ee5805de56d732d359
   languageName: node
   linkType: hard
 
@@ -4360,22 +4360,22 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@pagopa/azure-tracing@workspace:packages/azure-tracing"
   dependencies:
-    "@azure/functions": "npm:^4.7.0"
+    "@azure/functions": "npm:^4.7.2"
     "@azure/monitor-opentelemetry": "npm:^1.11.0"
     "@azure/monitor-opentelemetry-exporter": "npm:^1.0.0-beta.31"
     "@opentelemetry/api": "npm:^1.9.0"
-    "@opentelemetry/api-logs": "npm:^0.200.0"
-    "@opentelemetry/instrumentation": "npm:^0.200.0"
-    "@opentelemetry/instrumentation-undici": "npm:^0.11.0"
+    "@opentelemetry/api-logs": "npm:^0.201.1"
+    "@opentelemetry/instrumentation": "npm:^0.201.1"
+    "@opentelemetry/instrumentation-undici": "npm:^0.12.0"
     "@pagopa/eslint-config": "workspace:^"
-    "@t3-oss/env-core": "npm:^0.13.0"
+    "@t3-oss/env-core": "npm:^0.13.4"
     "@tsconfig/node20": "npm:^20.1.5"
     "@types/node": "npm:^20.12.2"
     eslint: "npm:8.57.0"
-    import-in-the-middle: "npm:^1.13.1"
-    tsup: "npm:^8.4.0"
+    import-in-the-middle: "npm:^1.13.2"
+    tsup: "npm:^8.5.0"
     typescript: "npm:~5.8.3"
-    zod: "npm:^3.24.3"
+    zod: "npm:^3.25.28"
   languageName: unknown
   linkType: soft
 
@@ -4890,9 +4890,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@t3-oss/env-core@npm:^0.13.0":
-  version: 0.13.0
-  resolution: "@t3-oss/env-core@npm:0.13.0"
+"@t3-oss/env-core@npm:^0.13.4":
+  version: 0.13.4
+  resolution: "@t3-oss/env-core@npm:0.13.4"
   peerDependencies:
     arktype: ^2.1.0
     typescript: ">=5.0.0"
@@ -4905,7 +4905,7 @@ __metadata:
       optional: true
     zod:
       optional: true
-  checksum: 10c0/4e5c23fe256f10826d737dad83e82e9969204a7c23c860fa8e1158b26967f5539c627853c4a4daefb2b38b4296ae8d07536d31ed9276df1d8ef2baa61affd6e7
+  checksum: 10c0/3598c1582b4cd0aead095a492d60cb7656ffa308c0362744fe32f04ec6563601c04d898c0da7b5efb4dc7ace1d3b18a77f268a15a9e940a6997d9dd84f86a749
   languageName: node
   linkType: hard
 
@@ -6946,6 +6946,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"confbox@npm:^0.1.8":
+  version: 0.1.8
+  resolution: "confbox@npm:0.1.8"
+  checksum: 10c0/fc2c68d97cb54d885b10b63e45bd8da83a8a71459d3ecf1825143dd4c7f9f1b696b3283e07d9d12a144c1301c2ebc7842380bdf0014e55acc4ae1c9550102418
+  languageName: node
+  linkType: hard
+
 "config-chain@npm:^1.1.11":
   version: 1.1.13
   resolution: "config-chain@npm:1.1.13"
@@ -8736,6 +8743,17 @@ __metadata:
   languageName: node
   linkType: hard
 
+"fix-dts-default-cjs-exports@npm:^1.0.0":
+  version: 1.0.1
+  resolution: "fix-dts-default-cjs-exports@npm:1.0.1"
+  dependencies:
+    magic-string: "npm:^0.30.17"
+    mlly: "npm:^1.7.4"
+    rollup: "npm:^4.34.8"
+  checksum: 10c0/61a3cbe32b6c29df495ef3aded78199fe9dbb52e2801c899fe76d9ca413d3c8c51f79986bac83f8b4b2094ebde883ddcfe47b68ce469806ba13ca6ed4e7cd362
+  languageName: node
+  linkType: hard
+
 "flat-cache@npm:^3.0.4":
   version: 3.2.0
   resolution: "flat-cache@npm:3.2.0"
@@ -9760,7 +9778,19 @@ __metadata:
   languageName: node
   linkType: hard
 
-"import-in-the-middle@npm:^1.13.1, import-in-the-middle@npm:^1.8.1":
+"import-in-the-middle@npm:^1.13.2":
+  version: 1.13.2
+  resolution: "import-in-the-middle@npm:1.13.2"
+  dependencies:
+    acorn: "npm:^8.14.0"
+    acorn-import-attributes: "npm:^1.9.5"
+    cjs-module-lexer: "npm:^1.2.2"
+    module-details-from-path: "npm:^1.0.3"
+  checksum: 10c0/485a7d7a1ebffc219064435a9aa041b34e2e66cac3d381957f6a73ad409f128b1f160b8aea6377c1fe2f330c243dc12b3b957d7436e23a51b209933422d6aeb0
+  languageName: node
+  linkType: hard
+
+"import-in-the-middle@npm:^1.8.1":
   version: 1.13.1
   resolution: "import-in-the-middle@npm:1.13.1"
   dependencies:
@@ -10660,6 +10690,15 @@ __metadata:
   version: 2.3.9
   resolution: "lunr@npm:2.3.9"
   checksum: 10c0/77d7dbb4fbd602aac161e2b50887d8eda28c0fa3b799159cee380fbb311f1e614219126ecbbd2c3a9c685f1720a8109b3c1ca85cc893c39b6c9cc6a62a1d8a8b
+  languageName: node
+  linkType: hard
+
+"magic-string@npm:^0.30.17":
+  version: 0.30.17
+  resolution: "magic-string@npm:0.30.17"
+  dependencies:
+    "@jridgewell/sourcemap-codec": "npm:^1.5.0"
+  checksum: 10c0/16826e415d04b88378f200fe022b53e638e3838b9e496edda6c0e086d7753a44a6ed187adc72d19f3623810589bf139af1a315541cd6a26ae0771a0193eaf7b8
   languageName: node
   linkType: hard
 
@@ -11737,6 +11776,18 @@ __metadata:
   languageName: node
   linkType: hard
 
+"mlly@npm:^1.7.4":
+  version: 1.7.4
+  resolution: "mlly@npm:1.7.4"
+  dependencies:
+    acorn: "npm:^8.14.0"
+    pathe: "npm:^2.0.1"
+    pkg-types: "npm:^1.3.0"
+    ufo: "npm:^1.5.4"
+  checksum: 10c0/69e738218a13d6365caf930e0ab4e2b848b84eec261597df9788cefb9930f3e40667be9cb58a4718834ba5f97a6efeef31d3b5a95f4388143fd4e0d0deff72ff
+  languageName: node
+  linkType: hard
+
 "module-details-from-path@npm:^1.0.3":
   version: 1.0.3
   resolution: "module-details-from-path@npm:1.0.3"
@@ -12438,6 +12489,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"pathe@npm:^2.0.1":
+  version: 2.0.3
+  resolution: "pathe@npm:2.0.3"
+  checksum: 10c0/c118dc5a8b5c4166011b2b70608762e260085180bb9e33e80a50dcdb1e78c010b1624f4280c492c92b05fc276715a4c357d1f9edc570f8f1b3d90b6839ebaca1
+  languageName: node
+  linkType: hard
+
 "pg-int8@npm:1.0.1":
   version: 1.0.1
   resolution: "pg-int8@npm:1.0.1"
@@ -12528,6 +12586,17 @@ __metadata:
   dependencies:
     find-up: "npm:^6.3.0"
   checksum: 10c0/1afb23d2efb1ec9d8b2c4a0c37bf146822ad2774f074cb05b853be5dca1b40815c5960dd126df30ab8908349262a266f31b771e877235870a3b8fd313beebec5
+  languageName: node
+  linkType: hard
+
+"pkg-types@npm:^1.3.0":
+  version: 1.3.1
+  resolution: "pkg-types@npm:1.3.1"
+  dependencies:
+    confbox: "npm:^0.1.8"
+    mlly: "npm:^1.7.4"
+    pathe: "npm:^2.0.1"
+  checksum: 10c0/19e6cb8b66dcc66c89f2344aecfa47f2431c988cfa3366bdfdcfb1dd6695f87dcce37fbd90fe9d1605e2f4440b77f391e83c23255347c35cf84e7fd774d7fcea
   languageName: node
   linkType: hard
 
@@ -15534,9 +15603,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"tsup@npm:^8.4.0":
-  version: 8.4.0
-  resolution: "tsup@npm:8.4.0"
+"tsup@npm:^8.5.0":
+  version: 8.5.0
+  resolution: "tsup@npm:8.5.0"
   dependencies:
     bundle-require: "npm:^5.1.0"
     cac: "npm:^6.7.14"
@@ -15544,6 +15613,7 @@ __metadata:
     consola: "npm:^3.4.0"
     debug: "npm:^4.4.0"
     esbuild: "npm:^0.25.0"
+    fix-dts-default-cjs-exports: "npm:^1.0.0"
     joycon: "npm:^3.1.1"
     picocolors: "npm:^1.1.1"
     postcss-load-config: "npm:^6.0.1"
@@ -15571,7 +15641,7 @@ __metadata:
   bin:
     tsup: dist/cli-default.js
     tsup-node: dist/cli-node.js
-  checksum: 10c0/c6636ffd6ade59d3544cd424c7115449f8712eb5c872e1e36d25817436f9ea9424d8ee8f1b6244ac7c9a887b0fcf6cc42c102baa55a9080236afc18ba73871e6
+  checksum: 10c0/2eddc1138ad992a2e67d826e92e0b0c4f650367355866c77df8368ade9489e0a8bf2b52b352e97fec83dc690af05881c29c489af27acb86ac2cef38b0d029087
   languageName: node
   linkType: hard
 
@@ -15738,6 +15808,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"ufo@npm:^1.5.4":
+  version: 1.6.1
+  resolution: "ufo@npm:1.6.1"
+  checksum: 10c0/5a9f041e5945fba7c189d5410508cbcbefef80b253ed29aa2e1f8a2b86f4bd51af44ee18d4485e6d3468c92be9bf4a42e3a2b72dcaf27ce39ce947ec994f1e6b
+  languageName: node
+  linkType: hard
+
 "undici-types@npm:~6.19.2":
   version: 6.19.8
   resolution: "undici-types@npm:6.19.8"
@@ -15752,7 +15829,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"undici@npm:^5.13.0":
+"undici@npm:^5.29.0":
   version: 5.29.0
   resolution: "undici@npm:5.29.0"
   dependencies:
@@ -16548,10 +16625,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"zod@npm:^3.24.3":
-  version: 3.24.3
-  resolution: "zod@npm:3.24.3"
-  checksum: 10c0/ab0369810968d0329a1a141e9418e01e5c9c2a4905cbb7cb7f5a131d6e9487596e1400e21eeff24c4a8ee28dacfa5bd6103893765c055b7a98c2006a5a4fc68d
+"zod@npm:^3.25.28":
+  version: 3.25.28
+  resolution: "zod@npm:3.25.28"
+  checksum: 10c0/557fb621813d128f8090c43de65f9e8661ce9bd8bd29d7adc6b38b0a79e14729a8926e28a2e6eee2fa0ec0ea390cc549363f50235e8f45d2e4771906d1f87b20
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
To ensure the legacy Azure Function programming model, requests are traced, we need to wrap the handler function in an OpenTelemetry wrapper that manipulates the context to have correlated requests on Application Insights.

Closes CES-1016