### PR TITLE
Enable ETags property on self-hosted GitHub runner's autoscaler

### DIFF
--- a/.changeset/upset-bears-look.md
+++ b/.changeset/upset-bears-look.md
@@ -1,0 +1,5 @@
+---
+"github_selfhosted_runner_on_container_app_jobs": minor
+---
+
+Enable enableEtags property on the KEDA scale rule to mitigate rate limit issue with GitHub

--- a/infra/modules/github_selfhosted_runner_on_container_app_jobs/container_app_job.tf
+++ b/infra/modules/github_selfhosted_runner_on_container_app_jobs/container_app_job.tf
@@ -24,13 +24,14 @@ resource "azurerm_container_app_job" "github_runner" {
         name             = "github-runner-rule"
         custom_rule_type = "github-runner"
 
-        # https://keda.sh/docs/2.16/scalers/github-runner/
+        # https://keda.sh/docs/2.17/scalers/github-runner/
         metadata = merge({
           owner                     = var.repository.owner
           runnerScope               = "repo"
           repos                     = var.repository.name
           targetWorkflowQueueLength = "1"
           github-runner             = "https://api.github.com"
+          enableEtags               = "true"
         }, var.container_app_environment.use_labels ? { labels = local.labels } : {})
 
         authentication {


### PR DESCRIPTION
Close CES-1333