### PR TITLE
Remove eslint-disable-next-line no-console comment

### DIFF
--- a/apps/cli/src/adapters/commander/commands/init.ts
+++ b/apps/cli/src/adapters/commander/commands/init.ts
@@ -41,7 +41,6 @@ export const makeInitCommand = (): Command =>
             .andThen((plop) => getGenerator(plop)("monorepo"))
             .andThen(runGenerator)
             .andTee(() => {
-              // eslint-disable-next-line no-console
               console.log("Monorepo initialized successfully ✅");
             })
             .orTee((err) => {

--- a/apps/cli/src/index.ts
+++ b/apps/cli/src/index.ts
@@ -25,7 +25,6 @@ await configure({
   sinks: {
     console: getConsoleSink(),
     rawJson(record) {
-      // eslint-disable-next-line no-console
       console.log(record.rawMessage);
     },
   },

--- a/packages/monorepo-generator/src/actions/terraform.ts
+++ b/packages/monorepo-generator/src/actions/terraform.ts
@@ -41,7 +41,6 @@ const fetchLatestSemver = async (
     .map(semverFormatFn);
 
   if (version.isErr()) {
-    // eslint-disable-next-line no-console
     console.warn(`Could not fetch latest version`);
     throw new Error("Could not fetch latest version", { cause: version.error });
   }


### PR DESCRIPTION
This pull request makes minor improvements by removing unnecessary ESLint disable comments for console usage across several files. The changes help clean up the codebase without affecting functionality.