### PR TITLE
Keep terraform modules between plan and apply jobs in infra_apply workflows

### DIFF
--- a/.github/workflows/infra_apply.yaml
+++ b/.github/workflows/infra_apply.yaml
@@ -132,6 +132,12 @@ jobs:
       - name: Cloud Login
         uses: pagopa/dx/actions/csp-login@main
 
+      - name: Download Terraform Bundle as Artifact
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
+        with:
+          name: terraform-bundle
+          path: ${{ needs.tf_plan.outputs.working_dir }}
+
       - name: Terraform Setup
         uses: pagopa/dx/.github/actions/terraform-setup@main
         id: set-terraform-version
@@ -154,11 +160,15 @@ jobs:
             -input=false \
             | grep -v "hidden-link:"
 
-      - name: Upload Terraform Plan as Artifact
-        uses: pagopa/dx/.github/actions/upload-artifact@main
+      - name: Upload Terraform Bundle as Artifact
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
-          bundle_name: tfplan
-          file_path: ${{ steps.directory.outputs.dir }}/tfplan-${{ github.sha }}
+          name: terraform-bundle
+          path: |
+            ${{ steps.directory.outputs.dir }}/tfplan-${{ github.sha }}
+            ${{ steps.directory.outputs.dir }}/.terraform.lock.hcl
+            ${{ steps.directory.outputs.dir }}/.terraform/modules/
+          retention-days: 7
 
   tf_apply:
     name: "Terraform Apply"


### PR DESCRIPTION
The [infra_apply.yaml](https://github.com/pagopa/dx/blob/main/.github/workflows/infra_apply.yaml) workflow runs terraform init twice (plan + apply jobs) without preserving resolved module versions, causing potential version drift between plan and apply phases if a module gets a new release in between.

Resolves [CES-1245](https://pagopa.atlassian.net/browse/CES-1245)

[CES-1245]: https://pagopa.atlassian.net/browse/CES-1245?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ