### PR TITLE
Load dynamically latest node-version

### DIFF
--- a/packages/monorepo-generator/README.md
+++ b/packages/monorepo-generator/README.md
@@ -28,6 +28,7 @@ The generator exposes the following variables to Handlebars templates. Use the H
 | `githubTfProviderVersion`             | custom action (GitHub fetch) | Version used inside Terraform infra templates for the GitHub provider/module. Formatted as `major.minor` (e.g. `4.13`). The value is derived from the latest provider release.                |
 | `dxGithubEnvironmentBootstrapVersion` | custom action (GitHub fetch) | Version/tag used by infra templates to bootstrap GitHub environment resources. Formatted as `major.minor` (e.g. `0.2`). The value is derived from the latest tag of the bootstrap repository. |
 | `preCommitTerraformVersion`           | custom action (GitHub fetch) | Version used for the `pre-commit-terraform` hooks in the generated `.pre-commit-config.yaml`. Full semver string (e.g. `1.81.0`). The generated file prefixes it with a `v` (`rev: v{{ preCommitTerraformVersion }}`). |
+| `nodeVersion`                         | custom action (GitHub fetch) | Latest Node.js version used to populate `.node-version`. Full semver string, e.g. `20.10.0`.                                                                                                   |
 
 ## Recommended usage
 

--- a/packages/monorepo-generator/src/actions/node.ts
+++ b/packages/monorepo-generator/src/actions/node.ts
@@ -1,0 +1,23 @@
+import type { ActionType } from "plop";
+
+import { Octokit } from "octokit";
+
+import { fetchLatestRelease } from "../adapters/octokit/index.js";
+import { fetchLatestSemver } from "./semver.js";
+
+interface NodeActionsDependencies {
+  octokitClient: Octokit;
+}
+
+export const getLatestNodeVersion =
+  ({ octokitClient }: NodeActionsDependencies): ActionType =>
+  async (answers) => {
+    const owner = "nodejs";
+    const repo = "node";
+
+    return fetchLatestSemver(
+      () => fetchLatestRelease({ client: octokitClient, owner, repo }),
+      answers,
+      "nodeVersion",
+    );
+  };

--- a/packages/monorepo-generator/src/actions/semver.ts
+++ b/packages/monorepo-generator/src/actions/semver.ts
@@ -1,0 +1,37 @@
+import { errAsync, okAsync, ResultAsync } from "neverthrow";
+import { SemVer } from "semver";
+
+/**
+ * Fetches the latest semantic version using the provided fetch function and writes
+ * a formatted version string into the given `answers` object under `answerKey`.
+ *
+ * @param fetchSemverFn - A zero-arg function that returns a `ResultAsync` resolving
+ *   to a `SemVer` (or `null`) or rejecting with an `Error`. Typically wraps an
+ *   Octokit call to fetch a release or tag and parse its semver.
+ * @param answers - Mutable answers object (plop prompts) where the resulting
+ *   formatted version will be stored.
+ * @param answerKey - Key name to assign the formatted version into `answers`.
+ * @param semverFormatFn - Optional formatter that converts the `SemVer` into
+ *   the desired string representation (defaults to `semver.toString()`).
+ * @returns A human-readable message indicating the fetched version. Throws an
+ *   `Error` if the fetch fails or yields an invalid version.
+ */
+export const fetchLatestSemver = async (
+  fetchSemverFn: () => ResultAsync<null | SemVer, Error>,
+  answers: Record<string, unknown>,
+  answerKey: string,
+  semverFormatFn: (semver: SemVer) => string = (semver) => semver.toString(),
+) => {
+  const version = await fetchSemverFn()
+    .andThen((semver) =>
+      semver ? okAsync(semver) : errAsync(new Error("Invalid version found")),
+    )
+    .map(semverFormatFn);
+
+  if (version.isErr()) {
+    console.warn(`Could not fetch latest version`);
+    throw new Error("Could not fetch latest version", { cause: version.error });
+  }
+  answers[answerKey] = version.value;
+  return `Fetched latest version: ${answers[answerKey]}`;
+};

--- a/packages/monorepo-generator/src/actions/terraform.ts
+++ b/packages/monorepo-generator/src/actions/terraform.ts
@@ -1,53 +1,16 @@
 import type { ActionType } from "plop";
 
-import { errAsync, okAsync, ResultAsync } from "neverthrow";
 import { Octokit } from "octokit";
-import { SemVer } from "semver";
 
 import {
   fetchLatestRelease,
   fetchLatestTag,
 } from "../adapters/octokit/index.js";
+import { fetchLatestSemver } from "./semver.js";
 
 interface TerraformActionsDependencies {
   octokitClient: Octokit;
 }
-
-/**
- * Fetches the latest semantic version using the provided fetch function and writes
- * a formatted version string into the given `answers` object under `answerKey`.
- *
- * @param fetchSemverFn - A zero-arg function that returns a `ResultAsync` resolving
- *   to a `SemVer` (or `null`) or rejecting with an `Error`. Typically wraps an
- *   Octokit call to fetch a release or tag and parse its semver.
- * @param answers - Mutable answers object (plop prompts) where the resulting
- *   formatted version will be stored.
- * @param answerKey - Key name to assign the formatted version into `answers`.
- * @param semverFormatFn - Optional formatter that converts the `SemVer` into
- *   the desired string representation (defaults to `semver.toString()`).
- * @returns A human-readable message indicating the fetched version. Throws an
- *   `Error` if the fetch fails or yields an invalid version.
- */
-const fetchLatestSemver = async (
-  fetchSemverFn: () => ResultAsync<null | SemVer, Error>,
-  answers: Record<string, unknown>,
-  answerKey: string,
-  semverFormatFn: (semver: SemVer) => string = (semver) => semver.toString(),
-) => {
-  const version = await fetchSemverFn()
-    .andThen((semver) =>
-      semver ? okAsync(semver) : errAsync(new Error("Invalid version found")),
-    )
-    .map(semverFormatFn);
-
-  if (version.isErr()) {
-    // eslint-disable-next-line no-console
-    console.warn(`Could not fetch latest version`);
-    throw new Error("Could not fetch latest version", { cause: version.error });
-  }
-  answers[answerKey] = version.value;
-  return `Fetched latest version: ${answers[answerKey]}`;
-};
 
 export const getGitHubTerraformProviderLatestRelease =
   ({ octokitClient }: TerraformActionsDependencies): ActionType =>

--- a/packages/monorepo-generator/src/index.ts
+++ b/packages/monorepo-generator/src/index.ts
@@ -24,6 +24,7 @@ import {
   enablePnpm,
   installRootDependencies,
 } from "./actions/pnpm.js";
+import { getLatestNodeVersion } from "./actions/node.js";
 
 const getPrompts = (): PlopGeneratorConfig["prompts"] => [
   {
@@ -124,6 +125,7 @@ const getActions = ({
   getDxGitHubBootstrapLatestTag({ octokitClient }),
   getTerraformLatestRelease({ octokitClient }),
   getPreCommitTerraformLatestRelease({ octokitClient }),
+  getLatestNodeVersion({ octokitClient }),
   ...getDotFiles(templatesPath),
   ...getMonorepoFiles(templatesPath),
   ...getTerraformRepositoryFile(templatesPath),

--- a/packages/monorepo-generator/templates/monorepo/.node-version.hbs
+++ b/packages/monorepo-generator/templates/monorepo/.node-version.hbs
@@ -1,0 +1,1 @@
+{{ nodeVersion }}


### PR DESCRIPTION
This pull request adds automated support for fetching and populating the latest Node.js version in generated monorepos. The changes introduce a new action to retrieve the latest Node.js release from GitHub and update the generator's templates and documentation accordingly. Additionally, the logic for fetching and formatting semantic versions has been refactored for reuse and clarity.


Closes CES-1300