### PR TITLE
Upgrade setup-node and cache actions

### DIFF
--- a/.github/actions/node-setup/action.yaml
+++ b/.github/actions/node-setup/action.yaml
@@ -19,7 +19,7 @@ runs:
       shell: bash
       run: corepack enable
 
-    - uses: actions/setup-node@1e60f620b9541d16bece96c5465dc8ee9832be0b # v4.0.3
+    - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
       with:
         node-version-file: ".node-version"
         cache: yarn
@@ -27,10 +27,9 @@ runs:
 
     - name: Setup turbo cache
       if: ${{ env.TURBO_CACHE_DIR != '' }}
-      uses: actions/cache@1bd1e32a3bdc45362d1e726936510720a7c30a57 # v4.2.0
+      uses: actions/cache@5a3ec84eff668545956fd18022155c47e93e2684 # v4.2.3
       with:
         path: ${{ env.TURBO_CACHE_DIR }}
         key: ${{ runner.os }}-turbo-${{ github.sha }}
         restore-keys: |
           ${{ runner.os }}-turbo-
-      


### PR DESCRIPTION
This will speed up the workflow execution due to some errors occurring in old versions

This will fix the warnings that occur when executing the dependent workflows: 
```
Failed to restore: getCacheEntry failed: connect ETIMEDOUT
```