### PR TITLE
Update PEP creation logic for Postgres module

### DIFF
--- a/.changeset/brave-states-strive.md
+++ b/.changeset/brave-states-strive.md
@@ -1,0 +1,5 @@
+---
+"azure_postgres_server": patch
+---
+
+Update PEP creation logic, if delegated subnet is defined pep will be not created. Now you must specify subnet_pep_id or delegated_subnet_id, not both. The private endpoint output is now optional and will return null if not created. This change is backward compatible, but the old output structure will be removed in the next major version.

--- a/infra/modules/azure_postgres_server/README.md
+++ b/infra/modules/azure_postgres_server/README.md
@@ -79,7 +79,7 @@ No modules.
 | <a name="input_replica_zone"></a> [replica\_zone](#input\_replica\_zone) | Specifies the Availability Zone in which the Replica PostgreSQL Flexible Server should be located. | `string` | `null` | no |
 | <a name="input_resource_group_name"></a> [resource\_group\_name](#input\_resource\_group\_name) | The name of the resource group where resources will be deployed. | `string` | n/a | yes |
 | <a name="input_storage_mb"></a> [storage\_mb](#input\_storage\_mb) | The max storage allowed for the PostgreSQL Flexible Server. Possible values are 32768, 65536, 131072, 262144, 524288, 1048576, 2097152, 4194304, 8388608, 16777216, and 33554432. | `number` | `32768` | no |
-| <a name="input_subnet_pep_id"></a> [subnet\_pep\_id](#input\_subnet\_pep\_id) | The ID of the subnet used for private endpoints. | `string` | n/a | yes |
+| <a name="input_subnet_pep_id"></a> [subnet\_pep\_id](#input\_subnet\_pep\_id) | The ID of the subnet used for private endpoints. | `string` | `null` | no |
 | <a name="input_tags"></a> [tags](#input\_tags) | A map of tags to assign to the resources. | `map(any)` | n/a | yes |
 | <a name="input_tier"></a> [tier](#input\_tier) | Resource tiers depending on demanding workload. Allowed values are 's', 'm', 'l'. | `string` | `"s"` | no |
 | <a name="input_zone"></a> [zone](#input\_zone) | Specifies the Availability Zone in which the PostgreSQL Flexible Server should be located. | `string` | `null` | no |

--- a/infra/modules/azure_postgres_server/network.tf
+++ b/infra/modules/azure_postgres_server/network.tf
@@ -1,4 +1,6 @@
 resource "azurerm_private_endpoint" "postgre_pep" {
+  count = var.delegated_subnet_id == null ? 1 : 0
+
   name                = provider::dx::resource_name(merge(local.naming_config, { resource_type = "postgre_private_endpoint" }))
   location            = var.environment.location
   resource_group_name = var.resource_group_name
@@ -19,12 +21,19 @@ resource "azurerm_private_endpoint" "postgre_pep" {
   tags = local.tags
 }
 
+# For backward compatibility, we keep the old output structure.
+# Remove this in the next major version.
+moved {
+  from = azurerm_private_endpoint.postgre_pep
+  to   = azurerm_private_endpoint.postgre_pep[0]
+}
+
 #--------------------------#
 # Replica Private Endpoint #
 #--------------------------#
 
 resource "azurerm_private_endpoint" "replica_postgre_pep" {
-  count = var.tier == "l" ? 1 : 0
+  count = var.tier == "l" && var.delegated_subnet_id == null ? 1 : 0
 
   name                = provider::dx::resource_name(merge(local.naming_config, { resource_type = "postgre_replica_private_endpoint" }))
   location            = var.environment.location

--- a/infra/modules/azure_postgres_server/outputs.tf
+++ b/infra/modules/azure_postgres_server/outputs.tf
@@ -1,6 +1,6 @@
 output "private_endpoint" {
   description = "The resource ID of the Private Endpoint associated with the PostgreSQL Flexible Server."
-  value       = azurerm_private_endpoint.postgre_pep.id
+  value       = try(azurerm_private_endpoint.postgre_pep[0].id, null)
 }
 
 output "postgres" {

--- a/infra/modules/azure_postgres_server/variables.tf
+++ b/infra/modules/azure_postgres_server/variables.tf
@@ -47,6 +47,12 @@ variable "private_dns_zone_resource_group_name" {
 variable "subnet_pep_id" {
   type        = string
   description = "The ID of the subnet used for private endpoints."
+  default     = null
+
+  validation {
+    condition     = (var.subnet_pep_id != null) != (var.delegated_subnet_id != null)
+    error_message = "'subnet_pep_id' is the default if applicable. You must specify exactly one of 'subnet_pep_id' or 'delegated_subnet_id'."
+  }
 }
 
 variable "delegated_subnet_id" {


### PR DESCRIPTION
This change updates the logic for creating the private endpoint in the Azure PostgreSQL server module. It introduces a new variable `delegated_subnet_id` to allow users to specify either `subnet_pep_id` or `delegated_subnet_id`, but not both. The private endpoint output is now optional and will return null if the private endpoint is not created. This change maintains backward compatibility, but the old output structure will be removed in the next major version.

Resolves: CES-1165