### PR TITLE
Add AD groups to authorization use case

### DIFF
--- a/.changeset/yellow-baboons-smell.md
+++ b/.changeset/yellow-baboons-smell.md
@@ -1,0 +1,5 @@
+---
+"@pagopa/dx-cli": patch
+---
+
+Add AD groups to the authorization use case

--- a/apps/cli/src/adapters/commander/commands/init.ts
+++ b/apps/cli/src/adapters/commander/commands/init.ts
@@ -273,6 +273,8 @@ export const authorizeCloudAccounts =
         const locShort = locationShort[account.defaultLocation];
         const input = requestAuthorizationInputSchema.safeParse({
           bootstrapIdentityId: `${prefix}-${envShort}-${locShort}-bootstrap-id-01`,
+          envShort,
+          prefix,
           subscriptionName: account.displayName,
         });
 

--- a/apps/cli/src/adapters/pagopa-technology/__tests__/authorization.test.ts
+++ b/apps/cli/src/adapters/pagopa-technology/__tests__/authorization.test.ts
@@ -32,13 +32,15 @@ const makeEnv = () => {
 const makeSampleInput = (): RequestAuthorizationInput =>
   requestAuthorizationInputSchema.parse({
     bootstrapIdentityId: "test-bootstrap-identity-id",
+    envShort: "d",
+    prefix: "test",
     subscriptionName: "test-subscription",
   });
 
 // eslint-disable-next-line max-lines-per-function
 describe("PagoPA AuthorizationService", () => {
   describe("happy path", () => {
-    it("should create a pull request when all steps succeed", async () => {
+    it("should create a pull request with identity and AD groups", async () => {
       const { authorizationService, gitHubService } = makeEnv();
       const input = makeSampleInput();
       const originalContent = `
@@ -82,10 +84,25 @@ directory_readers = {
         repo: "eng-azure-authorization",
       });
 
+      // Verify the updated content includes both the identity and AD groups
+      const updateCall = gitHubService.updateFile.mock.calls[0]?.[0];
+      expect(updateCall).toBeDefined();
+      expect(updateCall?.content).toContain('"test-bootstrap-identity-id"');
+      expect(updateCall?.content).toContain("test-d-adgroup-admin");
+      expect(updateCall?.content).toContain("test-d-adgroup-developers");
+      expect(updateCall?.content).toContain("test-d-adgroup-operations");
+      expect(updateCall?.content).toContain("test-d-adgroup-security");
+      expect(updateCall?.content).toContain(
+        "test-d-adgroup-technical-project-managers",
+      );
+      expect(updateCall?.content).toContain("test-d-adgroup-product-owners");
+      expect(updateCall?.content).toContain("test-d-adgroup-externals");
+      expect(updateCall?.content).toContain("test-d-adgroup-oncall");
+
       expect(gitHubService.updateFile).toHaveBeenCalledWith(
         expect.objectContaining({
           branch: "feats/add-test-subscription-bootstrap-identity",
-          message: "Add directory reader for test-subscription",
+          message: "Add bootstrap identity and AD groups for test-subscription",
           owner: "pagopa",
           path: "src/azure-subscriptions/subscriptions/test-subscription/terraform.tfvars",
           repo: "eng-azure-authorization",
@@ -95,12 +112,65 @@ directory_readers = {
 
       expect(gitHubService.createPullRequest).toHaveBeenCalledWith({
         base: "main",
-        body: "This PR adds the bootstrap identity `test-bootstrap-identity-id` to the directory readers for subscription `test-subscription`.",
+        body: "This PR adds the bootstrap identity `test-bootstrap-identity-id` to the directory readers and configures AD groups for subscription `test-subscription`.",
         head: "feats/add-test-subscription-bootstrap-identity",
         owner: "pagopa",
         repo: "eng-azure-authorization",
-        title: "Add directory reader for test-subscription",
+        title: "Add bootstrap identity and AD groups for test-subscription",
       });
+    });
+
+    it("should preserve existing groups and update roles when needed", async () => {
+      const { authorizationService, gitHubService } = makeEnv();
+      const input = makeSampleInput();
+      const contentWithExistingGroups = `
+directory_readers = {
+  service_principals_name = []
+}
+
+groups = [
+  {
+    name = "test-d-adgroup-admin"
+    members = ["existing-member"],
+    roles = [
+      "Reader"
+    ]
+  },
+  {
+    name = "test-d-adgroup-custom"
+    members = [],
+    roles = [
+      "Contributor"
+    ]
+  }
+]
+`.trim();
+
+      gitHubService.createBranch.mockResolvedValue(undefined);
+      gitHubService.getFileContent.mockResolvedValue({
+        content: contentWithExistingGroups,
+        sha: "sha-456",
+      });
+      gitHubService.updateFile.mockResolvedValue(undefined);
+      gitHubService.createPullRequest.mockResolvedValue(
+        new PullRequest(
+          "https://github.com/pagopa/eng-azure-authorization/pull/43",
+        ),
+      );
+
+      const result = await authorizationService.requestAuthorization(input);
+
+      expect(result.isOk()).toBe(true);
+
+      const updateCall = gitHubService.updateFile.mock.calls[0]?.[0];
+      expect(updateCall).toBeDefined();
+      // Admin group should have roles updated to "Owner" but preserve existing member
+      expect(updateCall?.content).toContain('"existing-member"');
+      expect(updateCall?.content).toContain("test-d-adgroup-admin");
+      // Custom group should be preserved
+      expect(updateCall?.content).toContain("test-d-adgroup-custom");
+      // All default groups should be present
+      expect(updateCall?.content).toContain("test-d-adgroup-developers");
     });
   });
 

--- a/apps/cli/src/adapters/pagopa-technology/authorization.ts
+++ b/apps/cli/src/adapters/pagopa-technology/authorization.ts
@@ -14,8 +14,11 @@ import {
   AuthorizationError,
   AuthorizationResult,
   AuthorizationService,
+  DEFAULT_GROUP_SPECS,
+  GroupConfig,
   IdentityAlreadyExistsError,
   InvalidAuthorizationFileFormatError,
+  makeGroupName,
   RequestAuthorizationInput,
 } from "../../domain/authorization.js";
 import { GitHubService } from "../../domain/github.js";
@@ -59,6 +62,216 @@ const addIdentity = (
   );
 };
 
+/**
+ * Finds and extracts the groups list from content using bracket counting.
+ */
+const findGroupsList = (
+  content: string,
+): undefined | { content: string; end: number; start: number } => {
+  const startMatch = content.match(/groups\s*=\s*\[/);
+  if (!startMatch || startMatch.index === undefined) {
+    return undefined;
+  }
+
+  const listStartIndex = startMatch.index + startMatch[0].length;
+  let depth = 1;
+  let i = listStartIndex;
+
+  while (i < content.length && depth > 0) {
+    if (content[i] === "[") {
+      depth++;
+    } else if (content[i] === "]") {
+      depth--;
+    }
+    i++;
+  }
+
+  if (depth !== 0) {
+    return undefined;
+  }
+
+  return {
+    content: content.slice(listStartIndex, i - 1),
+    end: i,
+    start: startMatch.index,
+  };
+};
+
+/**
+ * Parses all group objects from the groups list content using bracket counting.
+ */
+const parseGroupObjects = (groupsContent: string): string[] => {
+  const groups: string[] = [];
+  let depth = 0;
+  let currentGroup = "";
+  let inGroup = false;
+
+  for (const char of groupsContent) {
+    if (char === "{") {
+      if (depth === 0) {
+        inGroup = true;
+        currentGroup = "";
+      }
+      depth++;
+      currentGroup += char;
+    } else if (char === "}") {
+      depth--;
+      currentGroup += char;
+      if (depth === 0 && inGroup) {
+        groups.push(currentGroup);
+        inGroup = false;
+      }
+    } else if (inGroup) {
+      currentGroup += char;
+    }
+  }
+
+  return groups;
+};
+
+/**
+ * Parses a single group object from HCL format.
+ */
+const parseGroupObject = (groupStr: string): GroupConfig | undefined => {
+  const nameMatch = groupStr.match(/name\s*=\s*"([^"]+)"/);
+  const rolesMatch = groupStr.match(/roles\s*=\s*\[([\s\S]*?)]/);
+  const membersMatch = groupStr.match(/members\s*=\s*\[([\s\S]*?)]/);
+
+  if (!nameMatch) {
+    return undefined;
+  }
+
+  const name = nameMatch[1];
+  const roles = rolesMatch
+    ? [...rolesMatch[1].matchAll(/"([^"]+)"/g)].map((m) => m[1])
+    : [];
+  const members = membersMatch
+    ? [...membersMatch[1].matchAll(/"([^"]+)"/g)].map((m) => m[1])
+    : [];
+
+  return { members, name, roles };
+};
+
+/**
+ * Formats a group config to HCL format.
+ */
+const formatGroupToHcl = (group: GroupConfig): string => {
+  const membersStr =
+    group.members.length > 0
+      ? group.members.map((m) => `      "${m}"`).join(",\n")
+      : "";
+
+  const rolesStr = group.roles.map((r) => `      "${r}"`).join(",\n");
+
+  const membersBlock =
+    group.members.length > 0
+      ? `    members = [\n${membersStr}\n    ]`
+      : `    members = []`;
+
+  return `  {
+    name = "${group.name}"
+${membersBlock},
+    roles = [
+${rolesStr}
+    ]
+  }`;
+};
+
+/**
+ * Checks if two role arrays are equivalent (same roles, order-independent).
+ */
+const rolesAreEqual = (
+  roles1: readonly string[],
+  roles2: readonly string[],
+): boolean => {
+  if (roles1.length !== roles2.length) {
+    return false;
+  }
+  const sorted1 = [...roles1].sort();
+  const sorted2 = [...roles2].sort();
+  return sorted1.every((role, idx) => role === sorted2[idx]);
+};
+
+/**
+ * Adds or updates AD groups in the tfvars content.
+ */
+const upsertGroups = (
+  content: string,
+  prefix: string,
+  envShort: string,
+): Result<string, AuthorizationError> => {
+  const expectedGroups: GroupConfig[] = DEFAULT_GROUP_SPECS.map((spec) => ({
+    members: [],
+    name: makeGroupName(prefix, envShort, spec.groupName),
+    roles: [...spec.roles],
+  }));
+
+  const groupsListInfo = findGroupsList(content);
+
+  if (!groupsListInfo) {
+    // Groups list doesn't exist - create it with all default groups
+    const groupsHcl = expectedGroups.map(formatGroupToHcl).join(",\n");
+    const newGroupsBlock = `\ngroups = [\n${groupsHcl}\n]\n`;
+
+    const directoryReadersMatch = content.match(DIRECTORY_READERS_REGEX);
+    if (directoryReadersMatch) {
+      const insertIndex =
+        (directoryReadersMatch.index ?? 0) + directoryReadersMatch[0].length;
+      return ok(
+        content.slice(0, insertIndex) +
+          newGroupsBlock +
+          content.slice(insertIndex),
+      );
+    }
+
+    return ok(content + newGroupsBlock);
+  }
+
+  // Parse existing groups
+  const groupObjects = parseGroupObjects(groupsListInfo.content);
+  const existingGroups: GroupConfig[] = groupObjects
+    .map(parseGroupObject)
+    .filter((g): g is GroupConfig => g !== undefined);
+
+  const existingGroupsMap = new Map(existingGroups.map((g) => [g.name, g]));
+
+  const finalGroups: GroupConfig[] = [];
+  const processedNames = new Set<string>();
+
+  for (const expected of expectedGroups) {
+    const existing = existingGroupsMap.get(expected.name);
+    processedNames.add(expected.name);
+
+    if (!existing) {
+      finalGroups.push(expected);
+    } else if (!rolesAreEqual(existing.roles, expected.roles)) {
+      finalGroups.push({
+        members: existing.members,
+        name: expected.name,
+        roles: [...expected.roles],
+      });
+    } else {
+      finalGroups.push(existing);
+    }
+  }
+
+  // Preserve user-added groups
+  for (const existing of existingGroups) {
+    if (!processedNames.has(existing.name)) {
+      finalGroups.push(existing);
+    }
+  }
+
+  const groupsHcl = finalGroups.map(formatGroupToHcl).join(",\n");
+  const newGroupsBlock = `groups = [\n${groupsHcl}\n]`;
+
+  return ok(
+    content.slice(0, groupsListInfo.start) +
+      newGroupsBlock +
+      content.slice(groupsListInfo.end),
+  );
+};
+
 const REPO_OWNER = "pagopa";
 const REPO_NAME = "eng-azure-authorization";
 const BASE_BRANCH = "main";
@@ -70,7 +283,7 @@ export const makeAuthorizationService = (
     input: RequestAuthorizationInput,
   ): ResultAsync<AuthorizationResult, AuthorizationError> {
     const logger = getLogger(["dx-cli", "pagopa-authorization"]);
-    const { bootstrapIdentityId, subscriptionName } = input;
+    const { bootstrapIdentityId, envShort, prefix, subscriptionName } = input;
     const filePath = `src/azure-subscriptions/subscriptions/${subscriptionName}/terraform.tfvars`;
     const branchName = `feats/add-${subscriptionName}-bootstrap-identity`;
 
@@ -109,7 +322,7 @@ export const makeAuthorizationService = (
         .orTee((error) => {
           logger.error(error.message);
         })
-        // Modify the file content, detecting duplicates and format errors
+        // Step 3: Add identity and upsert AD groups
         .andThen(({ content, sha }) =>
           addIdentity(content, bootstrapIdentityId)
             .mapErr((error) => {
@@ -125,6 +338,16 @@ export const makeAuthorizationService = (
               }
               return error;
             })
+            .andThen((contentWithIdentity) =>
+              upsertGroups(contentWithIdentity, prefix, envShort).mapErr(
+                (error) => {
+                  logger.error("Failed to upsert groups", {
+                    error: error.message,
+                  });
+                  return error;
+                },
+              ),
+            )
             .match(
               (updatedContent) => okAsync({ sha, updatedContent }),
               (error) => errAsync(error),
@@ -136,7 +359,7 @@ export const makeAuthorizationService = (
             gitHubService.updateFile({
               branch: branchName,
               content: updatedContent,
-              message: `Add directory reader for ${subscriptionName}`,
+              message: `Add bootstrap identity and AD groups for ${subscriptionName}`,
               owner: REPO_OWNER,
               path: filePath,
               repo: REPO_NAME,
@@ -156,11 +379,11 @@ export const makeAuthorizationService = (
           ResultAsync.fromPromise(
             gitHubService.createPullRequest({
               base: BASE_BRANCH,
-              body: `This PR adds the bootstrap identity \`${bootstrapIdentityId}\` to the directory readers for subscription \`${subscriptionName}\`.`,
+              body: `This PR adds the bootstrap identity \`${bootstrapIdentityId}\` to the directory readers and configures AD groups for subscription \`${subscriptionName}\`.`,
               head: branchName,
               owner: REPO_OWNER,
               repo: REPO_NAME,
-              title: `Add directory reader for ${subscriptionName}`,
+              title: `Add bootstrap identity and AD groups for ${subscriptionName}`,
             }),
             () =>
               new AuthorizationError(

--- a/apps/cli/src/domain/authorization.ts
+++ b/apps/cli/src/domain/authorization.ts
@@ -35,12 +35,109 @@ const BootstrapIdentityId = z
   .brand<"BootstrapIdentityId">();
 
 /**
+ * Branded type for resource prefix (e.g., "dx", "io").
+ * Validates that the prefix contains only lowercase letters to prevent injection.
+ */
+const ResourcePrefix = z
+  .string()
+  .min(1)
+  .regex(/^[a-z]+$/, {
+    message: "Resource prefix may contain only lowercase letters",
+  })
+  .brand<"ResourcePrefix">();
+
+/**
+ * Branded type for environment short name (e.g., "d", "u", "p").
+ * Validates single lowercase letter for environment.
+ */
+const EnvShort = z
+  .string()
+  .min(1)
+  .max(1)
+  .regex(/^[a-z]$/, {
+    message: "Environment short name must be a single lowercase letter",
+  })
+  .brand<"EnvShort">();
+
+/**
  * Input validation schema for the request authorization use case.
  */
 export const requestAuthorizationInputSchema = z.object({
   bootstrapIdentityId: BootstrapIdentityId,
+  envShort: EnvShort,
+  prefix: ResourcePrefix,
   subscriptionName: SubscriptionName,
 });
+
+/**
+ * Configuration for an AD group with its roles.
+ */
+export type GroupConfig = {
+  readonly members: readonly string[];
+  readonly name: string;
+  readonly roles: readonly string[];
+};
+
+/**
+ * Group name and roles configuration for default AD groups.
+ */
+type DefaultGroupSpec = {
+  readonly groupName: string;
+  readonly roles: readonly string[];
+};
+
+/**
+ * Default AD groups that should be created for each subscription.
+ * These follow the PagoPA standard pattern: <prefix>-<envShort>-adgroup-<groupName>
+ */
+export const DEFAULT_GROUP_SPECS: readonly DefaultGroupSpec[] = [
+  { groupName: "admin", roles: ["Owner"] },
+  { groupName: "developers", roles: ["Owner"] },
+  {
+    groupName: "operations",
+    roles: [
+      "Reader",
+      "Monitoring Contributor",
+      "Support Request Contributor",
+      "Storage Blob Data Reader",
+      "Storage Queue Data Reader",
+      "Cosmos DB Account Reader Role",
+    ],
+  },
+  {
+    groupName: "security",
+    roles: ["Reader", "Support Request Contributor"],
+  },
+  {
+    groupName: "technical-project-managers",
+    roles: ["Reader", "Monitoring Contributor", "Support Request Contributor"],
+  },
+  {
+    groupName: "product-owners",
+    roles: ["Reader", "Support Request Contributor"],
+  },
+  { groupName: "externals", roles: ["Owner"] },
+  {
+    groupName: "oncall",
+    roles: [
+      "Reader",
+      "Monitoring Contributor",
+      "Support Request Contributor",
+      "Storage Blob Data Reader",
+      "Storage Queue Data Reader",
+      "Cosmos DB Account Reader Role",
+    ],
+  },
+];
+
+/**
+ * Generates the full group name from prefix, envShort, and groupName.
+ */
+export const makeGroupName = (
+  prefix: string,
+  envShort: string,
+  groupName: string,
+): string => `${prefix}-${envShort}-adgroup-${groupName}`;
 
 /**
  * Service interface for requesting cloud authorization.

--- a/apps/cli/src/use-cases/__tests__/request-authorization.test.ts
+++ b/apps/cli/src/use-cases/__tests__/request-authorization.test.ts
@@ -19,6 +19,8 @@ import { requestAuthorization } from "../request-authorization.js";
 const makeSampleInput = (): RequestAuthorizationInput =>
   requestAuthorizationInputSchema.parse({
     bootstrapIdentityId: "test-bootstrap-identity-id",
+    envShort: "d",
+    prefix: "test",
     subscriptionName: "test-subscription",
   });
 


### PR DESCRIPTION
This pull request enhances the authorization workflow to support automatic management of Azure AD groups in addition to bootstrap identities. It introduces robust parsing and updating of group definitions in the Terraform configuration, ensures default AD groups are present and correctly configured, and preserves any custom user-added groups. The changes also improve input validation for resource prefix and environment, and update test coverage accordingly.

These changes collectively automate and standardize AD group management for Azure subscriptions, reduce manual effort, and improve safety and traceability in the authorization workflow.

Closes CES-1658