### PR TITLE
Remove temporary directory from file path validation

### DIFF
--- a/actions/pr-comment/src/index.ts
+++ b/actions/pr-comment/src/index.ts
@@ -251,7 +251,6 @@ function validateFilePath(filePath: string): void {
     "/sys/",
     "/.ssh/",
     "/.env",
-    "/tmp/",
     "id_rsa",
     "id_dsa",
     "authorized_keys",


### PR DESCRIPTION
Eliminate the validation check for the temporary directory in file paths to enhance security and streamline the validation process.