### PR TITLE
Add pre-commit-config to monorepo template

### DIFF
--- a/.changeset/swift-beers-appear.md
+++ b/.changeset/swift-beers-appear.md
@@ -1,0 +1,7 @@
+---
+"@pagopa/monorepo-generator": minor
+---
+
+Add the `.pre-commit-config.yaml` to the template
+
+The generator already scaffold the dotfiles (`.`), so when executing the generator, you will have the `.pre-commit-config.yaml` file created in your project.

--- a/packages/monorepo-generator/templates/monorepo/.pre-commit-config.yaml
+++ b/packages/monorepo-generator/templates/monorepo/.pre-commit-config.yaml
@@ -1,13 +1,13 @@
 repos:
   - repo: https://github.com/pagopa/dx
-    rev: pre_commit_scripts@0.1.0 # TODO: use a variable here
+    rev: pre_commit_scripts@0.1.0 # TODO: use a variable here: https://pagopa.atlassian.net/browse/CES-1276
     hooks:
       - id: terraform_providers_lock_staged
       - id: lock_modules
         exclude: ^.*/(_modules|modules|\.terraform)(/.*)?$
         files: infra/(resources/prod|repository)
   - repo: https://github.com/antonbabenko/pre-commit-terraform
-    rev: v1.100.0 # TODO: use a variable here
+    rev: v1.100.0 # TODO: use a variable here: https://pagopa.atlassian.net/browse/CES-1276
     hooks:
       - id: terraform_tflint
         args:
@@ -32,3 +32,4 @@ repos:
         args:
           - --args=--skip-dirs="**/.terraform"
           - --args=--ignorefile=__GIT_WORKING_DIR__/.trivyignore
+# TODO: add pnpm code-review when available https://pagopa.atlassian.net/browse/CES-1277

--- a/packages/monorepo-generator/templates/monorepo/.pre-commit-config.yaml
+++ b/packages/monorepo-generator/templates/monorepo/.pre-commit-config.yaml
@@ -1,0 +1,34 @@
+repos:
+  - repo: https://github.com/pagopa/dx
+    rev: pre_commit_scripts@0.1.0 # TODO: use a variable here
+    hooks:
+      - id: terraform_providers_lock_staged
+      - id: lock_modules
+        exclude: ^.*/(_modules|modules|\.terraform)(/.*)?$
+        files: infra/(resources/prod|repository)
+  - repo: https://github.com/antonbabenko/pre-commit-terraform
+    rev: v1.100.0 # TODO: use a variable here
+    hooks:
+      - id: terraform_tflint
+        args:
+          - --args=--config=__GIT_WORKING_DIR__/.tflint.hcl
+      - id: terraform_fmt
+      - id: terraform_docs
+        name: terraform_docs on resources
+        args:
+          - --hook-config=--create-file-if-not-exist=true
+        exclude: |
+          (?x)^(
+            src\/(?:.*\/)?(?:_?modules)\/.*
+          )$
+      - id: terraform_validate
+        exclude: '(\/_?modules\/.*)'
+        args:
+          - --args=-json
+          - --args=-no-color
+          - --hook-config=--retry-once-with-cleanup=true
+      - id: terraform_trivy
+        files: ^src/
+        args:
+          - --args=--skip-dirs="**/.terraform"
+          - --args=--ignorefile=__GIT_WORKING_DIR__/.trivyignore


### PR DESCRIPTION
This pull request introduces a new `.pre-commit-config.yaml` file to the monorepo generator template, enabling projects scaffolded with the generator to have pre-commit hooks set up by default. This helps standardize and automate code quality checks, especially for Terraform code, across generated projects.

Closes CES-1256