### PR TITLE
Replaced `tier` variable with `use_case` for Cosmos

### DIFF
--- a/.changeset/cute-brooms-agree.md
+++ b/.changeset/cute-brooms-agree.md
@@ -1,0 +1,5 @@
+---
+"azure_cosmos_account": major
+---
+
+Replaced the `tier` variable with a new `use_case` variable for tiering configuration. The previous values (`s`, `l`) have been replaced by three new options: `development` (formerly `s`), and `default` (formerly `l`). This change simplifies and clarifies the selection of Cosmos Account tiers.

--- a/infra/modules/azure_cosmos_account/README.md
+++ b/infra/modules/azure_cosmos_account/README.md
@@ -14,12 +14,12 @@ This Terraform module provisions an Azure Cosmos DB Account with configurable se
 - **Serverless Mode**: Enables serverless mode for cost-efficient, on-demand scaling.
 - **Role Assignment**: Assigns SQL role permissions (Reader or Contributor) to specified principal IDs, enabling fine-grained access control.
 
-## Tiers and Configurations
+## Use cases and Configurations
 
-| Tier  | Description                                                                                        | Serverless Mode |
-|-------|----------------------------------------------------------------------------------------------------|-----------------|
-| `s`   | Recommended for development or testing environments where cost efficiency and flexibility are key. | Enabled         |
-| `l`   | Suitable for production environments requiring predictable performance and provisioned throughput. | Disabled        |
+| Use case      | Description                                                                                        | Serverless Mode |
+|---------------|----------------------------------------------------------------------------------------------------|-----------------|
+| `development` | Recommended for development or testing environments where cost efficiency and flexibility are key. | Enabled         |
+| `default`     | Suitable for production environments requiring predictable performance and provisioned throughput. | Disabled        |
 
 ## Usage Example
 
@@ -66,7 +66,7 @@ No modules.
 | <a name="input_secondary_geo_locations"></a> [secondary\_geo\_locations](#input\_secondary\_geo\_locations) | Secondary geo locations for Cosmos DB account. Failover priority determines the order in which regions will take over in case of a regional outage. If failover priority is not set, the items order is used. | <pre>list(object({<br/>    location          = optional(string, null)<br/>    failover_priority = optional(number, null)<br/>    zone_redundant    = optional(bool, true)<br/>  }))</pre> | `[]` | no |
 | <a name="input_subnet_pep_id"></a> [subnet\_pep\_id](#input\_subnet\_pep\_id) | The ID of the subnet designated for private endpoints. | `string` | n/a | yes |
 | <a name="input_tags"></a> [tags](#input\_tags) | A map of tags to assign to the resources. | `map(any)` | n/a | yes |
-| <a name="input_tier"></a> [tier](#input\_tier) | The offer type for the Cosmos DB account. Valid values are 's' and 'l'. | `string` | `"l"` | no |
+| <a name="input_use_case"></a> [use\_case](#input\_use\_case) | Specifies the use case for the Cosmos Acocount. Allowed values are 'default' and 'development'. | `string` | `"default"` | no |
 
 ## Outputs
 

--- a/infra/modules/azure_cosmos_account/cosmos.tf
+++ b/infra/modules/azure_cosmos_account/cosmos.tf
@@ -48,7 +48,7 @@ resource "azurerm_cosmosdb_account" "this" {
   }
 
   dynamic "capabilities" {
-    for_each = var.tier == "s" ? [1] : []
+    for_each = var.use_case == "development" ? [1] : []
 
     content {
       name = "EnableServerless"

--- a/infra/modules/azure_cosmos_account/examples/minimum/main.tf
+++ b/infra/modules/azure_cosmos_account/examples/minimum/main.tf
@@ -12,7 +12,7 @@ module "cosmos_db" {
   environment         = local.environment
   resource_group_name = azurerm_resource_group.example.name
 
-  tier = "s"
+  use_case = "development"
 
   subnet_pep_id = data.azurerm_subnet.pep.id
 

--- a/infra/modules/azure_cosmos_account/tests/cosmos.tftest.hcl
+++ b/infra/modules/azure_cosmos_account/tests/cosmos.tftest.hcl
@@ -44,7 +44,7 @@ run "cosmos_is_correct_plan" {
       TestName       = "Create Cosmos account for test"
     }
 
-    tier = "s"
+    use_case = "development"
 
     resource_group_name = run.setup_tests.resource_group_name
 

--- a/infra/modules/azure_cosmos_account/variables.tf
+++ b/infra/modules/azure_cosmos_account/variables.tf
@@ -28,16 +28,15 @@ variable "subnet_pep_id" {
   description = "The ID of the subnet designated for private endpoints."
 }
 
-variable "tier" {
+variable "use_case" {
   type        = string
-  description = "The offer type for the Cosmos DB account. Valid values are 's' and 'l'."
-  default     = "l"
+  description = "Specifies the use case for the Cosmos Acocount. Allowed values are 'default' and 'development'."
+  default     = "default"
 
   validation {
-    condition     = contains(["s", "l"], var.tier)
-    error_message = "Valid values for tier are 's' and 'l'."
+    condition     = contains(["default", "development"], var.use_case)
+    error_message = "Allowed values for \"use_case\" are \"default\", or \"development\"."
   }
-
 }
 
 variable "private_dns_zone_resource_group_name" {


### PR DESCRIPTION
Replaced the `tier` variable with a new `use_case` variable for tiering configuration. New values are:

- development
- default

Resolves: CES-1208