### PR TITLE
Remove snapshot and add privatePackage options

### DIFF
--- a/.changeset/config.json
+++ b/.changeset/config.json
@@ -8,7 +8,8 @@
   "baseBranch": "main",
   "updateInternalDependencies": "patch",
   "ignore": [],
-  "snapshot": {
-    "prereleaseTemplate": "{commit}"
+  "privatePackages": {
+    "version": true,
+    "tag": true
   }
 }


### PR DESCRIPTION
Doing this, also the Terraform module releases are going to be visible under the releases section on GitHub