### PR TITLE
Scaffold default prod environment

### DIFF
--- a/packages/monorepo-generator/src/index.ts
+++ b/packages/monorepo-generator/src/index.ts
@@ -44,7 +44,7 @@ const getMonorepoFiles = (templatesPath: string): ActionType[] => [
   },
 ];
 
-const getTerraformRepositoryFile = (templatesPath: string): ActionType[] => [
+const getTerraformRepositoryFiles = (templatesPath: string): ActionType[] => [
   {
     abortOnFail: true,
     base: `${templatesPath}/infra/repository`,
@@ -54,12 +54,35 @@ const getTerraformRepositoryFile = (templatesPath: string): ActionType[] => [
   },
 ];
 
+const getTerraformDefaultEnvironmentFiles = (
+  templatesPath: string,
+): ActionType[] => [
+  {
+    abortOnFail: true,
+    base: `${templatesPath}/infra/resources/prod`,
+    destination: "{{repoSrc}}/{{repoName}}/infra/resources/prod",
+    templateFiles: path.join(
+      templatesPath,
+      "infra",
+      "resources",
+      "prod",
+      "*.tf.hbs",
+    ),
+    type: "addMany",
+  },
+];
+
+const getInfraFiles = (templatesPath: string): ActionType[] => [
+  ...getTerraformRepositoryFiles(templatesPath),
+  ...getTerraformDefaultEnvironmentFiles(templatesPath),
+];
+
 const getActions = (templatesPath: string): ActionType[] => [
   getGitHubTerraformProviderLatestRelease,
   getDxGitHubBootstrapLatestTag,
   ...getDotFiles(templatesPath),
   ...getMonorepoFiles(templatesPath),
-  ...getTerraformRepositoryFile(templatesPath),
+  ...getInfraFiles(templatesPath),
 ];
 
 const scaffoldMonorepo = (plopApi: NodePlopAPI) => {

--- a/packages/monorepo-generator/templates/monorepo/infra/resources/prod/providers.tf.hbs
+++ b/packages/monorepo-generator/templates/monorepo/infra/resources/prod/providers.tf.hbs
@@ -1,0 +1,4 @@
+terraform {
+  required_providers {}
+  // TODO: Add the backend configuration
+}


### PR DESCRIPTION
This pull request enhances the infrastructure scaffolding process in the monorepo generator by improving how Terraform files are organized and generated. The changes introduce a clearer separation of repository-level and environment-specific Terraform files, and add a new default provider configuration template for production environments.

Closes CES-1260