### PR TITLE
Manage FrontDoor rule sets in Azure CDN module

### DIFF
--- a/.changeset/rotten-frogs-divide.md
+++ b/.changeset/rotten-frogs-divide.md
@@ -1,0 +1,5 @@
+---
+"azure_cdn": minor
+---
+
+Added `rule_set_id` output that exposes the Front Door Rule Set ID. This allows users to implement custom rules via the `azurerm_cdn_frontdoor_rule` resource and link them to the rule set provided by the module.

--- a/infra/modules/azure_cdn/README.md
+++ b/infra/modules/azure_cdn/README.md
@@ -12,6 +12,44 @@ This Terraform module provisions an Azure CDN Front Door profile with endpoints,
 - **Routing Rules**: Enables custom routing rules, URL rewriting, and redirects.
 - **Diagnostic Settings**: Configurable diagnostic settings for monitoring and logging.
 
+### Routing rules
+The module returns the id of a FrontDoor rule set via the `rule_set_id` output. The user can then implement ad-hoc rules for the created FrontDoor endpoint as follows:
+
+```
+module "azure_cdn" {
+  source  = "pagopa-dx/azure-cdn/azurerm"
+  version = "~> 0.0"
+  ...
+}
+
+resource "azurerm_cdn_frontdoor_rule" "example" {
+  name                      = "examplerule"
+  cdn_frontdoor_rule_set_id = module.azure_cdn.rule_set_id
+  order                     = 1
+  behavior_on_match         = "Continue"
+
+  actions {
+    url_redirect_action {
+      redirect_type        = "PermanentRedirect"
+      redirect_protocol    = "MatchRequest"
+      query_string         = "clientIp={client_ip}"
+      destination_path     = "/exampleredirection"
+      destination_hostname = "contoso.com"
+      destination_fragment = "UrlRedirect"
+    }
+  }
+
+  conditions {
+    host_name_condition {
+      operator         = "Equal"
+      negate_condition = false
+      match_values     = ["www.contoso.com", "images.contoso.com", "video.contoso.com"]
+      transforms       = ["Lowercase", "Trim"]
+    }
+  }
+}
+```
+
 ## Usage Example
 
 A complete example of how to use this module can be found in the [examples/basic](https://github.com/pagopa-dx/terraform-azurerm-azure-cdn/tree/main/examples/basic) directory.
@@ -39,6 +77,7 @@ No modules.
 | [azurerm_cdn_frontdoor_origin_group.this](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/cdn_frontdoor_origin_group) | resource |
 | [azurerm_cdn_frontdoor_profile.this](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/cdn_frontdoor_profile) | resource |
 | [azurerm_cdn_frontdoor_route.this](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/cdn_frontdoor_route) | resource |
+| [azurerm_cdn_frontdoor_rule_set.this](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/cdn_frontdoor_rule_set) | resource |
 | [azurerm_dns_a_record.this](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/dns_a_record) | resource |
 | [azurerm_dns_txt_record.validation](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/dns_txt_record) | resource |
 | [azurerm_monitor_diagnostic_setting.diagnostic_settings_cdn_profile](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/monitor_diagnostic_setting) | resource |
@@ -48,10 +87,11 @@ No modules.
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
 | <a name="input_custom_domains"></a> [custom\_domains](#input\_custom\_domains) | Map of custom domain configurations to associate with the CDN endpoint. If dns parameter is set, DNS records are created. | <pre>list(object({<br/>    host_name = string<br/>    dns = optional(object({<br/>      zone_name                = string<br/>      zone_resource_group_name = string<br/>    }), { zone_name = null, zone_resource_group_name = null })<br/>  }))</pre> | `[]` | no |
-| <a name="input_diagnostic_settings"></a> [diagnostic\_settings](#input\_diagnostic\_settings) | Define if diagnostic settings should be enabled.<br/>if it is:<br/>Specifies the ID of a Log Analytics Workspace where Diagnostics Data should be sent and <br/>the ID of the Storage Account where logs should be sent. (Changing this forces a new resource to be created) | <pre>object({<br/>    enabled                                   = bool<br/>    log_analytics_workspace_id                = string<br/>    diagnostic_setting_destination_storage_id = string<br/>  })</pre> | <pre>{<br/>  "diagnostic_setting_destination_storage_id": null,<br/>  "enabled": false,<br/>  "log_analytics_workspace_id": null<br/>}</pre> | no |
+| <a name="input_diagnostic_settings"></a> [diagnostic\_settings](#input\_diagnostic\_settings) | Define if diagnostic settings should be enabled.<br/>if it is:<br/>Specifies the ID of a Log Analytics Workspace where Diagnostics Data should be sent and<br/>the ID of the Storage Account where logs should be sent. (Changing this forces a new resource to be created) | <pre>object({<br/>    enabled                                   = bool<br/>    log_analytics_workspace_id                = string<br/>    diagnostic_setting_destination_storage_id = string<br/>  })</pre> | <pre>{<br/>  "diagnostic_setting_destination_storage_id": null,<br/>  "enabled": false,<br/>  "log_analytics_workspace_id": null<br/>}</pre> | no |
 | <a name="input_environment"></a> [environment](#input\_environment) | Environment configuration object for resource naming | <pre>object({<br/>    prefix          = string<br/>    env_short       = string<br/>    location        = string<br/>    domain          = optional(string)<br/>    app_name        = string<br/>    instance_number = string<br/>  })</pre> | n/a | yes |
 | <a name="input_origins"></a> [origins](#input\_origins) | Map of origin configurations. Key is the origin identifier. Priority determines routing preference (lower values = higher priority) | <pre>map(object({<br/>    host_name = string<br/>    priority  = optional(number, 1)<br/>  }))</pre> | n/a | yes |
 | <a name="input_resource_group_name"></a> [resource\_group\_name](#input\_resource\_group\_name) | Resource group name where the CDN profile will be created | `string` | n/a | yes |
+| <a name="input_rule_set_ids"></a> [rule\_set\_ids](#input\_rule\_set\_ids) | List of rule set IDs to associate with the CDN endpoint | `list(string)` | `[]` | no |
 | <a name="input_tags"></a> [tags](#input\_tags) | Resource tags | `map(any)` | n/a | yes |
 
 ## Outputs
@@ -64,4 +104,5 @@ No modules.
 | <a name="output_origin_group_id"></a> [origin\_group\_id](#output\_origin\_group\_id) | The ID of the CDN FrontDoor Origin Group |
 | <a name="output_principal_id"></a> [principal\_id](#output\_principal\_id) | The principal ID of the Front Door Profile's system-assigned managed identity. |
 | <a name="output_resource_group_name"></a> [resource\_group\_name](#output\_resource\_group\_name) | The name of the resource group the CDN FrontDoor Profile was created in |
+| <a name="output_rule_set_id"></a> [rule\_set\_id](#output\_rule\_set\_id) | The ID of the CDN FrontDoor Rule Set |
 <!-- END_TF_DOCS -->

--- a/infra/modules/azure_cdn/README.md
+++ b/infra/modules/azure_cdn/README.md
@@ -91,7 +91,6 @@ No modules.
 | <a name="input_environment"></a> [environment](#input\_environment) | Environment configuration object for resource naming | <pre>object({<br/>    prefix          = string<br/>    env_short       = string<br/>    location        = string<br/>    domain          = optional(string)<br/>    app_name        = string<br/>    instance_number = string<br/>  })</pre> | n/a | yes |
 | <a name="input_origins"></a> [origins](#input\_origins) | Map of origin configurations. Key is the origin identifier. Priority determines routing preference (lower values = higher priority) | <pre>map(object({<br/>    host_name = string<br/>    priority  = optional(number, 1)<br/>  }))</pre> | n/a | yes |
 | <a name="input_resource_group_name"></a> [resource\_group\_name](#input\_resource\_group\_name) | Resource group name where the CDN profile will be created | `string` | n/a | yes |
-| <a name="input_rule_set_ids"></a> [rule\_set\_ids](#input\_rule\_set\_ids) | List of rule set IDs to associate with the CDN endpoint | `list(string)` | `[]` | no |
 | <a name="input_tags"></a> [tags](#input\_tags) | Resource tags | `map(any)` | n/a | yes |
 
 ## Outputs

--- a/infra/modules/azure_cdn/cdn.tf
+++ b/infra/modules/azure_cdn/cdn.tf
@@ -47,12 +47,17 @@ resource "azurerm_cdn_frontdoor_origin" "this" {
   certificate_name_check_enabled = true
 }
 
+resource "azurerm_cdn_frontdoor_rule_set" "this" {
+  name                     = "ruleset"
+  cdn_frontdoor_profile_id = azurerm_cdn_frontdoor_profile.this.id
+}
+
 resource "azurerm_cdn_frontdoor_route" "this" {
   name                            = provider::dx::resource_name(merge(local.naming_config, { resource_type = "cdn_frontdoor_route" }))
   cdn_frontdoor_endpoint_id       = azurerm_cdn_frontdoor_endpoint.this.id
   cdn_frontdoor_origin_group_id   = azurerm_cdn_frontdoor_origin_group.this.id
   cdn_frontdoor_origin_ids        = [for origin in azurerm_cdn_frontdoor_origin.this : origin.id]
-  cdn_frontdoor_rule_set_ids      = []
+  cdn_frontdoor_rule_set_ids      = [azurerm_cdn_frontdoor_rule_set.this.id]
   cdn_frontdoor_custom_domain_ids = length(var.custom_domains) > 0 ? [for domain in azurerm_cdn_frontdoor_custom_domain.this : domain.id] : []
   enabled                         = true
 

--- a/infra/modules/azure_cdn/examples/basic/README.md
+++ b/infra/modules/azure_cdn/examples/basic/README.md
@@ -19,6 +19,7 @@
 
 | Name | Type |
 |------|------|
+| [azurerm_cdn_frontdoor_rule.example](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/cdn_frontdoor_rule) | resource |
 | [azurerm_resource_group.example](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/resource_group) | resource |
 | [azurerm_subnet.pep](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/data-sources/subnet) | data source |
 

--- a/infra/modules/azure_cdn/examples/basic/main.tf
+++ b/infra/modules/azure_cdn/examples/basic/main.tf
@@ -79,6 +79,8 @@ module "azure_cdn" {
   tags = local.tags
 }
 
+# Optionally add FrontDoor rules to manage redirects
+# https://learn.microsoft.com/en-us/azure/frontdoor/front-door-rules-engine?pivots=front-door-standard-premium
 resource "azurerm_cdn_frontdoor_rule" "example" {
   name                      = "examplerule"
   cdn_frontdoor_rule_set_id = module.azure_cdn.rule_set_id

--- a/infra/modules/azure_cdn/examples/basic/main.tf
+++ b/infra/modules/azure_cdn/examples/basic/main.tf
@@ -79,6 +79,33 @@ module "azure_cdn" {
   tags = local.tags
 }
 
+resource "azurerm_cdn_frontdoor_rule" "example" {
+  name                      = "examplerule"
+  cdn_frontdoor_rule_set_id = module.azure_cdn.rule_set_id
+  order                     = 1
+  behavior_on_match         = "Continue"
+
+  actions {
+    url_redirect_action {
+      redirect_type        = "PermanentRedirect"
+      redirect_protocol    = "MatchRequest"
+      query_string         = "clientIp={client_ip}"
+      destination_path     = "/exampleredirection"
+      destination_hostname = "contoso.com"
+      destination_fragment = "UrlRedirect"
+    }
+  }
+
+  conditions {
+    host_name_condition {
+      operator         = "Equal"
+      negate_condition = false
+      match_values     = ["www.contoso.com", "images.contoso.com", "video.contoso.com"]
+      transforms       = ["Lowercase", "Trim"]
+    }
+  }
+}
+
 output "cdn_endpoint_url" {
   value = module.azure_cdn.endpoint_hostname
 }

--- a/infra/modules/azure_cdn/outputs.tf
+++ b/infra/modules/azure_cdn/outputs.tf
@@ -27,3 +27,8 @@ output "principal_id" {
   description = "The principal ID of the Front Door Profile's system-assigned managed identity."
   value       = azurerm_cdn_frontdoor_profile.this.identity[0].principal_id
 }
+
+output "rule_set_id" {
+  description = "The ID of the CDN FrontDoor Rule Set"
+  value       = azurerm_cdn_frontdoor_rule_set.this.id
+}

--- a/infra/modules/azure_cdn/variables.tf
+++ b/infra/modules/azure_cdn/variables.tf
@@ -40,6 +40,11 @@ variable "custom_domains" {
   default = []
 }
 
+variable "rule_set_ids" {
+  type        = list(string)
+  description = "List of rule set IDs to associate with the CDN endpoint"
+  default     = []
+}
 
 variable "diagnostic_settings" {
   type = object({
@@ -55,7 +60,7 @@ variable "diagnostic_settings" {
   description = <<-EOT
     Define if diagnostic settings should be enabled.
     if it is:
-    Specifies the ID of a Log Analytics Workspace where Diagnostics Data should be sent and 
+    Specifies the ID of a Log Analytics Workspace where Diagnostics Data should be sent and
     the ID of the Storage Account where logs should be sent. (Changing this forces a new resource to be created)
   EOT
 

--- a/infra/modules/azure_cdn/variables.tf
+++ b/infra/modules/azure_cdn/variables.tf
@@ -40,12 +40,6 @@ variable "custom_domains" {
   default = []
 }
 
-variable "rule_set_ids" {
-  type        = list(string)
-  description = "List of rule set IDs to associate with the CDN endpoint"
-  default     = []
-}
-
 variable "diagnostic_settings" {
   type = object({
     enabled                                   = bool


### PR DESCRIPTION
Added `rule_set_id` output that exposes the Front Door Rule Set ID. This allows users to implement custom rules via the `azurerm_cdn_frontdoor_rule` resource and link them to the rule set provided by the module.

Resolves CES-1062