### PR TITLE
Preserve simlinks on pnpm artifact build

### DIFF
--- a/.github/workflows/release-azure-appsvc-v1.yaml
+++ b/.github/workflows/release-azure-appsvc-v1.yaml
@@ -114,7 +114,7 @@ jobs:
           if [ "$PACKAGE_MANAGER" = "pnpm" ]; then
             echo "::debug::The workspace uses pnpm"
             pnpm --filter $WORKSPACE_NAME deploy --prod bundle
-            cd bundle && zip -r $BUNDLE_NAME.zip .
+            cd bundle && zip -yr $BUNDLE_NAME.zip .
             echo "artifact-path=$(realpath $BUNDLE_NAME.zip)" >> $GITHUB_OUTPUT
             exit 0
           fi


### PR DESCRIPTION
Breaking symlinks can cause problems at runtime because `node` is unable to reach certain indirect dependencies.