### PR TITLE
Add into APIM module a section for Public Network Access Limitation

### DIFF
--- a/.changeset/ready-dingos-find.md
+++ b/.changeset/ready-dingos-find.md
@@ -1,0 +1,5 @@
+---
+"azure_api_management": patch
+---
+
+Update README with Public Network Access limitation workaround

--- a/infra/modules/azure_api_management/README.md
+++ b/infra/modules/azure_api_management/README.md
@@ -34,6 +34,14 @@ Since Azure can take some time to create those resources, you may not see the lo
 
 For a complete example of how to use this module, refer to the [example/complete](https://github.com/pagopa-dx/terraform-azurerm-azure-api-management/tree/main/example/complete) folder in the module repository.
 
+## Troubleshooting
+
+### ⚠️ Public Network Access Limitation ⚠️
+
+Currently, it is not possible to create a new Azure API Management instance with `enable_public_network_access = false`.  
+If you need to disable public network access, you must first create the APIM with `enable_public_network_access = true`.  
+After that, submit a new _Pull Request_ to update the variable to `false` and apply the changes.
+
 <!-- markdownlint-disable -->
 <!-- BEGIN_TF_DOCS -->
 ## Requirements


### PR DESCRIPTION
This PR adds a troubleshooting section to the README to highlight the current limitation with the `enable_public_network_access` variable. 

Resolves: CES-1054