### PR TITLE
Add GitHub Workflow for Static Web App build and deploy

### DIFF
--- a/.changeset/eleven-states-dig.md
+++ b/.changeset/eleven-states-dig.md
@@ -1,0 +1,5 @@
+---
+"docs": patch
+---
+
+Add doc page for Static Web App deploy pipeline

--- a/.github/workflows/release-azure-staticapp-v1.yaml
+++ b/.github/workflows/release-azure-staticapp-v1.yaml
@@ -171,4 +171,3 @@ jobs:
           repo_token: ${{ secrets.GITHUB_TOKEN }}
           action: "upload"
           app_location: "./${{ env.OUTPUT_DIR }}"
-          api_location: ""

--- a/.github/workflows/release-typescript-static-website-deploy-v1.yaml
+++ b/.github/workflows/release-typescript-static-website-deploy-v1.yaml
@@ -131,6 +131,7 @@ jobs:
     permissions:
       id-token: write
       contents: read
+      pull-requests: write
 
     steps:
       - name: Checkout

--- a/.github/workflows/release-typescript-static-website-deploy-v1.yaml
+++ b/.github/workflows/release-typescript-static-website-deploy-v1.yaml
@@ -1,0 +1,170 @@
+name: Deploy Static Site to Azure
+
+# This reusable workflow builds a static application from a monorepo workspace,
+# uploads the assets to an Azure Static Web App, and deploys them.
+# It is designed to be called by other workflows.
+
+# NOTE: use as trigger
+# on:
+#   push:
+#     branches:
+#       - main
+#     paths:
+#       - "apps/my-static-app/**" # Trigger only when this app changes
+#   pull_request:
+#     types: [opened, synchronize, reopened, closed]
+#     branches:
+#       - main
+#     paths:
+#       - "apps/my-static-app/**"
+# To be sure that during a PR the preview will be triggered
+
+on:
+  workflow_call:
+    inputs:
+      workspace_name:
+        description: The name of the workspace to create the artifact for.
+        type: string
+        required: true
+      output_dir:
+        description: The name of the build output directory.
+        type: string
+        required: false
+        default: 'dist'
+      static_web_app_name:
+        description: Azure Static Web App name where the assets will be deployed.
+        type: string
+        required: true
+      resource_group_name:
+        description: Resource group name for the Azure Static Web App.
+        type: string
+        required: true
+      environment:
+        description: Environment where the artifact will be deployed.
+        type: string
+        required: true
+      use_private_agent:
+        description: Use a private agent to deploy the built artifact.
+        type: boolean
+        required: false
+        default: false
+      use_labels:
+        description: Use labels to start the right environment's GitHub runner. If use_labels is true, also use_private_agent must be set to true
+        type: boolean
+        required: false
+        default: false
+      override_labels:
+        description: Needed for special cases where the environment alone is not sufficient as a distinguishing label
+        type: string
+        required: false
+        default: ''
+
+concurrency:
+  group: ${{ github.workflow }}-cd
+  cancel-in-progress: true
+
+env:
+  BUNDLE_NAME: bundle
+  OUTPUT_DIR: ${{ inputs.output_dir }}
+
+jobs:
+  build:
+    name: Build Artifact
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
+
+      - name: Prune
+        run: npx turbo prune --scope=$WORKSPACE
+        env:
+          WORKSPACE: ${{ inputs.workspace_name }}
+
+      - name: Node Setup
+        id: node-setup
+        uses: pagopa/dx/.github/actions/node-setup@main
+        with:
+          working_dir: ./out
+      
+      - name: Install dependencies (npm)
+        if: steps.node-setup.outputs.package-manager == 'npm'
+        run: npm ci
+        working-directory: ./out
+
+      - name: Install dependencies (yarn)
+        if: steps.node-setup.outputs.package-manager == 'yarn'
+        run: yarn install --immutable
+        working-directory: ./out
+
+      - name: Install dependencies (pnpm)
+        if: steps.node-setup.outputs.package-manager == 'pnpm'
+        run: pnpm install
+        working-directory: ./out
+
+      - name: Build project
+        run: npx turbo build
+        working-directory: ./out
+
+      - name: Find build output directory path
+        id: find_package
+        env:
+          TURBO_PRINT_VERSION_DISABLED: 1
+          WORKSPACE: ${{ inputs.workspace_name }}
+        run: |
+          packages_path=$(npx turbo ls --output json | jq -sr --arg WORKSPACE "$WORKSPACE" '.[].packages.items[] | select(.name==$WORKSPACE).path')
+          echo "Found $OUTPUT_DIR directory at: ./out/$packages_path/$OUTPUT_DIR"
+          echo "packages_path=./out/$packages_path/$OUTPUT_DIR" >> $GITHUB_OUTPUT
+
+      - name: Upload Artifact
+        uses: pagopa/dx/.github/actions/upload-artifact@main
+        with:
+          bundle_name: ${{ env.BUNDLE_NAME }}
+          file_path: ${{ steps.find_package.outputs.packages_path }}
+
+  deploy:
+    name: Deploy
+    runs-on: ${{ inputs.use_labels && inputs.use_private_agent && (inputs.override_labels != '' && inputs.override_labels || inputs.environment) || inputs.use_private_agent && 'self-hosted' || 'ubuntu-latest' }}
+    needs: [build]
+    if: ${{ !github.event.act }}
+    environment: ${{ inputs.environment }}-cd
+    permissions:
+      id-token: write
+      contents: read
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
+        with:
+          fetch-depth: 0
+
+      - name: Download Artifact
+        uses: pagopa/dx/.github/actions/download-artifact@main
+        with:
+          bundle_name: ${{ env.BUNDLE_NAME }}
+          file_path: "./${{ env.OUTPUT_DIR }}"
+
+      - name: Azure Login
+        uses: pagopa/dx/.github/actions/azure-login@main
+        env:
+          ARM_USE_OIDC: true
+          ARM_CLIENT_ID: ${{ secrets.ARM_CLIENT_ID }}
+          ARM_TENANT_ID: ${{ secrets.ARM_TENANT_ID }}
+          ARM_SUBSCRIPTION_ID: ${{ secrets.ARM_SUBSCRIPTION_ID }}
+
+      - name: Find API Key
+        id: find_api_key
+        run: |
+          api_key=$(az staticwebapp secrets list --name ${{ inputs.static_web_app_name }} --resource-group ${{ inputs.resource_group_name }} | jq -r '.properties.apiKey')
+          echo "::add-mask::$api_key"
+          echo "sensitive-value=$api_key" >> $GITHUB_OUTPUT
+
+      - name: Deploy
+        id: builddeploy
+        uses: Azure/static-web-apps-deploy@v1
+        with:
+          azure_static_web_apps_api_token: ${{ steps.find_api_key.outputs.sensitive-value }}
+          repo_token: ${{ secrets.GITHUB_TOKEN }}
+          action: "upload"
+          app_location: "./${{ env.OUTPUT_DIR }}"
+          api_location: ""

--- a/.github/workflows/release-typescript-static-website-deploy-v1.yaml
+++ b/.github/workflows/release-typescript-static-website-deploy-v1.yaml
@@ -156,13 +156,16 @@ jobs:
       - name: Find API Key
         id: find_api_key
         run: |
-          api_key=$(az staticwebapp secrets list --name ${{ inputs.static_web_app_name }} --resource-group ${{ inputs.resource_group_name }} | jq -r '.properties.apiKey')
+          api_key=$(az staticwebapp secrets list --name $STATIC_WEB_APP_NAME --resource-group $RESOURCE_GROUP_NAME | jq -r '.properties.apiKey')
           echo "::add-mask::$api_key"
           echo "sensitive-value=$api_key" >> $GITHUB_OUTPUT
+        env:
+          STATIC_WEB_APP_NAME: ${{ inputs.static_web_app_name }}
+          RESOURCE_GROUP_NAME: ${{ inputs.resource_group_name }}
 
       - name: Deploy
         id: builddeploy
-        uses: Azure/static-web-apps-deploy@v1
+        uses: Azure/static-web-apps-deploy@4d27395796ac319302594769cfe812bd207490b1 # v1
         with:
           azure_static_web_apps_api_token: ${{ steps.find_api_key.outputs.sensitive-value }}
           repo_token: ${{ secrets.GITHUB_TOKEN }}

--- a/apps/website/docs/pipelines/build-deploy-static-web-app.md
+++ b/apps/website/docs/pipelines/build-deploy-static-web-app.md
@@ -1,0 +1,92 @@
+---
+sidebar_position: 50
+---
+
+# Deploy Static Site to Azure Static Web App Workflow
+
+The
+[Build and Deploy Static Site to Azure Static Web App](https://github.com/pagopa/dx/tree/main/.github/workflows/release-typescript-static-website-deploy-v1.yaml)
+is a reusable workflow (`workflow_call`) that automates the build and deployment
+of a static application from a Turborepo-based monorepo to **Azure Static Web
+Apps**. It is designed to provide a streamlined, secure, and consistent
+deployment process, complete with integrated support for **Pull Request
+previews**.
+
+## How It Works
+
+The workflow is divided into two distinct jobs to separate build and deployment
+concerns:
+
+1. **`build` Job**:
+    - Runs on a standard `ubuntu-latest` runner.
+    - Uses `turbo prune` to create a minimal, isolated copy of the monorepo
+      containing only the code and dependencies required for the specified
+      `workspace_name`.
+    - Dynamically detects the package manager (`npm`, `yarn`, or `pnpm`) and
+      uses the appropriate "clean install" command for reproducible builds.
+    - Runs the `build` script for the target workspace using Turborepo.
+    - Locates the resulting build output directory (e.g., `build` or `dist`) and
+      uploads it as an artifact, making it available for the deployment job.
+
+2. **`deploy` Job**:
+    - Waits for the `build` job to complete successfully.
+    - Runs on a configurable runner (public or self-hosted) based on input
+      parameters.
+    - Downloads the build artifact.
+    - Logs into Azure using OIDC credentials configured as GitHub secrets.
+    - Retrieves the **deployment token** (API key) from the target Azure Static
+      Web App. This token is used to authorize the deployment.
+    - Calls the official `Azure/static-web-apps-deploy@v1` action to handle the
+      final deployment, uploading the pre-built application assets. This action
+      also automatically handles the creation and management of **preview
+      environments** for Pull Requests.
+
+## Usage
+
+To use this reusable workflow, you need to call it from another workflow file in
+your repository. Below is an example of how to trigger it for a specific
+application.
+
+```yaml
+name: Deploy My Static App to Azure
+
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - "apps/my-static-app/**" # Trigger only when this app changes
+  pull_request:
+    types: [opened, synchronize, reopened, closed]
+    branches:
+      - main
+    paths:
+      - "apps/my-static-app/**"
+
+jobs:
+  deploy_to_static_web_app:
+    uses: pagopa/dx/.github/workflows/release-typescript-static-website-deploy-v1.yaml@main # Path to the reusable workflow
+    secrets: inherit
+    with:
+      workspace_name: "my-static-app" # The 'name' from the app's package.json
+      output_dir: "dist" # The build output directory name
+      static_web_app_name: "your-static-web-app-name"
+      resource_group_name: "your-resource-group-name"
+      environment: "app-dev"
+```
+
+### Important Notes
+
+1. **Trigger Configuration**: The calling workflow must be triggered on `push`
+    and `pull_request` events for the preview environment functionality to work
+    correctly.
+2. **Workspace Name**: Ensure the `workspace_name` input matches the `name`
+    field in the `package.json` of the application you want to deploy, not its
+    directory path.
+3. **Permissions & Secrets**: The calling workflow must have the necessary
+    permissions (`id-token: write`, `contents: read`) and secrets (e.g., for
+    Azure login) available. Using `secrets: inherit` is the easiest way to pass
+    them down.
+4. **Monorepo Structure**: This workflow is optimized for a monorepo managed
+    with Turborepo. It assumes your applications are located in workspaces
+    (under an `apps/` directory).

--- a/apps/website/docs/pipelines/build-deploy-static-web-app.md
+++ b/apps/website/docs/pipelines/build-deploy-static-web-app.md
@@ -14,8 +14,7 @@ previews**.
 
 ## How It Works
 
-The workflow is divided into two distinct jobs to separate build and deployment
-concerns:
+The workflow automates the entire deployment process from build to release.
 
 1. Automatically identifies the package manager used in the project (pnpm, yarn,
    or npm), configures the runner accordingly and builds the application using

--- a/apps/website/docs/pipelines/build-deploy-static-web-app.md
+++ b/apps/website/docs/pipelines/build-deploy-static-web-app.md
@@ -5,7 +5,7 @@ sidebar_position: 50
 # Deploy Static Site to Azure Static Web App Workflow
 
 The
-[Build and Deploy Static Site to Azure Static Web App](https://github.com/pagopa/dx/tree/main/.github/workflows/release-typescript-static-website-deploy-v1.yaml)
+[Build and Deploy Static Site to Azure Static Web App](https://github.com/pagopa/dx/tree/main/.github/workflows/release-azure-staticapp-v1.yaml)
 is a reusable workflow (`workflow_call`) that automates the build and deployment
 of a static application from a Turborepo-based monorepo to **Azure Static Web
 Apps**. It is designed to provide a streamlined, secure, and consistent
@@ -17,29 +17,14 @@ previews**.
 The workflow is divided into two distinct jobs to separate build and deployment
 concerns:
 
-1. **`build` Job**:
-   - Runs on a standard `ubuntu-latest` runner.
-   - Uses `turbo prune` to create a minimal, isolated copy of the monorepo
-     containing only the code and dependencies required for the specified
-     `workspace_name`.
-   - Dynamically detects the package manager (`npm`, `yarn`, or `pnpm`) and uses
-     the appropriate "clean install" command for reproducible builds.
-   - Runs the `build` script for the target workspace using Turborepo.
-   - Locates the resulting build output directory (e.g., `build` or `dist`) and
-     uploads it as an artifact, making it available for the deployment job.
-
-2. **`deploy` Job**:
-   - Waits for the `build` job to complete successfully.
-   - Runs on a configurable runner (public or self-hosted) based on input
-     parameters.
-   - Downloads the build artifact.
-   - Logs into Azure using OIDC credentials configured as GitHub secrets.
-   - Retrieves the **deployment token** (API key) from the target Azure Static
-     Web App. This token is used to authorize the deployment.
-   - Calls the official `Azure/static-web-apps-deploy@v1` action to handle the
-     final deployment, uploading the pre-built application assets. This action
-     also automatically handles the creation and management of **preview
-     environments** for Pull Requests.
+1. Automatically identifies the package manager used in the project (pnpm, yarn,
+   or npm), configures the runner accordingly and builds the application using
+   `turbo build` command.
+2. It uses the official `Azure/static-web-apps-deploy@v1` action to upload the
+   built application.
+3. If the workflow is triggered by a Pull Request, the deployment step
+   automatically creates a temporary preview environment, allowing you to see
+   your changes live before merging.
 
 ## Usage
 
@@ -65,7 +50,7 @@ on:
 
 jobs:
   deploy_to_static_web_app:
-    uses: pagopa/dx/.github/workflows/release-typescript-static-website-deploy-v1.yaml@main # Path to the reusable workflow
+    uses: pagopa/dx/.github/workflows/release-azure-staticapp-v1.yaml@main # Path to the reusable workflow
     secrets: inherit
     with:
       workspace_name: "my-static-app" # The 'name' from the app's package.json

--- a/apps/website/docs/pipelines/build-deploy-static-web-app.md
+++ b/apps/website/docs/pipelines/build-deploy-static-web-app.md
@@ -18,28 +18,28 @@ The workflow is divided into two distinct jobs to separate build and deployment
 concerns:
 
 1. **`build` Job**:
-    - Runs on a standard `ubuntu-latest` runner.
-    - Uses `turbo prune` to create a minimal, isolated copy of the monorepo
-      containing only the code and dependencies required for the specified
-      `workspace_name`.
-    - Dynamically detects the package manager (`npm`, `yarn`, or `pnpm`) and
-      uses the appropriate "clean install" command for reproducible builds.
-    - Runs the `build` script for the target workspace using Turborepo.
-    - Locates the resulting build output directory (e.g., `build` or `dist`) and
-      uploads it as an artifact, making it available for the deployment job.
+   - Runs on a standard `ubuntu-latest` runner.
+   - Uses `turbo prune` to create a minimal, isolated copy of the monorepo
+     containing only the code and dependencies required for the specified
+     `workspace_name`.
+   - Dynamically detects the package manager (`npm`, `yarn`, or `pnpm`) and uses
+     the appropriate "clean install" command for reproducible builds.
+   - Runs the `build` script for the target workspace using Turborepo.
+   - Locates the resulting build output directory (e.g., `build` or `dist`) and
+     uploads it as an artifact, making it available for the deployment job.
 
 2. **`deploy` Job**:
-    - Waits for the `build` job to complete successfully.
-    - Runs on a configurable runner (public or self-hosted) based on input
-      parameters.
-    - Downloads the build artifact.
-    - Logs into Azure using OIDC credentials configured as GitHub secrets.
-    - Retrieves the **deployment token** (API key) from the target Azure Static
-      Web App. This token is used to authorize the deployment.
-    - Calls the official `Azure/static-web-apps-deploy@v1` action to handle the
-      final deployment, uploading the pre-built application assets. This action
-      also automatically handles the creation and management of **preview
-      environments** for Pull Requests.
+   - Waits for the `build` job to complete successfully.
+   - Runs on a configurable runner (public or self-hosted) based on input
+     parameters.
+   - Downloads the build artifact.
+   - Logs into Azure using OIDC credentials configured as GitHub secrets.
+   - Retrieves the **deployment token** (API key) from the target Azure Static
+     Web App. This token is used to authorize the deployment.
+   - Calls the official `Azure/static-web-apps-deploy@v1` action to handle the
+     final deployment, uploading the pre-built application assets. This action
+     also automatically handles the creation and management of **preview
+     environments** for Pull Requests.
 
 ## Usage
 
@@ -78,15 +78,15 @@ jobs:
 ### Important Notes
 
 1. **Trigger Configuration**: The calling workflow must be triggered on `push`
-    and `pull_request` events for the preview environment functionality to work
-    correctly.
+   and `pull_request` events for the preview environment functionality to work
+   correctly.
 2. **Workspace Name**: Ensure the `workspace_name` input matches the `name`
-    field in the `package.json` of the application you want to deploy, not its
-    directory path.
+   field in the `package.json` of the application you want to deploy, not its
+   directory path.
 3. **Permissions & Secrets**: The calling workflow must have the necessary
-    permissions (`id-token: write`, `contents: read`) and secrets (e.g., for
-    Azure login) available. Using `secrets: inherit` is the easiest way to pass
-    them down.
+   permissions (`id-token: write`, `contents: read`, `pull-requests: write`) and
+   secrets (e.g., for Azure login) available. Using `secrets: inherit` is the
+   easiest way to pass them down.
 4. **Monorepo Structure**: This workflow is optimized for a monorepo managed
-    with Turborepo. It assumes your applications are located in workspaces
-    (under an `apps/` directory).
+   with Turborepo. It assumes your applications are located in workspaces (under
+   an `apps/` directory).


### PR DESCRIPTION
This PR introduces a new reusable GitHub Actions workflow to build and deploy static sites to **Azure Static Web Apps**. It standardizes our deployment process and adds support for automated Pull Request previews.

Resolves: CES-1180