### PR TITLE
Set standard tier to dx website

### DIFF
--- a/.changeset/angry-lands-hang.md
+++ b/.changeset/angry-lands-hang.md
@@ -1,0 +1,5 @@
+---
+"docs": patch
+---
+
+Include input sku_size in Azure Static Web Apps HCL snippet

--- a/apps/website/docs/azure/static-websites/setting-up-azure-static-web-app.md
+++ b/apps/website/docs/azure/static-websites/setting-up-azure-static-web-app.md
@@ -22,6 +22,7 @@ resource "azurerm_static_web_app" "example" {
   resource_group_name = "your-resource-group-name"
   location            = "westeurope" # Is a required parameter, but doesn't affect deployments because the service is global
   sku_tier            = "Standard" # Choose Free for testing, Standard for production
+  sku_size            = "Standard" # Choose Free for testing, Standard for production
 
   tags = {
     ...

--- a/apps/website/docs/azure/static-websites/setting-up-azure-static-web-app.md
+++ b/apps/website/docs/azure/static-websites/setting-up-azure-static-web-app.md
@@ -21,7 +21,6 @@ resource "azurerm_static_web_app" "example" {
   name                = "your-static-web-app-name"
   resource_group_name = "your-resource-group-name"
   location            = "westeurope" # Is a required parameter, but doesn't affect deployments because the service is global
-  sku_tier            = "Standard" # Choose Free for testing, Standard for production
   sku_size            = "Standard" # Choose Free for testing, Standard for production
 
   tags = {

--- a/infra/resources/_modules/dx_website/README.md
+++ b/infra/resources/_modules/dx_website/README.md
@@ -9,7 +9,7 @@ No requirements.
 
 | Name | Version |
 |------|---------|
-| <a name="provider_azurerm"></a> [azurerm](#provider\_azurerm) | 4.46.0 |
+| <a name="provider_azurerm"></a> [azurerm](#provider\_azurerm) | n/a |
 
 ## Modules
 

--- a/infra/resources/_modules/dx_website/README.md
+++ b/infra/resources/_modules/dx_website/README.md
@@ -9,7 +9,7 @@ No requirements.
 
 | Name | Version |
 |------|---------|
-| <a name="provider_azurerm"></a> [azurerm](#provider\_azurerm) | n/a |
+| <a name="provider_azurerm"></a> [azurerm](#provider\_azurerm) | 4.46.0 |
 
 ## Modules
 

--- a/infra/resources/_modules/dx_website/main.tf
+++ b/infra/resources/_modules/dx_website/main.tf
@@ -9,6 +9,7 @@ resource "azurerm_static_web_app" "this" {
   resource_group_name = var.resource_group_name
   location            = "westeurope"
   sku_tier            = "Standard"
+  sku_size            = "Standard"
 
   tags = var.tags
 }

--- a/infra/resources/_modules/dx_website/main.tf
+++ b/infra/resources/_modules/dx_website/main.tf
@@ -8,7 +8,6 @@ resource "azurerm_static_web_app" "this" {
   )
   resource_group_name = var.resource_group_name
   location            = "westeurope"
-  sku_tier            = "Standard"
   sku_size            = "Standard"
 
   tags = var.tags

--- a/infra/resources/_modules/testing/README.md
+++ b/infra/resources/_modules/testing/README.md
@@ -9,7 +9,7 @@ No requirements.
 
 | Name | Version |
 |------|---------|
-| <a name="provider_azurerm"></a> [azurerm](#provider\_azurerm) | 4.46.0 |
+| <a name="provider_azurerm"></a> [azurerm](#provider\_azurerm) | n/a |
 | <a name="provider_dx"></a> [dx](#provider\_dx) | n/a |
 
 ## Modules

--- a/infra/resources/prod/tfmodules.lock.json
+++ b/infra/resources/prod/tfmodules.lock.json
@@ -1,8 +1,8 @@
 {
   "core_values": {
-    "hash": "3bca12aafe02724205dc0459a6caa2bcde040759dc33721b2735737d4832ff70",
-    "version": "0.2.2",
+    "hash": "60b207054f4f2b97e2f6cd601ad43e3f57ba184e63f30bb10053c18146832f4c",
+    "version": "0.2.3",
     "name": "azure_core_values_exporter",
-    "source": "https://registry.terraform.io/modules/pagopa-dx/azure-core-values-exporter/azurerm/0.2.2"
+    "source": "https://registry.terraform.io/modules/pagopa-dx/azure-core-values-exporter/azurerm/0.2.3"
   }
 }


### PR DESCRIPTION
The former "free" sku size limited the number of preview environments to 3. This will increase them to 10.