### PR TITLE
Remove `no-console` rule

### DIFF
--- a/.changeset/dark-parents-change.md
+++ b/.changeset/dark-parents-change.md
@@ -1,0 +1,5 @@
+---
+"@pagopa/eslint-config": minor
+---
+
+Removed no-console rule

--- a/packages/eslint-config/index.js
+++ b/packages/eslint-config/index.js
@@ -33,7 +33,6 @@ export default [
       "guard-for-in": "error",
       "max-lines-per-function": ["error", 200],
       "no-bitwise": "error",
-      "no-console": "error",
       "no-eval": "error",
       "no-new-wrappers": "error",
       "no-param-reassign": "error",


### PR DESCRIPTION
As it is stated in the [official documentation](https://eslint.org/docs/latest/rules/no-console), `no-console` is a rule that is meant for code that targets to `browsers`.

Our `@pagopa/eslint-config` package is a generic, base package for js projects so it should contain only the common rules shared by all environments.