### PR TITLE
Replace `tier` variable with `use_case` for Service Bus

### DIFF
--- a/.changeset/calm-doors-know.md
+++ b/.changeset/calm-doors-know.md
@@ -1,0 +1,5 @@
+---
+"azure_service_bus_namespace": major
+---
+
+Replace the `tier` variable with a new `use_case` variable for tiering configuration. The previous values (`m`, `l`) have been replaced by a new option: `default` (formerly `m`). This change simplifies and clarifies the selection of Service Bus namespace. In addition, some variables with tier dependencies have been updated with new validation rules to ensure they are only used when appropriate (`subnet_pep_id`, `private_dns_zone_resource_group_name`, `allowed_ips`).

--- a/infra/modules/azure_service_bus_namespace/README.md
+++ b/infra/modules/azure_service_bus_namespace/README.md
@@ -2,7 +2,7 @@
 
 ![Terraform Module Downloads](https://img.shields.io/terraform/module/dm/pagopa-dx/azure-service-bus-namespace/azurerm?logo=terraform&label=downloads&cacheSeconds=5000&link=https%3A%2F%2Fregistry.terraform.io%2Fmodules%2Fpagopa-dx%2Fazure-service-bus-namespace%2Fazurerm%2Flatest)
 
-This Terraform module deploys an Azure Service Bus namespace. It supports `Standard` and `Premium` SKUs only.
+This Terraform module deploys an Azure Service Bus namespace. Currently it supports `Premium` SKUs only.
 
 ## Features
 
@@ -13,10 +13,8 @@ This Terraform module deploys an Azure Service Bus namespace. It supports `Stand
 ## Use cases and Configurations
 
 | Use case | Description                                                  | Security                                                                      |
-|------|--------------------------------------------------------------|-------------------------------------------------------------------------------|
-| default    | High-load production environments and all features available | Access via Private Endpoints only                                             |
-
-**WARNING**: It is strongly encouraged to use the `Premium` SKU (default) due to the mentioned security concerns of the `Standard` SKU.
+|----------|--------------------------------------------------------------|-------------------------------------------------------------------------------|
+| default  | High-load production environments and all features available | Access via Private Endpoints only                                             |
 
 ## Best Practices
 

--- a/infra/modules/azure_service_bus_namespace/README.md
+++ b/infra/modules/azure_service_bus_namespace/README.md
@@ -10,12 +10,11 @@ This Terraform module deploys an Azure Service Bus namespace. It supports `Stand
 - **Secure Authentication**: Supports authentication via Entra ID
 - **Private Endpoint Integration**: (`Premium` SKU only) Creates a private DNS A record for the container app, enabling secure internal communication.
 
-## Tiers and Configurations
+## Use cases and Configurations
 
-| Tier | Description                                                  | Security                                                                      |
+| Use case | Description                                                  | Security                                                                      |
 |------|--------------------------------------------------------------|-------------------------------------------------------------------------------|
-| m    | Low-load production environments and basic features usage    | Despite a firewall, it is publicly available on internet. No VNet integration |
-| l    | High-load production environments and all features available | Access via Private Endpoints only                                             |
+| default    | High-load production environments and all features available | Access via Private Endpoints only                                             |
 
 **WARNING**: It is strongly encouraged to use the `Premium` SKU (default) due to the mentioned security concerns of the `Standard` SKU.
 
@@ -25,31 +24,7 @@ Patterns and advices on how use Service Bus can be found in [DX documentation](h
 
 ## Usage Example
 
-Below is an example of how to use this module:
-
-```hcl
-module "service_bus_01" {
-  source = "./modules/azure_service_bus_namespace"
-
-  environment = {
-    prefix          = "dx"
-    env_short       = "d"
-    location        = "italynorth"
-    app_name        = "test"
-    instance_number = "01"
-  }
-
-  resource_group_name = azurerm_resource_group.example.name
-
-  subnet_pep_id = data.azurerm_subnet.pep.id
-
-  tier = "l"
-
-  tags = local.tags
-}
-```
-
-- A [complete example](https://github.com/pagopa-dx/terraform-azurerm-azure-services-bus-namespace/tree/main/examples/complete) demonstrates all features.
+A [complete example](https://github.com/pagopa-dx/terraform-azurerm-azure-services-bus-namespace/tree/main/examples/complete) demonstrates all features.
 
 <!-- markdownlint-disable -->
 <!-- BEGIN_TF_DOCS -->
@@ -77,13 +52,13 @@ No modules.
 
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
-| <a name="input_allowed_ips"></a> [allowed\_ips](#input\_allowed\_ips) | A list of IP addresses or CIDR blocks to allow access to the Service Bus Namespace. Mandatory if "tier" is "m", while not used for "l". | `list(string)` | `null` | no |
+| <a name="input_allowed_ips"></a> [allowed\_ips](#input\_allowed\_ips) | A list of IP addresses or CIDR blocks to allow access to the Service Bus Namespace. Use only if "use\_case" is not "default". | `list(string)` | `null` | no |
 | <a name="input_environment"></a> [environment](#input\_environment) | Values which are used to generate resource names and location short names. They are all mandatory except for domain, which should not be used only in the case of a resource used by multiple domains. | <pre>object({<br/>    prefix          = string<br/>    env_short       = string<br/>    location        = string<br/>    domain          = optional(string)<br/>    app_name        = string<br/>    instance_number = string<br/>  })</pre> | n/a | yes |
 | <a name="input_private_dns_zone_resource_group_name"></a> [private\_dns\_zone\_resource\_group\_name](#input\_private\_dns\_zone\_resource\_group\_name) | The name of the resource group containing the private DNS zone for private endpoints. | `string` | `null` | no |
 | <a name="input_resource_group_name"></a> [resource\_group\_name](#input\_resource\_group\_name) | The name of the resource group where resources will be deployed. | `string` | n/a | yes |
-| <a name="input_subnet_pep_id"></a> [subnet\_pep\_id](#input\_subnet\_pep\_id) | The ID of the subnet designated for private endpoints. Mandatory if "tier" is "m". | `string` | `null` | no |
+| <a name="input_subnet_pep_id"></a> [subnet\_pep\_id](#input\_subnet\_pep\_id) | The ID of the subnet designated for private endpoints. Use only if private endpoints are enabled. | `string` | `null` | no |
 | <a name="input_tags"></a> [tags](#input\_tags) | A map of tags to assign to the resources. | `map(any)` | n/a | yes |
-| <a name="input_tier"></a> [tier](#input\_tier) | Resource tiers depending on demanding workload and security considerations. Allowed values are 'm', 'l'. | `string` | `"l"` | no |
+| <a name="input_use_case"></a> [use\_case](#input\_use\_case) | Specifies the use case for the Service Bus. Allowed value is 'default'. | `string` | `"default"` | no |
 
 ## Outputs
 

--- a/infra/modules/azure_service_bus_namespace/autoscaler.tf
+++ b/infra/modules/azure_service_bus_namespace/autoscaler.tf
@@ -1,5 +1,5 @@
 resource "azurerm_monitor_autoscale_setting" "this" {
-  count = local.sku_name == "Premium" ? 1 : 0
+  count = local.use_case_features.autoscale ? 1 : 0
 
   name                = local.autoscaler_name
   resource_group_name = var.resource_group_name

--- a/infra/modules/azure_service_bus_namespace/data.tf
+++ b/infra/modules/azure_service_bus_namespace/data.tf
@@ -1,5 +1,5 @@
 data "azurerm_private_dns_zone" "this" {
-  count = local.sku_name == "Premium" ? 1 : 0
+  count = local.use_case_features.private_enpoint ? 1 : 0
 
   name                = "privatelink.servicebus.windows.net"
   resource_group_name = local.private_dns_zone_resource_group_name

--- a/infra/modules/azure_service_bus_namespace/examples/complete/main.tf
+++ b/infra/modules/azure_service_bus_namespace/examples/complete/main.tf
@@ -39,7 +39,7 @@ module "service_bus_01" {
   subnet_pep_id                        = data.azurerm_subnet.pep.id
   private_dns_zone_resource_group_name = local.virtual_network.resource_group_name
 
-  tier = "l"
+  use_case = "default"
 
   tags = local.tags
 }

--- a/infra/modules/azure_service_bus_namespace/locals.tf
+++ b/infra/modules/azure_service_bus_namespace/locals.tf
@@ -10,19 +10,18 @@ locals {
 
   name            = provider::dx::resource_name(merge(local.naming_config, { resource_type = "servicebus_namespace" }))
   autoscaler_name = replace(local.name, "sbns", "sbns-as")
+  use_cases = {
+    default = {
+      sku_name        = "Premium"
+      capacity        = 1
+      partitions      = 1
+      default_action  = "Allow" # Using "Deny" for Premium SKU breaks the provider validation
+      private_enpoint = true
+      autoscale       = true
+    }
+  }
 
-  sku_name = lookup(
-    {
-      "m" = "Standard",
-      "l" = "Premium"
-    },
-    var.tier,
-    "Premium"
-  )
-
-  capacity       = local.sku_name == "Premium" ? 1 : 0
-  partitions     = local.sku_name == "Premium" ? 1 : 0
-  default_action = local.sku_name == "Premium" ? "Allow" : "Deny" # Using "Deny" for Premium SKU breaks the provider validation
+  use_case_features = local.use_cases[var.use_case]
 
   private_dns_zone_resource_group_name = var.private_dns_zone_resource_group_name == null ? var.resource_group_name : var.private_dns_zone_resource_group_name
 

--- a/infra/modules/azure_service_bus_namespace/network.tf
+++ b/infra/modules/azure_service_bus_namespace/network.tf
@@ -1,5 +1,5 @@
 resource "azurerm_private_endpoint" "service_bus_pep" {
-  count = local.sku_name == "Premium" ? 1 : 0
+  count = local.use_case_features.private_enpoint ? 1 : 0
 
   name                = provider::dx::resource_name(merge(local.naming_config, { resource_type = "servicebus_private_endpoint" }))
   location            = var.environment.location

--- a/infra/modules/azure_service_bus_namespace/service_bus.tf
+++ b/infra/modules/azure_service_bus_namespace/service_bus.tf
@@ -2,17 +2,17 @@ resource "azurerm_servicebus_namespace" "this" {
   name                = local.name
   location            = var.environment.location
   resource_group_name = var.resource_group_name
-  sku                 = local.sku_name
+  sku                 = local.use_case_features.sku_name
 
   local_auth_enabled           = false
-  capacity                     = local.capacity
-  premium_messaging_partitions = local.partitions
+  capacity                     = local.use_case_features.capacity
+  premium_messaging_partitions = local.use_case_features.partitions
 
   public_network_access_enabled = false
 
   network_rule_set {
     public_network_access_enabled = false
-    default_action                = local.default_action
+    default_action                = local.use_case_features.default_action
     trusted_services_allowed      = true
     ip_rules                      = var.allowed_ips
   }

--- a/infra/modules/azure_service_bus_namespace/tests/sbns.tftest.hcl
+++ b/infra/modules/azure_service_bus_namespace/tests/sbns.tftest.hcl
@@ -65,7 +65,7 @@ run "sbns_is_correct_plan" {
   }
 }
 
-run "sbns_premium_is_correct_plan" {
+run "sbns_default_is_correct_plan" {
   command = plan
 
   variables {
@@ -115,12 +115,12 @@ run "sbns_premium_is_correct_plan" {
   }
 
   assert {
-    condition = azurerm_monitor_autoscale_setting.this[0] != null
+    condition     = azurerm_monitor_autoscale_setting.this[0] != null
     error_message = "Autoscaler should be created"
   }
 }
 
-run "sbns_standard_is_correct_plan" {
+run "sbns_default_fail_plan" {
   command = plan
 
   variables {
@@ -128,45 +128,14 @@ run "sbns_standard_is_correct_plan" {
 
     resource_group_name = run.setup_tests.resource_group_name
 
-    allowed_ips = ["127.0.0.1"]
-
-    tier = "m"
+    allowed_ips = ["0.0.0.0/0"]
 
     tags = run.setup_tests.tags
   }
 
-  assert {
-    condition     = azurerm_servicebus_namespace.this.sku == "Standard"
-    error_message = "Tier \"l\" should be the default one and set to \"Standard\""
-  }
-
-  assert {
-    condition     = azurerm_servicebus_namespace.this.capacity == 0
-    error_message = "Service Bus Namespace capacity should be 0"
-  }
-
-  assert {
-    condition     = azurerm_servicebus_namespace.this.premium_messaging_partitions == 0
-    error_message = "Service Bus Namespace partitions should be 0"
-  }
-
-  assert {
-    condition     = azurerm_servicebus_namespace.this.network_rule_set[0].public_network_access_enabled == false
-    error_message = "Service Bus Namespace public network access should be disabled"
-  }
-
-  assert {
-    condition     = azurerm_servicebus_namespace.this.network_rule_set[0].default_action == "Deny"
-    error_message = "Service Bus Namespace default action should be \"Deny\" for \"m\" tier"
-  }
-
-  assert {
-    condition     = azurerm_servicebus_namespace.this.network_rule_set[0].trusted_services_allowed == true
-    error_message = "Service Bus Namespace trusted services should be allowed"
-  }
-
-  assert {
-    condition     = length(azurerm_servicebus_namespace.this.network_rule_set[0].ip_rules) == 1
-    error_message = "Service Bus Namespace IP rules should be filled"
-  }
+  expect_failures = [
+    var.subnet_pep_id,
+    var.private_dns_zone_resource_group_name,
+    var.allowed_ips,
+  ]
 }

--- a/infra/modules/azure_service_bus_namespace/variables.tf
+++ b/infra/modules/azure_service_bus_namespace/variables.tf
@@ -32,40 +32,40 @@ variable "private_dns_zone_resource_group_name" {
   default     = null
 
   validation {
-    condition     = var.tier == "l" || (var.tier == "m" && var.private_dns_zone_resource_group_name == null)
-    error_message = "The \"private_dns_zone_resource_group_name\" variable can be used if \"tier\" is \"l\" and should not be used otherwise."
+    condition     = local.use_case_features.private_enpoint && var.private_dns_zone_resource_group_name != null
+    error_message = "The \"private_dns_zone_resource_group_name\" variable can be used if \"use_case\" need it."
   }
 }
 
 variable "subnet_pep_id" {
   type        = string
-  description = "The ID of the subnet designated for private endpoints. Mandatory if \"tier\" is \"m\"."
+  description = "The ID of the subnet designated for private endpoints. Use only if private endpoints are enabled."
   default     = null
 
   validation {
-    condition     = (var.tier == "l" && var.subnet_pep_id != null) || (var.tier == "m" && var.subnet_pep_id == null)
-    error_message = "The \"subnet_pep_id\" variable is mandatory if \"tier\" is \"l\" and should not be used otherwise."
+    condition     = local.use_case_features.private_enpoint && var.subnet_pep_id != null
+    error_message = "The \"subnet_pep_id\" variable is mandatory if \"sku\" is \"Premium\" (or when private endpoints are enabled) and should not be used otherwise."
   }
 }
 
 variable "allowed_ips" {
   type        = list(string)
-  description = "A list of IP addresses or CIDR blocks to allow access to the Service Bus Namespace. Mandatory if \"tier\" is \"m\", while not used for \"l\"."
+  description = "A list of IP addresses or CIDR blocks to allow access to the Service Bus Namespace. Use only if \"use_case\" is not \"default\"."
   default     = null
 
   validation {
-    condition     = (var.tier == "m" && try(length(var.allowed_ips) > 0, false)) || (var.tier == "l" && var.allowed_ips == null)
-    error_message = "The \"allowed_ips\" variable is mandatory if \"tier\" is \"m\" and should not be used otherwise."
+    condition     = (var.use_case != "default" && try(length(var.allowed_ips) > 0, false)) || (var.use_case == "default" && var.allowed_ips == null)
+    error_message = "The \"allowed_ips\" variable is mandatory if \"use_case\" is not \"default\" and should not be used otherwise."
   }
 }
 
-variable "tier" {
+variable "use_case" {
   type        = string
-  description = "Resource tiers depending on demanding workload and security considerations. Allowed values are 'm', 'l'."
-  default     = "l"
+  description = "Specifies the use case for the Service Bus. Allowed value is 'default'."
+  default     = "default"
 
   validation {
-    condition     = contains(["m", "l"], var.tier)
-    error_message = "Allowed values for \"tier\" are \"m\", or \"l\"."
+    condition     = contains(["default"], var.use_case)
+    error_message = "Allowed value for \"use_case\" is \"default\"."
   }
 }


### PR DESCRIPTION
Replace the `tier` variable with a new `use_case` variable for tiering configuration. New value are:

- default

Update some variable validation method:

- `allowed_ips`: Now it can be defined only if `use_case` is `default`
- `subnet_pep_id`: Now it can be defined only when private_enpoint will be created (in this case only when `use_case` is `default`)
- `private_dns_zone_resource_group_name`: As subnet pep id now it can be defined only when `private_enpoint` will be created

Previously, validation for some of this variables was strictly tied to specific `tier`.
This change decouples the validation from the `use_case` definitions, making it easier to add new profiles in the future without having to update multiple validation blocks.

Resolves: CES-1211