### PR TITLE
Fallback to latest when RUNNER_DIGEST is not provided

### DIFF
--- a/containers/self-hosted-runner/Dockerfile
+++ b/containers/self-hosted-runner/Dockerfile
@@ -2,7 +2,7 @@
 # === Stage 1: Use base Runner and install tools ===
 ARG RUNNER_DIGEST
 
-FROM ghcr.io/actions/actions-runner@${RUNNER_DIGEST} AS base
+FROM ghcr.io/actions/actions-runner${RUNNER_DIGEST:+@${RUNNER_DIGEST}} AS base
 
 LABEL base_runner_digest=${RUNNER_DIGEST}
 


### PR DESCRIPTION
`docker build` for `self-hosted-runner` fails with [InvalidDefaultArgInFrom](https://docs.docker.com/reference/build-checks/invalid-default-arg-in-from/) because when `RUNNER_DIGEST` is not provided (via `--build-arg`) the resulting `FROM` content is `FROM ghcr.io/actions/actions-runner@ as base`, which is invalid.

With this change, I added `@` as prefix only when `RUNNER_DIGEST` is provided so `docker build .` without `--build-arg` will result to `FROM ghcr.io/actions/actions-runner AS base` that defaults to `latest` tag.
