### PR TITLE
Allow queue readers to set visibility timeout

### DIFF
--- a/.changeset/angry-buckets-camp.md
+++ b/.changeset/angry-buckets-camp.md
@@ -1,0 +1,5 @@
+---
+"azure_role_assignments": minor
+---
+
+Add permissions to set visibility timeout in storage queues to readers

--- a/infra/modules/azure_role_assignments/modules/storage_account/locals.tf
+++ b/infra/modules/azure_role_assignments/modules/storage_account/locals.tf
@@ -54,7 +54,7 @@ locals {
     }
 
     queue = {
-      reader = ["Storage Queue Data Message Processor", "Storage Queue Data Reader"],
+      reader = ["Storage Queue Data Message Processor", "Storage Queue Data Reader", "PagoPA Storage Queue Data Message Contributor"],
       writer = ["Storage Queue Data Message Sender"],
       owner  = ["Storage Queue Data Contributor"]
     }


### PR DESCRIPTION
Assign the new custom role "PagoPA Storage Queue Data Message Contributor" to storage queue "reader" role