### PR TITLE
Implement a GitHub Action that comments PRs

### DIFF
--- a/.github/actions/pr-comment/README.md
+++ b/.github/actions/pr-comment/README.md
@@ -1,0 +1,60 @@
+# PR Comment Manager Action
+
+This action creates or updates comments on Pull Requests. It provides a simple way to post comments and optionally update existing ones based on a search pattern.
+
+## Features
+
+- Create new comments on PRs
+- Optionally update existing comments using search patterns
+- Full markdown support in comments
+
+## Usage
+
+### Post a New Comment
+```yaml
+- uses: ./.github/actions/pr-comment
+  with:
+    comment-body: |
+      ### Build Results ✅
+      Build completed successfully!
+```
+
+### Update Existing Comment
+```yaml
+- uses: ./.github/actions/pr-comment
+  with:
+    comment-body: |
+      ### Test Coverage Report
+      \`\`\`json
+      ${{ steps.coverage.outputs.report }}
+      \`\`\`
+    search-pattern: 'Test Coverage Report'  # Will update existing comment if found
+```
+
+## Inputs
+
+| Input | Description | Required |
+|-------|-------------|----------|
+| `comment-body` | Content of the comment (supports markdown) | Yes |
+| `search-pattern` | Text pattern to identify existing comments to replace | No |
+
+## Example Use Cases
+
+### Terraform Plan
+```yaml
+- uses: ./.github/actions/pr-comment
+  with:
+    comment-body: |
+      ### 📖 Terraform Plan (${{ steps.directory.outputs.dir }}) - ${{ steps.plan.outcome }}
+      <details>
+      <summary>Show Plan</summary>
+
+      \`\`\`hcl
+      ${{ steps.plan.outputs.stdout }}
+      \`\`\`
+      </details>
+    search-pattern: "Terraform Plan (${{ steps.directory.outputs.dir }})"
+
+## Maintainers
+
+This action is maintained by the [PagoPA DX](https://pagopa.github.io/dx/docs/) team.

--- a/.github/actions/pr-comment/action.yml
+++ b/.github/actions/pr-comment/action.yml
@@ -1,0 +1,53 @@
+name: 'PR Comment Manager'
+description: 'Creates or updates comments on Pull Requests'
+inputs:
+  comment-body:
+    description: 'The comment content to post (supports markdown)'
+    required: true
+  search-pattern:
+    description: 'Text pattern to identify existing comments to replace. If not provided, a new comment will always be created'
+    required: false
+
+runs:
+  using: 'composite'
+  steps:
+    - name: Manage PR Comment
+      uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea # v7.0.1
+      with:
+        script: |
+          const body = process.env.INPUT_COMMENT_BODY;
+          const searchPattern = process.env.INPUT_SEARCH_PATTERN;
+
+          // Find existing comment if search pattern is provided
+          let existingComment;
+          if (searchPattern) {
+            const { data: comments } = await github.rest.issues.listComments({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.issue.number
+            });
+
+            existingComment = comments.find(comment =>
+              comment.body.includes(searchPattern)
+            );
+          }
+
+          // Update or create comment
+          if (existingComment) {
+            await github.rest.issues.updateComment({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              comment_id: existingComment.id,
+              body: body
+            });
+          } else {
+            await github.rest.issues.createComment({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.issue.number,
+              body: body
+            });
+          }
+      env:
+        INPUT_COMMENT_BODY: ${{ inputs.comment-body }}
+        INPUT_SEARCH_PATTERN: ${{ inputs.search-pattern }}

--- a/.github/workflows/infra_plan.yaml
+++ b/.github/workflows/infra_plan.yaml
@@ -150,52 +150,21 @@ jobs:
 
 
       # Post the plan output in the PR
-      # The plan output is posted in a comment in the PR
-      - uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea # v7.0.1
-        name: Post Plan on PR
+      - name: Post Plan on PR
         id: comment
         if: always() && github.event_name == 'pull_request'
-        env:
-          OUTPUT_DIR: ${{ steps.directory.outputs.dir }}
-          PLAN_STATUS: ${{ steps.plan.outcome }}
+        uses: ./.github/actions/pr-comment
         with:
-          script: |
-            const fs = require('fs');
-            const outputDir = process.env.OUTPUT_DIR;
-            const output = fs.readFileSync(`${outputDir}/plan_output_multiline.txt`, 'utf8');
-            const status = process.env.PLAN_STATUS;
-            const { data: comments } = await github.rest.issues.listComments({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              issue_number: context.issue.number
-            })
-            const botComment = comments.find(comment => {
-              return comment.user.type === 'Bot' && comment.body.includes(`Terraform Plan (${outputDir})`)
-            })
-            const commentBody = `#### 📖 Terraform Plan (${outputDir}) - ${status}
+          comment-body: |
+            ### 📖 Terraform Plan (${{ steps.directory.outputs.dir }}) - ${{ steps.plan.outcome }}
             <details>
-            <summary>Terraform Plan</summary>
+            <summary>Show Plan</summary>
 
-            \`\`\`hcl
-            ${output}
-            \`\`\`
-
+            ```hcl
+            ${{ steps.plan.outputs.stdout }}
+            ```
             </details>
-            `;
-            if (botComment) {
-              await github.rest.issues.deleteComment({
-                owner: context.repo.owner,
-                repo: context.repo.repo,
-                comment_id: botComment.id
-              })
-            }
-
-            await github.rest.issues.createComment({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              body: commentBody,
-              issue_number: context.issue.number
-            })
+          search-pattern: "Terraform Plan (${{ steps.directory.outputs.dir }})"
 
 
       # Fail the workflow if the Terraform plan failed


### PR DESCRIPTION
As of now, only the infra_plan.yaml workflow writes a comment in PRs. In the near future, also the static_analysis.yaml workflow will post comments.
For this reason, the development of this reusable Github Action is suggested.