### PR TITLE
Fix filtered plan action sensitive-key value metch

### DIFF
--- a/.changeset/ninety-pigs-refuse.md
+++ b/.changeset/ninety-pigs-refuse.md
@@ -1,0 +1,5 @@
+---
+"filter-terraform-plan": patch
+---
+
+Fix, now the sensitive-key passed as input checks whether the value is contained in the key; it no longer performs an exact match.

--- a/actions/filter-terraform-plan/run_plan.sh
+++ b/actions/filter-terraform-plan/run_plan.sh
@@ -70,9 +70,9 @@ SED_EXPRESSIONS=()
 for key in $(echo "$SENSITIVE_KEYS" | tr ',' '\n'); do
   trimmed_key=$(echo "$key" | xargs)
   if [[ -n "$trimmed_key" ]]; then
-    # Matches an optional-quoted key followed by : or =, then a quoted value;
-    # it captures the left side and replaces the value with "[REDACTED]" (non-greedy match, case-insensitive).
-    SED_EXPRESSIONS+=(-e "s/(\"?${trimmed_key}\"?\s*[:=]\s*)\"[^\"]*\"/\\1\"[REDACTED]\"/I")
+    # Matches an optional-quoted key followed by =, then a quoted value;
+    # it captures the left side, check if contain the sensitive key and replaces the value with "[REDACTED]" (case-insensitive).
+    SED_EXPRESSIONS+=(-e "s/(\"?${trimmed_key}[^\"]*\"?\s*=\s*)\"[^\"]*\"/\\1\"[REDACTED]\"/I")
   fi
 done
 

--- a/actions/filter-terraform-plan/test.sh
+++ b/actions/filter-terraform-plan/test.sh
@@ -19,7 +19,7 @@ for input_file in "$TEST_DIR"/*.input; do
   TEST_COUNT=$((TEST_COUNT + 1))
 
   # Execute script and save the result in tmp file
-  cat "$input_file" | "$SCRIPT_TO_TEST" --plan-file "test.txt" --sensitive-keys "hidden-link" --test > "$TMP_OUTPUT_FILE"
+  cat "$input_file" | "$SCRIPT_TO_TEST" --plan-file "test.txt" --sensitive-keys "hidden-link, test-sensible-key" --test > "$TMP_OUTPUT_FILE"
 
   # Check diff between tmp file and expected result file
   if ! diff -u "$TMP_OUTPUT_FILE" "$expected_file"; then

--- a/actions/filter-terraform-plan/tests/03_masking.expected
+++ b/actions/filter-terraform-plan/tests/03_masking.expected
@@ -3,4 +3,17 @@ Test mode enabled.
 normal_value = "Keep Me"
 
 hidden-link = "[REDACTED]"
-hidden-links = "http://non_sensitive_test.link"
+hidden-links = "[REDACTED]"
+very-hidden-link = "[REDACTED]"
+
+hiddden-link = "http://non_sensitive_test.link"
+
+hidden-link: /app-insights-conn-string         = "[REDACTED]"
+hidden-link: /app-insights-instrumentation-key = "[REDACTED]"
+hidden-link: /app-insights-resource-id         = "[REDACTED]"
+
+test-sensible-key       = "[REDACTED]"
+test-super-sensible-key = "test"
+sensible-key            = "test"
+hide-test-sensible-key  = "[REDACTED]"
+test-sensible-key-hide  = "[REDACTED]"

--- a/actions/filter-terraform-plan/tests/03_masking.input
+++ b/actions/filter-terraform-plan/tests/03_masking.input
@@ -2,3 +2,16 @@ normal_value = "Keep Me"
 
 hidden-link = "http://sensitive_test.link"
 hidden-links = "http://non_sensitive_test.link"
+very-hidden-link = "http://non_sensitive_test.link"
+
+hiddden-link = "http://non_sensitive_test.link"
+
+hidden-link: /app-insights-conn-string         = "InstrumentationKey=000000-000000-000000-000000;IngestionEndpoint=https://westeurope-3.in.applicationinsights.azure.com/;LiveEndpoint=https://westeurope.livediagnostics.monitor.azure.com/;ApplicationId=000000-000000-000000-000000"
+hidden-link: /app-insights-instrumentation-key = "000000-000000-000000-000000"
+hidden-link: /app-insights-resource-id         = "/subscriptions/***/resourceGroups/XXXXX/providers/microsoft.insights/components/XXXXX"
+
+test-sensible-key       = "test"
+test-super-sensible-key = "test"
+sensible-key            = "test"
+hide-test-sensible-key  = "test"
+test-sensible-key-hide  = "test"


### PR DESCRIPTION
Now verify if the sensitive key passed as input is contained in the plan key value, no longer performs an exact metch

resolves: CES-1349