### PR TITLE
Clarify Azure RBAC permissions for bootstrap module initial setup

### DIFF
--- a/.changeset/silly-coats-stick.md
+++ b/.changeset/silly-coats-stick.md
@@ -1,0 +1,5 @@
+---
+"azure_github_environment_bootstrap": patch
+---
+
+Update Readme with some information about required Azure Permissions

--- a/apps/website/docs/getting-started/monorepository-setup.md
+++ b/apps/website/docs/getting-started/monorepository-setup.md
@@ -147,13 +147,9 @@ and the [IAM Framework documentation](../infrastructure/azure/azure-iam.md).
 
 :::info[Azure Permissions for Initial Setup]
 
-The initial `terraform apply` for the Bootstrap module must be executed locally
-by an Engineering Leader or their delegate. To do this, they must have the
-"**Role Based Access Control Administrator**" role, and the "**Contributor**"
-role (if not already assigned), on the Azure subscription.
+The initial `terraform apply` for the Bootstrap module must be run locally by an Azure account that has the `Role Based Access Control Administrator` and `Contributor` roles assigned at the subscription level.
 
-The RBAC role can be obtained by opening a Pull Request on the
-[pagopa/eng-azure-authorization](https://github.com/pagopa/eng-azure-authorization)
+Within the PagoPA context, you can obtain the necessary RBAC role by opening a Pull Request against the company Azure authorization repository,
 repository, adding the user to the `io-p-adgroup-rbac-admins` team. For example:
 
 ```terraform

--- a/apps/website/docs/getting-started/monorepository-setup.md
+++ b/apps/website/docs/getting-started/monorepository-setup.md
@@ -150,7 +150,7 @@ and the [IAM Framework documentation](../infrastructure/azure/azure-iam.md).
 The initial `terraform apply` for the Bootstrap module must be run locally by an Azure account that has the `Role Based Access Control Administrator` and `Contributor` roles assigned at the subscription level.
 
 Within the PagoPA context, you can obtain the necessary RBAC role by opening a Pull Request against the company Azure authorization repository,
-repository, adding the user to the `io-p-adgroup-rbac-admins` team. For example:
+adding this administrative user to the `io-p-adgroup-rbac-admins` team. For example:
 
 ```terraform
   ...

--- a/apps/website/docs/getting-started/monorepository-setup.md
+++ b/apps/website/docs/getting-started/monorepository-setup.md
@@ -144,3 +144,29 @@ Terraform module.
 For more information, see the
 [related blog post](https://pagopa.github.io/dx/blog/devex-azure-bootstrap-0.1-alpha)
 and the [IAM Framework documentation](../infrastructure/azure/azure-iam.md).
+
+:::info[Azure Permissions for Initial Setup]
+
+The initial `terraform apply` for the Bootstrap module must be executed locally by an Engineering Leader or their delegate.
+To do this, they must have the "**Role Based Access Control Administrator**" role, and the "**Contributor**" role (if not already assigned), on the Azure subscription.
+
+The RBAC role can be obtained by opening a Pull Request on the [pagopa/eng-azure-authorization](https://github.com/pagopa/eng-azure-authorization) repository, adding the user to the `io-p-adgroup-rbac-admins` team. For example:
+
+```terraform
+  ...
+  {
+    name = "io-p-adgroup-rbac-admins"
+    members = [
+      ...
+      "eng.lead.or.delegate@example.com", // Add the user's email here
+      ...
+    ],
+    roles = [
+      "Role Based Access Control Administrator",
+    ],
+  },
+  ...
+```
+
+This step is crucial for the `azure-github-environment-bootstrap` module to correctly set up the necessary resources and permissions in Azure during the first local apply. Subsequent applies can be automated with a GitHub Workflow.
+:::

--- a/apps/website/docs/getting-started/monorepository-setup.md
+++ b/apps/website/docs/getting-started/monorepository-setup.md
@@ -147,10 +147,14 @@ and the [IAM Framework documentation](../infrastructure/azure/azure-iam.md).
 
 :::info[Azure Permissions for Initial Setup]
 
-The initial `terraform apply` for the Bootstrap module must be executed locally by an Engineering Leader or their delegate.
-To do this, they must have the "**Role Based Access Control Administrator**" role, and the "**Contributor**" role (if not already assigned), on the Azure subscription.
+The initial `terraform apply` for the Bootstrap module must be executed locally
+by an Engineering Leader or their delegate. To do this, they must have the
+"**Role Based Access Control Administrator**" role, and the "**Contributor**"
+role (if not already assigned), on the Azure subscription.
 
-The RBAC role can be obtained by opening a Pull Request on the [pagopa/eng-azure-authorization](https://github.com/pagopa/eng-azure-authorization) repository, adding the user to the `io-p-adgroup-rbac-admins` team. For example:
+The RBAC role can be obtained by opening a Pull Request on the
+[pagopa/eng-azure-authorization](https://github.com/pagopa/eng-azure-authorization)
+repository, adding the user to the `io-p-adgroup-rbac-admins` team. For example:
 
 ```terraform
   ...
@@ -168,5 +172,7 @@ The RBAC role can be obtained by opening a Pull Request on the [pagopa/eng-azure
   ...
 ```
 
-This step is crucial for the `azure-github-environment-bootstrap` module to correctly set up the necessary resources and permissions in Azure during the first local apply. Subsequent applies can be automated with a GitHub Workflow.
+This step is crucial for the `azure-github-environment-bootstrap` module to
+correctly set up the necessary resources and permissions in Azure during the
+first local apply. Subsequent applies can be automated with a GitHub Workflow.
 :::

--- a/infra/modules/azure_github_environment_bootstrap/README.md
+++ b/infra/modules/azure_github_environment_bootstrap/README.md
@@ -18,6 +18,10 @@ The module performs the following actions:
 
 ## Gotchas
 
+### Ensure Necessary Azure Permissions
+
+The Azure principal (user or managed identity) executing the `terraform apply` command must have the **Role Based Access Control Administrator** and **Contributor** roles on the target Azure subscription. This is required to create and assign necessary IAM roles.
+
 ### Use Entra Id to Authenticate Connections to Storage Accounts
 
 Entra Id should be used as the authentication method for Storage Accounts, replacing


### PR DESCRIPTION
This PR updates documentation to clarify Azure RBAC permission requirements for the initial setup of the `azure-github-environment-bootstrap` module.

Resolves: CES-1020