### PR TITLE
Fix trivy failing for missing cache folder

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -52,3 +52,4 @@ repos:
         args:
           - --args=--skip-dirs="**/.terraform"
           - --args=--ignorefile=__GIT_WORKING_DIR__/.trivyignore
+          - --args=--cache-dir=__GIT_WORKING_DIR__/terraform/.trivy-cache

--- a/infra/core/dev/main.tf
+++ b/infra/core/dev/main.tf
@@ -10,7 +10,6 @@ module "azure" {
 
   virtual_network_cidr = "10.51.0.0/16"
 
-
   tags = local.tags
 }
 

--- a/infra/core/dev/main.tf
+++ b/infra/core/dev/main.tf
@@ -10,6 +10,7 @@ module "azure" {
 
   virtual_network_cidr = "10.51.0.0/16"
 
+
   tags = local.tags
 }
 

--- a/infra/core/dev/tfmodules.lock.json
+++ b/infra/core/dev/tfmodules.lock.json
@@ -1,9 +1,9 @@
 {
   "aws": {
-    "hash": "f2b75a44bc0296b0fb098bc473097e22a33b49c75386a2785b94c29f5f1df9f6",
-    "version": "0.0.2",
+    "hash": "2a4539053ea0ec4ff368961d0899f653214e80fe9132e043bb6e4949e2fd37a2",
+    "version": "0.0.3",
     "name": "aws_core_infra",
-    "source": "https://registry.terraform.io/modules/pagopa-dx/aws-core-infra/aws/0.0.2"
+    "source": "https://registry.terraform.io/modules/pagopa-dx/aws-core-infra/aws/0.0.3"
   },
   "azure": {
     "hash": "09954755eac0f0b64c1c7ecd6e594642b1884de91a8de8d177889438424ffd77",


### PR DESCRIPTION
Trivy fails occasionally on first run in CI due to a missing cache folder. We now set the cache directory to a known path.

Resolves CES-1249