### PR TITLE
Add CSP selection prompt

### DIFF
--- a/packages/monorepo-generator/src/index.ts
+++ b/packages/monorepo-generator/src/index.ts
@@ -17,6 +17,16 @@ const getPrompts = (): PlopGeneratorConfig["prompts"] => [
     message: "What is the repository description?",
     name: "repoDescription",
   },
+  {
+    choices: [
+      { name: "AWS", value: "aws" },
+      { name: "Azure", value: "azure" },
+    ],
+    default: "azure",
+    message: "What Cloud Provider would you like to use?",
+    name: "csp",
+    type: "list",
+  },
 ];
 
 const getDotFiles = (templatesPath: string): ActionType[] => [

--- a/packages/monorepo-generator/src/index.ts
+++ b/packages/monorepo-generator/src/index.ts
@@ -19,8 +19,8 @@ const getPrompts = (): PlopGeneratorConfig["prompts"] => [
   },
   {
     choices: [
-      { name: "AWS", value: "aws" },
-      { name: "Azure", value: "azure" },
+      { name: "Amazon Web Services", value: "aws" },
+      { name: "Microsoft Azure", value: "azure" },
     ],
     default: "azure",
     message: "What Cloud Provider would you like to use?",


### PR DESCRIPTION
This pull request introduces a new prompt to the monorepo generator, allowing users to select a cloud provider when setting up a repository. This enhances the generator's flexibility by supporting both AWS and Azure options.

New feature:

* Added a cloud provider selection prompt (`csp`) to `getPrompts`, with choices for AWS and Azure, defaulting to Azure.

Closes CES-1280