### PR TITLE
Add role assign for Static Web Apps secrets to App CI/CD identity

### DIFF
--- a/.changeset/nice-horses-end.md
+++ b/.changeset/nice-horses-end.md
@@ -2,4 +2,4 @@
 "azure_github_environment_bootstrap": patch
 ---
 
-Add Static Web App list secrets role assingment to App CI managed identity
+Add Static Web App list secrets role assingment to App CI and CD managed identities

--- a/infra/modules/azure_github_environment_bootstrap/README.md
+++ b/infra/modules/azure_github_environment_bootstrap/README.md
@@ -135,6 +135,7 @@ This module includes practical examples to help you get started quickly:
 | [azurerm_role_assignment.app_cd_rgs_blob_contributor](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/role_assignment) | resource |
 | [azurerm_role_assignment.app_cd_rgs_cae_contributor](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/role_assignment) | resource |
 | [azurerm_role_assignment.app_cd_rgs_cdn_profile_contributor](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/role_assignment) | resource |
+| [azurerm_role_assignment.app_cd_rgs_static_webapp_secrets](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/role_assignment) | resource |
 | [azurerm_role_assignment.app_cd_rgs_website_contributor](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/role_assignment) | resource |
 | [azurerm_role_assignment.app_cd_subscription_reader](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/role_assignment) | resource |
 | [azurerm_role_assignment.app_cd_tf_rg_blob_contributor](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/role_assignment) | resource |

--- a/infra/modules/azure_github_environment_bootstrap/id_app_cd_iam.tf
+++ b/infra/modules/azure_github_environment_bootstrap/id_app_cd_iam.tf
@@ -49,3 +49,12 @@ resource "azurerm_role_assignment" "app_cd_tf_rg_blob_contributor" {
   principal_id         = azurerm_user_assigned_identity.app_cd.principal_id
   description          = "Allow ${var.repository.name} App CD identity to apply changes to the Terraform state file Storage Account scope"
 }
+
+resource "azurerm_role_assignment" "app_cd_rgs_static_webapp_secrets" {
+  for_each = local.resource_group_ids
+
+  scope                = each.value
+  role_definition_name = "PagoPA Static Web Apps List Secrets"
+  principal_id         = azurerm_user_assigned_identity.app_cd.principal_id
+  description          = "Allow ${var.repository.name} App CD identity to to read Static Web Apps secrets at ${each.value} resource group scope"
+}

--- a/infra/modules/azure_github_environment_bootstrap/id_app_ci_iam.tf
+++ b/infra/modules/azure_github_environment_bootstrap/id_app_ci_iam.tf
@@ -21,6 +21,6 @@ resource "azurerm_role_assignment" "app_ci_rgs_static_webapp_secrets" {
 
   scope                = each.value
   role_definition_name = "PagoPA Static Web Apps List Secrets"
-  principal_id         = azurerm_user_assigned_identity.app_cd.principal_id
+  principal_id         = azurerm_user_assigned_identity.app_ci.principal_id
   description          = "Allow ${var.repository.name} App CI identity to to read Static Web Apps secrets at ${each.value} resource group scope"
 }


### PR DESCRIPTION
To improve RBAC this PR add a new Role Assignment for App CI/CD managed identities in bootstrap module, the role is the custom one **PagoPA Static Web Apps List Secrets**, used instead of **Contributor**.

Resolves: CES-1270
relates-to: CES-1271