### PR TITLE
Remove dx-cli from root

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,6 @@
   "devDependencies": {
     "@changesets/cli": "^2.29.5",
     "@devcontainers/cli": "^0.79.0",
-    "@pagopa/dx-cli": "workspace:^",
     "@vitest/coverage-v8": "catalog:",
     "eslint": "catalog:",
     "prettier": "catalog:",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -6,12 +6,6 @@ settings:
 
 catalogs:
   default:
-    '@tsconfig/node22':
-      specifier: 22.0.2
-      version: 22.0.2
-    '@types/node':
-      specifier: ^22.16.2
-      version: 22.16.2
     '@vitest/coverage-v8':
       specifier: ^3.2.4
       version: 3.2.4
@@ -21,9 +15,6 @@ catalogs:
     prettier:
       specifier: 3.6.2
       version: 3.6.2
-    tsup:
-      specifier: ^8.5.0
-      version: 8.5.0
     typescript:
       specifier: ~5.8.3
       version: 5.8.3
@@ -41,9 +32,6 @@ importers:
       '@devcontainers/cli':
         specifier: ^0.79.0
         version: 0.79.0
-      '@pagopa/dx-cli':
-        specifier: workspace:^
-        version: link:apps/cli
       '@vitest/coverage-v8':
         specifier: 'catalog:'
         version: 3.2.4(vitest@3.2.4(@types/debug@4.1.12)(@types/node@22.16.2)(jiti@1.21.7)(terser@5.39.0))


### PR DESCRIPTION
Revert https://github.com/pagopa/dx/pull/731

With the previous change, I made the root package (`@pagopa/dx`) dependent on the CLI package (`@pagopa/dx-cli`), introducing a circular dependency since dx-cli was already dependent on the root package, as per the way pnpm packages works.

This change introduced an unintended (but predictable) side effect: each change on `@pagopa/dx-cli` triggered a change for all the workspaces in the monorepo.

## Repro

I want to use `turbo` to build only the changed packages, using `turbo build --affected`

Example 1:

1. I make changes in `apps/website`.
2. I run `turbo build --affected`.
3. Turbo runs the `build` command against the affected target(s) and their dependents.
4. The target is `apps/website`, since it's the only package with changes and it has no dependents.
5. Turbo correctly builds only `apps/website`. ✅

Example 2:

1. I make changes in `apps/cli`.
2. I run `turbo build --affected`.
3. Turbo runs the `build` command against the affected target(s) and their dependents.
4. The affected target is `apps/cli`, which has `@pagopa/dx` as a dependent. `@pagopa/dx` in turn has all other workspaces (the entire monorepo) as dependents.
5. Turbo ends up building the whole monorepo. ❌ (UNWANTED CHANGE, I WAS EXPECTING TO BUILD ONLY DX-CLI)




