### PR TITLE
Ignore customer_managed_key value asking for changes although managed with external resource

### DIFF
--- a/.changeset/hip-emus-serve.md
+++ b/.changeset/hip-emus-serve.md
@@ -1,0 +1,5 @@
+---
+"azure_storage_account": patch
+---
+
+Ignore customer_managed_key value as per [documentation](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/storage_account) to avoid removing CMK already instantiated created via the azurerm_storage_account_customer_managed_key resource

--- a/infra/modules/azure_storage_account/storage_account.tf
+++ b/infra/modules/azure_storage_account/storage_account.tf
@@ -65,6 +65,12 @@ resource "azurerm_storage_account" "this" {
   }
 
   tags = local.tags
+
+  lifecycle {
+    ignore_changes = [
+      customer_managed_key
+    ]
+  }
 }
 
 resource "azurerm_security_center_storage_defender" "this" {


### PR DESCRIPTION
Ignore customer_managed_key value as per [documentation](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/storage_account) to avoid removing CMK already instantiated created via the azurerm_storage_account_customer_managed_key resource

Resolves CES-1226