### PR TITLE
Update infra plan workflow to fix incomplete PR comments

### DIFF
--- a/.github/workflows/infra_plan.yaml
+++ b/.github/workflows/infra_plan.yaml
@@ -119,12 +119,16 @@ jobs:
         run: |
           terraform plan -lock-timeout=3000s -no-color -out=plan.out | grep -v "hidden-link:" | tee tf_plan_stdout.txt
           terraform show -no-color plan.out > full_plan.txt
-
+          
+          # Extracts only the diff section from the Plan by skipping everything before the resource changes,
+          # and filters out non-essential log lines like state refreshes and reads.
           sed -n '/^  #/,$p' full_plan.txt | grep -Ev "Refreshing state|state lock|Reading|Read" > filtered_plan.txt
 
+          # The summary with number of resources to be added, changed, or destroyed (will be used in case the plan output is too long)
           SUMMARY_LINE=$(grep -E "^Plan: [0-9]+ to add" tf_plan_stdout.txt || echo "No changes.")
           echo "$SUMMARY_LINE" > plan_summary.txt
 
+          # If the filtered plan is too long use the summary line, otherwise use the full filtered plan
           if [ "$(wc -c < filtered_plan.txt)" -gt 60000 ]; then
             echo "${SUMMARY_LINE}" > plan_output_multiline.txt
             echo "" >> plan_output_multiline.txt


### PR DESCRIPTION
This PR fixes the `infra_plan` workflow issue where the PR comment was too large and got truncated.
If the plan output exceeds `60KB`, only the final summary of the plan will be printed in the comment, along with a message indicating to check the action logs for the full output:
![image](https://github.com/user-attachments/assets/7cc560c8-5431-4a37-8cec-e9117fd5d9c7)
Otherwise, it works as before, but with a cleaner output as all unnecessary lines have been removed.
In addition fix the possible code injection founded by CodeQL.

Resolves: CES-1061
