### PR TITLE
Replace `tier` variable with `use_case` for Storage Account

### DIFF
--- a/.changeset/moody-pears-sip.md
+++ b/.changeset/moody-pears-sip.md
@@ -1,0 +1,8 @@
+---
+"azure_storage_account": major
+---
+
+Replace the `tier` variable with a new `use_case` variable for tiering configuration. The previous values (`s`, `l`) have been replaced by five new options: `development` (formerly `s`), `default` (formerly `l`),  `audit`, `delegated_access` and `archive`. This change simplifies and clarifies the selection of Storage Account.
+- The `audit` use case now requires Customer-Managed Key (BYOK) encryption to be enabled.
+- For the `delegated_access` use case, `shared_access_key_enabled` is now set to false.
+- Microsoft Defender for Storage (`advanced_threat_protection`) is now consistently enabled for use cases exposed to higher risks, such as `delegated_access`.

--- a/infra/modules/azure_storage_account/examples/complete/locals.tf
+++ b/infra/modules/azure_storage_account/examples/complete/locals.tf
@@ -31,10 +31,11 @@ locals {
   }
 
   tags = {
-    CreatedBy   = "Terraform"
-    Environment = "Dev"
-    Owner       = "DevEx"
-    Source      = "https://github.com/pagopa/dx/modules/azure_role_assignments/examples/complete"
-    CostCenter  = "TS700 - ENGINEERING"
+    CostCenter     = "TS000 - Tecnologia e Servizi"
+    CreatedBy      = "Terraform"
+    Environment    = "Dev"
+    BusinessUnit   = "DevEx"
+    Source         = "https://github.com/pagopa/dx/modules/azure_storage_account/examples/complete"
+    ManagementTeam = "Developer Experience"
   }
 }

--- a/infra/modules/azure_storage_account/examples/complete/main.tf
+++ b/infra/modules/azure_storage_account/examples/complete/main.tf
@@ -30,7 +30,7 @@ module "azure_storage_account" {
   source = "../../"
 
   environment         = local.environment
-  tier                = "l"
+  use_case            = "default"
   resource_group_name = azurerm_resource_group.example.name
 
   subnet_pep_id                        = data.azurerm_subnet.pep.id

--- a/infra/modules/azure_storage_account/locals.tf
+++ b/infra/modules/azure_storage_account/locals.tf
@@ -10,26 +10,56 @@ locals {
     instance_number = tonumber(var.environment.instance_number),
   }
 
-  tiers = {
-    s = {
+  use_cases = {
+    development = {
       alerts                     = false
       advanced_threat_protection = false
+      immutability_policy        = false
+      shared_access_key_enabled  = true
       account_tier               = "Standard"
       replication_type           = "LRS"
     }
 
-    l = {
+    default = {
       alerts                     = true
-      advanced_threat_protection = var.environment.location != "italynorth"
+      advanced_threat_protection = false
+      immutability_policy        = false
+      shared_access_key_enabled  = true
       account_tier               = "Standard"
       replication_type           = "ZRS"
     }
+    audit = {
+      alerts                     = true
+      advanced_threat_protection = false
+      immutability_policy        = true
+      shared_access_key_enabled  = true
+      account_tier               = "Standard"
+      replication_type           = "GZRS"
+    }
+    delegated_access = {
+      alerts                     = true
+      advanced_threat_protection = true
+      immutability_policy        = false
+      shared_access_key_enabled  = false
+      account_tier               = "Standard"
+      replication_type           = "ZRS"
+    }
+    archive = {
+      alerts                     = false
+      advanced_threat_protection = false
+      immutability_policy        = true
+      shared_access_key_enabled  = true
+      account_tier               = "Standard"
+      replication_type           = "GZRS"
+    }
   }
 
-  tier_features = local.tiers[var.tier]
+  tier_features = local.use_cases[var.use_case]
+
+  force_public_network_access_enabled = var.force_public_network_access_enabled || var.use_case == "delegated_access"
 
   peps = {
-    create_subservices = var.force_public_network_access_enabled ? {
+    create_subservices = local.force_public_network_access_enabled ? {
       blob  = false
       file  = false
       queue = false

--- a/infra/modules/azure_storage_account/locals.tf
+++ b/infra/modules/azure_storage_account/locals.tf
@@ -19,7 +19,6 @@ locals {
       account_tier               = "Standard"
       replication_type           = "LRS"
     }
-
     default = {
       alerts                     = true
       advanced_threat_protection = false

--- a/infra/modules/azure_storage_account/storage_account.tf
+++ b/infra/modules/azure_storage_account/storage_account.tf
@@ -7,8 +7,9 @@ resource "azurerm_storage_account" "this" {
   account_tier                    = local.tier_features.account_tier
   account_replication_type        = local.tier_features.replication_type
   access_tier                     = var.access_tier
-  public_network_access_enabled   = var.force_public_network_access_enabled
-  allow_nested_items_to_be_public = var.force_public_network_access_enabled
+  public_network_access_enabled   = local.force_public_network_access_enabled
+  allow_nested_items_to_be_public = local.force_public_network_access_enabled
+  shared_access_key_enabled       = local.tier_features.shared_access_key_enabled
 
   blob_properties {
     versioning_enabled            = var.blob_features.versioning
@@ -55,7 +56,7 @@ resource "azurerm_storage_account" "this" {
   }
 
   dynamic "immutability_policy" {
-    for_each = var.blob_features.immutability_policy.enabled ? [1] : []
+    for_each = local.tier_features.immutability_policy || var.blob_features.immutability_policy.enabled ? [1] : []
 
     content {
       allow_protected_append_writes = var.blob_features.immutability_policy.allow_protected_append_writes
@@ -68,6 +69,72 @@ resource "azurerm_storage_account" "this" {
 }
 
 resource "azurerm_security_center_storage_defender" "this" {
-  count              = local.tier_features.advanced_threat_protection ? 1 : 0
+  count              = local.force_public_network_access_enabled || local.tier_features.advanced_threat_protection ? 1 : 0
   storage_account_id = azurerm_storage_account.this.id
+}
+
+# Blob lifecycle management policy for Audit (Hot -> Cool -> Archive -> Delete)
+resource "azurerm_storage_management_policy" "lifecycle_audit" {
+  count = var.use_case == "audit" ? 1 : 0
+
+  storage_account_id = azurerm_storage_account.this.id
+  rule {
+    name    = "audit-log-lifecycle-policy"
+    enabled = true
+
+    filters {
+      prefix_match = [""] # Apply to all blobs
+      blob_types   = ["blockBlob"]
+    }
+
+    actions {
+      base_blob {
+        # Tier to Cool after 30 days of inactivity (no modification)
+        tier_to_cool_after_days_since_modification_greater_than = 30
+        # Tier to Archive after 90 days of inactivity (no modification)
+        tier_to_archive_after_days_since_modification_greater_than = 90
+        # Delete after 1095 days (3 years) of inactivity (no modification)
+        delete_after_days_since_modification_greater_than = 1095
+      }
+
+      snapshot {
+        delete_after_days_since_creation_greater_than = 30
+      }
+
+      version {
+        delete_after_days_since_creation = 30
+      }
+    }
+  }
+}
+
+# Blob lifecycle management policy for Archive (Any -> Archive)
+resource "azurerm_storage_management_policy" "lifecycle_archive" {
+  count = var.use_case == "archive" ? 1 : 0
+
+  storage_account_id = azurerm_storage_account.this.id
+  rule {
+    name    = "archive-storage-lifecycle-policy"
+    enabled = true
+
+    filters {
+      prefix_match = [""] # Apply to all blobs
+      blob_types   = ["blockBlob"]
+    }
+
+    actions {
+      base_blob {
+        # Tier to Archive after 1 day
+        tier_to_archive_after_days_since_creation_greater_than = 1
+      }
+
+      snapshot {
+        delete_after_days_since_creation_greater_than = 180
+      }
+
+      version {
+        delete_after_days_since_creation = 180
+      }
+    }
+  }
 }

--- a/infra/modules/azure_storage_account/tests/setup/README.md
+++ b/infra/modules/azure_storage_account/tests/setup/README.md
@@ -16,6 +16,7 @@ No modules.
 
 | Name | Type |
 |------|------|
+| [azurerm_key_vault.kv](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/data-sources/key_vault) | data source |
 | [azurerm_resource_group.rg](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/data-sources/resource_group) | data source |
 | [azurerm_subnet.pep](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/data-sources/subnet) | data source |
 | [azurerm_subnet.snet](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/data-sources/subnet) | data source |
@@ -25,12 +26,16 @@ No modules.
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
 | <a name="input_environment"></a> [environment](#input\_environment) | n/a | <pre>object({<br/>    prefix          = string<br/>    env_short       = string<br/>    location        = string<br/>    domain          = optional(string)<br/>    app_name        = string<br/>    instance_number = string<br/>  })</pre> | n/a | yes |
+| <a name="input_tags"></a> [tags](#input\_tags) | A map of tags to assign to the resources. | `map(string)` | `{}` | no |
 
 ## Outputs
 
 | Name | Description |
 |------|-------------|
+| <a name="output_environment"></a> [environment](#output\_environment) | n/a |
+| <a name="output_kv_id"></a> [kv\_id](#output\_kv\_id) | n/a |
 | <a name="output_pep_id"></a> [pep\_id](#output\_pep\_id) | n/a |
 | <a name="output_resource_group_name"></a> [resource\_group\_name](#output\_resource\_group\_name) | n/a |
 | <a name="output_subnet_id"></a> [subnet\_id](#output\_subnet\_id) | n/a |
+| <a name="output_tags"></a> [tags](#output\_tags) | n/a |
 <!-- END_TF_DOCS -->

--- a/infra/modules/azure_storage_account/tests/setup/main.tf
+++ b/infra/modules/azure_storage_account/tests/setup/main.tf
@@ -63,6 +63,19 @@ data "azurerm_resource_group" "rg" {
   }))
 }
 
+data "azurerm_key_vault" "kv" {
+  name = provider::dx::resource_name(merge(local.naming_config, {
+    domain        = null,
+    name          = "common",
+    resource_type = "key_vault"
+  }))
+  resource_group_name = provider::dx::resource_name(merge(local.naming_config, {
+    domain        = null,
+    name          = "common",
+    resource_type = "resource_group"
+  }))
+}
+
 output "pep_id" {
   value = data.azurerm_subnet.pep.id
 }
@@ -73,4 +86,15 @@ output "subnet_id" {
 
 output "resource_group_name" {
   value = data.azurerm_resource_group.rg.name
+}
+
+output "kv_id" {
+  value = data.azurerm_key_vault.kv.id
+}
+output "tags" {
+  value = var.tags
+}
+
+output "environment" {
+  value = var.environment
 }

--- a/infra/modules/azure_storage_account/tests/setup/variables.tf
+++ b/infra/modules/azure_storage_account/tests/setup/variables.tf
@@ -8,3 +8,9 @@ variable "environment" {
     instance_number = string
   })
 }
+
+variable "tags" {
+  type        = map(string)
+  description = "A map of tags to assign to the resources."
+  default     = {}
+}


### PR DESCRIPTION
Replace the `tier` variable with a new `use_case` variable for tiering configuration. New value are:

- default
- development
- audit
- delegated_access
- archive

The `audit` use case now requires Customer-Managed Key encryption to be enabled.
For the `delegated_access` use case, `shared_access_key_enabled` is now set to false to force user delegate SAS.
Microsoft Defender for Storage (`advanced_threat_protection`) is now consistently enabled for use cases exposed, such as `delegated_access`.

Resolves: CES-1210