### PR TITLE
Clarify role assignment for managing Service Bus Namespace

### DIFF
--- a/apps/website/docs/infrastructure/azure/using-service-bus.md
+++ b/apps/website/docs/infrastructure/azure/using-service-bus.md
@@ -48,8 +48,9 @@ module "service_bus_01" {
 The module disables access keys, so authentication is handled only by Entra ID.
 
 The team or pipeline that manages the Service Bus Namespace must have the
-`Contributor` role assigned to the Namespace. This is necessary to create and
-manage entities such as queues, topics, and subscriptions within the Namespace.
+`Contributor` role assigned on the whole service. This is necessary to create
+and manage entities such as queues, topics, and subscriptions within the
+Namespace.
 
 If you are using GitHub Actions to manage the Service Bus Namespace, it is
 recommended to leverage the

--- a/apps/website/docs/infrastructure/azure/using-service-bus.md
+++ b/apps/website/docs/infrastructure/azure/using-service-bus.md
@@ -47,16 +47,19 @@ module "service_bus_01" {
 
 The module disables access keys, so authentication is handled only by Entra ID.
 
-If you have a common Service Bus Namespace instance shared among teams, you can
-use the
-[azure-github-environment-bootstrap](https://registry.terraform.io/modules/pagopa-dx/azure-github-environment-bootstrap/azurerm/latest)
-module to set the required role to apply changes to the GitHub workflow of your
-monorepository, via the `sbns_id` variable.
+To manage the infrastructure of the Service Bus Namespace, you must assign the
+`Contributor` role to the Principal ID of the team or pipeline (such as a GitHub
+Action) responsible for its management.
 
-For your own access as writer, declare a
+The recommended approach is to use the
+[azure-github-environment-bootstrap](https://registry.terraform.io/modules/pagopa-dx/azure-github-environment-bootstrap/azurerm/latest)
+module. This ensures that the required roles are granted to the repository's
+GitHub Actions by including the `sbns_id` variable in the module configuration.
+
+If, for any exceptional reason, you need to configure permissions manually, you
+can use the
 [`azurerm_role_assignment`](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/role_assignment)
-next to the Service Bus Namespace definition, setting the `Contributor` role to
-your team's Principal ID. For example:
+resource to assign the `Contributor` role to a Principal ID. For example:
 
 ```hcl
 data "azuread_group" "adgroup_domain_devs" {

--- a/apps/website/docs/infrastructure/azure/using-service-bus.md
+++ b/apps/website/docs/infrastructure/azure/using-service-bus.md
@@ -59,7 +59,7 @@ module. By specifying the `sbns_id` variable in the module configuration, you
 can ensure that the necessary roles are automatically assigned to your
 repository's GitHub Actions workflows.
 
-If, for any exceptional reason, you need to configure permissions manually, you
+If, for any exceptional reason you need to configure permissions manually, you
 can use the
 [`azurerm_role_assignment`](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/role_assignment)
 resource to assign the `Contributor` role to a Principal ID. For example:

--- a/apps/website/docs/infrastructure/azure/using-service-bus.md
+++ b/apps/website/docs/infrastructure/azure/using-service-bus.md
@@ -51,7 +51,8 @@ To manage the infrastructure of the Service Bus Namespace, you must assign the
 `Contributor` role to the Principal ID of the team or pipeline (such as a GitHub
 Action) responsible for its management.
 
-The recommended approach is to use the
+To let GitHub Actions manage the Service Bus Namespace, the recommended approach
+is to use the
 [azure-github-environment-bootstrap](https://registry.terraform.io/modules/pagopa-dx/azure-github-environment-bootstrap/azurerm/latest)
 module. This ensures that the required roles are granted to the repository's
 GitHub Actions by including the `sbns_id` variable in the module configuration.

--- a/apps/website/docs/infrastructure/azure/using-service-bus.md
+++ b/apps/website/docs/infrastructure/azure/using-service-bus.md
@@ -47,10 +47,10 @@ module "service_bus_01" {
 
 The module disables access keys, so authentication is handled only by Entra ID.
 
-The team or pipeline that manages the Service Bus Namespace must have the
-`Contributor` role assigned on the whole service. This is necessary to create
-and manage entities such as queues, topics, and subscriptions within the
-Namespace.
+The team or pipeline that manages the Service Bus Namespace infrastructure must
+have the `Contributor` role assigned on the whole service. This is necessary,
+for example, to let GitHub Actions create and manage entities such as queues,
+topics, and subscriptions within the Namespace.
 
 If you are using GitHub Actions to manage the Service Bus Namespace, it is
 recommended to leverage the

--- a/apps/website/docs/infrastructure/azure/using-service-bus.md
+++ b/apps/website/docs/infrastructure/azure/using-service-bus.md
@@ -47,15 +47,16 @@ module "service_bus_01" {
 
 The module disables access keys, so authentication is handled only by Entra ID.
 
-To manage the infrastructure of the Service Bus Namespace, you must assign the
-`Contributor` role to the Principal ID of the team or pipeline (such as a GitHub
-Action) responsible for its management.
+The team or pipeline that manages the Service Bus Namespace must have the
+`Contributor` role assigned to the Namespace. This is necessary to create and
+manage entities such as queues, topics, and subscriptions within the Namespace.
 
-To let GitHub Actions manage the Service Bus Namespace, the recommended approach
-is to use the
+If you are using GitHub Actions to manage the Service Bus Namespace, it is
+recommended to leverage the
 [azure-github-environment-bootstrap](https://registry.terraform.io/modules/pagopa-dx/azure-github-environment-bootstrap/azurerm/latest)
-module. This ensures that the required roles are granted to the repository's
-GitHub Actions by including the `sbns_id` variable in the module configuration.
+module. By specifying the `sbns_id` variable in the module configuration, you
+can ensure that the necessary roles are automatically assigned to your
+repository's GitHub Actions workflows.
 
 If, for any exceptional reason, you need to configure permissions manually, you
 can use the


### PR DESCRIPTION
Update documentation to specify the need for assigning the `Contributor` role to the Principal ID for managing the Service Bus Namespace. Include guidance on using the recommended module for role assignment and mention manual configuration options.