### PR TITLE
Add mysql to resource abbreviations

### DIFF
--- a/.changeset/vast-days-sin.md
+++ b/.changeset/vast-days-sin.md
@@ -1,0 +1,5 @@
+---
+"provider-azure": minor
+---
+
+Add mysql to resource abbreviations

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -17,11 +17,15 @@
       "installYarnUsingApt": false,
       "pnpmVersion": "none",
       "nvmInstallPath": "/opt/nvm"
-    }
+    },
+    "ghcr.io/devcontainers/features/go:1": {}
   },
   "postStartCommand": {
     "set-workspace-as-safe-dir": "git config --global --add safe.directory ${containerWorkspaceFolder}",
-    "install-yarn-and-deps": "COREPACK_ENABLE_DOWNLOAD_PROMPT=0 yarn install"
+    "install-yarn-and-deps": "yarn install"
+  },
+  "containerEnv": {
+    "COREPACK_ENABLE_DOWNLOAD_PROMPT": "0",
   },
   "customizations": {
     "vscode": {

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -4,10 +4,6 @@
     "**/.pnp.*": true
   },
   "prettier.prettierPath": ".yarn/sdks/prettier/index.cjs",
-  "editor.defaultFormatter": "esbenp.prettier-vscode",
-  "[terraform]": {
-    "editor.defaultFormatter": "hashicorp.terraform"
-  },
   "github.copilot.chat.codeGeneration.instructions": [
     {
       "file": ".github/instructions/code.instructions.md"
@@ -35,7 +31,15 @@
   ],
   "typescript.tsdk": ".yarn/sdks/typescript/lib",
   "typescript.enablePromptUseWorkspaceTsdk": true,
+  "editor.defaultFormatter": "esbenp.prettier-vscode",
+  "editor.formatOnSave": true,
+  "[terraform]": {
+    "editor.defaultFormatter": "hashicorp.terraform"
+  },
   "[terraform-test]": {
     "editor.defaultFormatter": "hashicorp.terraform"
+  },
+  "[go]": {
+    "editor.defaultFormatter": "golang.go"
   }
 }

--- a/apps/providers/azure/internal/provider/function_resource_name.go
+++ b/apps/providers/azure/internal/provider/function_resource_name.go
@@ -108,6 +108,7 @@ func (f *resourceNameFunction) Run(ctx context.Context, req function.RunRequest,
 		"postgresql":         "psql",
 		"postgresql_replica": "psql-replica",
 		"redis_cache":        "redis",
+		"mysql":              "mysql",
 
 		// Integration
 		"eventhub_namespace":   "evhns",

--- a/apps/providers/azure/package.json
+++ b/apps/providers/azure/package.json
@@ -2,5 +2,8 @@
   "name": "provider-azure",
   "version": "0.3.0",
   "private": true,
-  "description": "Terraform provider for DX on Azure, to enhance developer experience"
+  "description": "Terraform provider for DX on Azure, to enhance developer experience",
+  "scripts": {
+    "format": "go fmt"
+  }
 }


### PR DESCRIPTION
Minor changes:
- Add the go feature to the devcontainer
- Register "go fmt" as "format" script for the provider
- Set "golang.go" as the default formatter for go source files