### PR TITLE
Attest artifact has been created by reusable workflow in release-azure-appsvc-v1

### DIFF
--- a/.github/workflows/release-azure-appsvc-v1.yaml
+++ b/.github/workflows/release-azure-appsvc-v1.yaml
@@ -57,9 +57,11 @@ jobs:
     concurrency:
       group: ${{ format('{0}-build-{1}', github.run_id, inputs.workspace_name) }}
       cancel-in-progress: false
+
     permissions:
       id-token: write
       attestations: write
+
     env:
       WORKSPACE_NAME: ${{ inputs.workspace_name }}
 


### PR DESCRIPTION
Added the generation and validation of build provenance (artifact attestation) to the Azure App Service release workflow, improving the security and traceability of released artifacts.

Resolves CES-1250