### PR TITLE
Pin `azure-function-core-tools` version

### DIFF
--- a/.devcontainer/features/azure-functions-core-tools/devcontainer-feature.json
+++ b/.devcontainer/features/azure-functions-core-tools/devcontainer-feature.json
@@ -1,19 +1,11 @@
 {
   "id": "azure-functions-core-tools",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "name": "Azure Functions Core Tools",
   "description": "Installs the Azure Functions Core Tools",
   "documentationURL": "https://github.com/pagopa/dx/tree/main/.devcontainer/features/azure-functions-core-tools",
   "dependsOn": {
     "ghcr.io/devcontainers/features/dotnet:2": "8.0"
-  },
-  "options": {
-    "version": {
-      "type": "string",
-      "description": "The version of Azure Functions Core Tools to install",
-      "proposals": ["latest"],
-      "default": "latest"
-    }
   },
   "installsAfter": ["ghcr.io/devcontainers/features/common-utils"]
 }

--- a/.devcontainer/features/azure-functions-core-tools/install.sh
+++ b/.devcontainer/features/azure-functions-core-tools/install.sh
@@ -2,13 +2,7 @@
 
 set -e
 
-echo "Choose the version of Azure Functions Core Tools to install"
-if [ "$VERSION" = "latest" ]; then
-    CORE_TOOLS_VERSION=$(curl -s https://api.github.com/repos/Azure/azure-functions-core-tools/releases/latest | jq -r '.tag_name')
-else
-    CORE_TOOLS_VERSION=$VERSION
-fi
-
+CORE_TOOLS_VERSION=4.0.7030
 BUILD_NUMBER=$(echo $CORE_TOOLS_VERSION | cut -d '.' -f 3)
 
 echo "Clone Azure Functions Core Tools repository"


### PR DESCRIPTION
TL;DR: Pin `azure-functions-core-tools` to version `4.0.7030`

[Microsoft is currently working on an official Linux ARM64 release (now in **Preview**)](https://github.com/Azure/azure-functions-core-tools/releases/tag/4.0.7332-preview1), which will eventually be available via **NPM** or **APT**, eliminating the need to manually build the CLI from source. 

To support this platform, recent changes were made to the source code that are incompatible with the build steps used by this **devcontainer feature**.

As a result, we will now only support version `4.0.7030`, which is the latest version compatible with our `install.sh` script.

Once the official build is released, this feature will be **deprecated** and replaced by the [community-maintained version](https://github.com/jlaundry/devcontainer-features/tree/main/src/azure-functions-core-tools).

---

I decided to mark this change as a patch to avoid breaking the devcontainer builds used by our teams — since the `version` parameter (which I removed) was optional and not used by anyone. Releasing this change as v2 would have inevitably broken local builds.
