### PR TITLE
Run `format` script on `pr-comment` action

### DIFF
--- a/.changeset/curly-heads-show.md
+++ b/.changeset/curly-heads-show.md
@@ -1,0 +1,5 @@
+---
+"pr-comment-action": patch
+---
+
+Do format files to fix an issue during code-review

--- a/actions/pr-comment/tsup.config.ts
+++ b/actions/pr-comment/tsup.config.ts
@@ -11,5 +11,5 @@ export default defineConfig({
   bundle: true,
   platform: "node",
   noExternal: [/.*/],
-  treeshake: true
+  treeshake: true,
 });


### PR DESCRIPTION
There is a formatting error that let the `code-review` script to fail