### PR TITLE
Scaffold turbo configuration

### DIFF
--- a/.changeset/yellow-queens-fly.md
+++ b/.changeset/yellow-queens-fly.md
@@ -1,0 +1,5 @@
+---
+"@pagopa/monorepo-generator": minor
+---
+
+Create a template for `turbo` configuration file and instruct the generator to generate it

--- a/packages/monorepo-generator/src/index.ts
+++ b/packages/monorepo-generator/src/index.ts
@@ -32,6 +32,11 @@ const getDotFiles = (templatesPath: string): ActionType[] => [
 
 const getMonorepoFiles = (templatesPath: string): ActionType[] => [
   {
+    path: "{{repoSrc}}/{{repoName}}/turbo.json",
+    templateFile: path.join(templatesPath, "turbo.json"),
+    type: "add",
+  },
+  {
     path: "{{repoSrc}}/{{repoName}}/package.json",
     templateFile: path.join(templatesPath, "package.json.hbs"),
     type: "add",

--- a/packages/monorepo-generator/templates/monorepo/turbo.json
+++ b/packages/monorepo-generator/templates/monorepo/turbo.json
@@ -14,11 +14,11 @@
     },
     "format:check": {},
     "test": {
-      "dependsOn": ["^test"],
+      "dependsOn": ["^build"],
       "inputs": [],
       "outputLogs": "errors-only"
     },
-    "//#test:coverage": {
+    "test:coverage": {
       "dependsOn": ["^build"],
       "inputs": [],
       "outputs": ["coverage"],

--- a/packages/monorepo-generator/templates/monorepo/turbo.json
+++ b/packages/monorepo-generator/templates/monorepo/turbo.json
@@ -1,0 +1,28 @@
+{
+  "$schema": "https://turbo.build/schema.json",
+  "tasks": {
+    "build": {
+      "dependsOn": ["^build"],
+      "inputs": [],
+      "outputs": []
+    },
+    "typecheck": {
+      "inputs": []
+    },
+    "lint:check": {
+      "inputs": []
+    },
+    "format:check": {},
+    "test": {
+      "dependsOn": ["^test"],
+      "inputs": [],
+      "outputLogs": "errors-only"
+    },
+    "//#test:coverage": {
+      "dependsOn": ["^build"],
+      "inputs": [],
+      "outputs": ["coverage"],
+      "outputLogs": "errors-only"
+    }
+  }
+}


### PR DESCRIPTION
This pull request adds support for generating a `turbo.json` configuration file when scaffolding a new monorepo. This change ensures that new monorepos are set up with sensible defaults for task orchestration using Turborepo.

Closes CES-1257 CES-1265