### PR TITLE
Update pnpm

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pagopa/dx",
-  "packageManager": "pnpm@10.14.0+sha512.ad27a79641b49c3e481a16a805baa71817a04bbe06a38d17e60e2eaee83f6a146c6a688125f5792e48dd5ba30e7da52a5cda4c3992b9ccf333f9ce223af84748",
+  "packageManager": "pnpm@10.15.0+sha512.486ebc259d3e999a4e8691ce03b5cac4a71cbeca39372a9b762cb500cfdf0873e2cb16abe3d951b1ee2cf012503f027b98b6584e4df22524e0c7450d9ec7aa7b",
   "devDependencies": {
     "@changesets/cli": "^2.29.5",
     "@devcontainers/cli": "^0.79.0",

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -14,6 +14,8 @@ catalog:
   tsup: ^8.5.0
   typescript: ~5.8.3
 
+cleanupUnusedCatalogs: true
+
 onlyBuiltDependencies:
   - esbuild
 


### PR DESCRIPTION
Update `pnpm` to `10.15.0` and add the new `cleanupUnusedCatalogs` option that will remove unused catalog entries during installation.

This will keep the catalog clean.