### PR TITLE
Replace KeyVault deprecated property in Azure Core Infra module

### DIFF
--- a/.changeset/mighty-cows-shine.md
+++ b/.changeset/mighty-cows-shine.md
@@ -1,0 +1,6 @@
+---
+"azure_core_infra": patch
+"docs": patch
+---
+
+Replace azurerm keyvault's deprecated property "enable_rbac_authorization" with "rbac_authorization_enabled"

--- a/apps/website/docs/azure/iam/azure-iam.md
+++ b/apps/website/docs/azure/iam/azure-iam.md
@@ -315,7 +315,7 @@ resource "azurerm_key_vault" "" {
   location            = "location"
   resource_group_name = "resource-group"
 
-  enable_rbac_authorization = true
+  rbac_authorization_enabled = true
 }
 ```
 

--- a/apps/website/docs/azure/networking/app-gateway-tls-cert.md
+++ b/apps/website/docs/azure/networking/app-gateway-tls-cert.md
@@ -25,7 +25,7 @@ with the following characteristics:
 resource "azurerm_key_vault" "this" {
   ...
 
-  enable_rbac_authorization     = true
+  rbac_authorization_enabled     = true
   enabled_for_disk_encryption   = true
   soft_delete_retention_days    = 30
   purge_protection_enabled      = true

--- a/infra/modules/azure_core_infra/README.md
+++ b/infra/modules/azure_core_infra/README.md
@@ -26,7 +26,7 @@ For detailed usage examples, refer to the [examples folder](https://github.com/p
 
 | Name | Version |
 |------|---------|
-| <a name="requirement_azurerm"></a> [azurerm](#requirement\_azurerm) | ~>4 |
+| <a name="requirement_azurerm"></a> [azurerm](#requirement\_azurerm) | ~>4.42 |
 | <a name="requirement_dx"></a> [dx](#requirement\_dx) | >= 0.0.6, < 1.0.0 |
 
 ## Modules

--- a/infra/modules/azure_core_infra/_modules/key_vault/kv.tf
+++ b/infra/modules/azure_core_infra/_modules/key_vault/kv.tf
@@ -16,7 +16,7 @@ resource "azurerm_key_vault" "common" {
   enabled_for_disk_encryption = true
   purge_protection_enabled    = local.secrets_protection_enabled
   soft_delete_retention_days  = local.secrets_protection_enabled ? 14 : 7
-  enable_rbac_authorization   = true
+  rbac_authorization_enabled  = true
 
   network_acls {
     bypass         = "AzureServices"

--- a/infra/modules/azure_core_infra/main.tf
+++ b/infra/modules/azure_core_infra/main.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     azurerm = {
       source  = "hashicorp/azurerm"
-      version = "~>4"
+      version = "~>4.42"
     }
     dx = {
       source  = "pagopa-dx/azure"

--- a/infra/modules/azure_core_infra/tests/setup/README.md
+++ b/infra/modules/azure_core_infra/tests/setup/README.md
@@ -5,7 +5,7 @@
 
 | Name | Version |
 |------|---------|
-| <a name="requirement_azurerm"></a> [azurerm](#requirement\_azurerm) | <= 4.10.0 |
+| <a name="requirement_azurerm"></a> [azurerm](#requirement\_azurerm) | ~> 4.10 |
 
 ## Modules
 

--- a/infra/modules/azure_core_infra/tests/setup/main.tf
+++ b/infra/modules/azure_core_infra/tests/setup/main.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     azurerm = {
       source  = "hashicorp/azurerm"
-      version = "<= 4.10.0"
+      version = "~> 4.10"
     }
   }
 }


### PR DESCRIPTION
Since v4.42, azurerm deprecated keyvault's property `enable_rbac_authorization` in favor of `rbac_authorization_enabled`