### PR TITLE
Create a skill to create secure Azure Key Vault secrets

### DIFF
--- a/.github/skills/azure-keyvault-secret/SKILL.md
+++ b/.github/skills/azure-keyvault-secret/SKILL.md
@@ -1,0 +1,149 @@
+---
+name: azure-keyvault-secret
+description: Create secure azurerm_key_vault_secret Terraform resources using the write-only value_wo pattern. Use when asked to create a key vault secret, add a secret to Azure Key Vault in Terraform, use value_wo or value_wo_version, or make secrets secure by keeping them out of Terraform state. Requires Terraform >= 1.11.0 and azurerm provider >= 4.23.
+---
+
+# Azure Key Vault Secret (Secure Write-Only Pattern)
+
+This skill generates `azurerm_key_vault_secret` resources that use the **write-only** `value_wo` attribute, ensuring secret values are never stored in Terraform state.
+
+## Prerequisites
+
+Before generating any code, check the caller's Terraform files for **both** a Terraform version constraint and an `azurerm` provider version constraint.
+
+### Terraform version
+
+Check **both** sources for the Terraform version; if either is present it must satisfy `>= 1.11.0`.
+
+#### 1. `.terraform-version` file
+
+Look for a `.terraform-version` file in the project root (used by `tfenv` / `tofuenv` to pin the binary version). It contains a single plain version string, e.g.:
+
+```
+1.10.3
+```
+
+If the file exists and the version is **< 1.11.0**, stop immediately:
+
+```
+⚠️  Cannot proceed: the write-only value_wo attribute requires Terraform >= 1.11.0.
+
+    .terraform-version pins the binary to: <version found>
+
+    Update .terraform-version to at least 1.11.0:
+
+        echo "1.11.0" > .terraform-version
+
+    Then upgrade your Terraform binary (e.g. tfenv install) and re-run.
+```
+
+#### 2. `required_version` in .tf files
+
+Look for a `required_version` constraint in any `.tf` file:
+
+```hcl
+terraform {
+  required_version = ">= 1.9"   # or any other constraint
+}
+```
+
+**The constraint MUST satisfy `>= 1.11.0`.**
+
+| Scenario | Action |
+|---|---|
+| Constraint is `>= 1.11`, `>= 1.11.0`, `~> 1.11`, `~> 1` with no upper bound below 1.11 | ✅ Proceed to provider check |
+| Constraint is `< 1.11`, `~> 1.9`, `>= 1.0, < 1.11` | ❌ Stop — inform the user |
+| No `required_version` found | ❌ Stop — inform the user |
+
+If the `required_version` requirement is **not met**, output this message and do nothing else:
+
+```
+⚠️  Cannot proceed: the write-only value_wo attribute requires Terraform >= 1.11.0.
+
+    Your current constraint: <show the constraint found, or "not found">
+
+    To fix this, update your versions.tf:
+
+    terraform {
+      required_version = ">= 1.11.0"
+    }
+
+    Then upgrade your Terraform binary and re-run.
+```
+
+### azurerm provider version
+
+Look for an `azurerm` entry inside `required_providers`:
+
+```hcl
+required_providers {
+  azurerm = {
+    source  = "hashicorp/azurerm"
+    version = "~> 4.0"   # or any other constraint
+  }
+}
+```
+
+**The constraint MUST satisfy `>= 4.23`.**
+
+| Scenario | Action |
+|---|---|
+| Constraint is `~> 4.23`, `>= 4.23`, `~> 4.0` with no upper bound below 4.23, `~> 4` | ✅ Proceed |
+| Constraint is `~> 3.x`, `< 4.23`, `>= 3.116, < 5.0` with no guaranteed 4.23 overlap | ❌ Stop — inform the user |
+| No azurerm provider block found | ❌ Stop — inform the user |
+
+If the azurerm requirement is **not met**, output this message and do nothing else:
+
+```
+⚠️  Cannot proceed: the write-only value_wo attribute for azurerm_key_vault_secret
+    requires the azurerm provider >= 4.23.
+
+    Your current constraint: <show the constraint found, or "not found">
+
+    To fix this, update your versions.tf:
+
+    required_providers {
+      azurerm = {
+        source  = "hashicorp/azurerm"
+        version = "~> 4.23"
+      }
+    }
+
+    Then run `terraform init -upgrade` to apply the change.
+```
+
+## Workflow
+
+### Step 1 — Gather inputs
+
+Ask the user (or infer from context) for:
+
+| Input | Required | Example |
+|---|---|---|
+| Resource label (Terraform identifier) | Yes | `db_password` |
+| Secret name (Azure resource name) | Yes | `"db-password"` |
+| `key_vault_id` reference | Yes | `azurerm_key_vault.main.id` |
+| `content_type` | No | `"text/plain"` |
+| `tags` | No | `var.tags` |
+
+### Step 2 — Generate the resource
+
+Use the template at [./templates/key_vault_secret.tf.tpl](./templates/key_vault_secret.tf.tpl) and fill in the gathered values.
+
+**Rules that must never be broken:**
+- `value_wo` must always be `""`
+- `value_wo_version` must always be `1`
+- Never use the `value` attribute — it stores the secret in state
+
+### Step 3 — Explain the pattern
+
+After generating the code, include a short explanation:
+
+```
+ℹ️  The secret is created with value_wo = "" so Terraform never stores the actual
+    secret value in state. Set the real value through a secure channel (CI/CD pipeline,
+    Azure CLI, or the portal) after the first apply. Increment value_wo_version
+    whenever you need Terraform to trigger an update cycle.
+```
+
+See [./references/write-only-secrets.md](./references/write-only-secrets.md) for full background.

--- a/.github/skills/azure-keyvault-secret/references/write-only-secrets.md
+++ b/.github/skills/azure-keyvault-secret/references/write-only-secrets.md
@@ -2,9 +2,10 @@
 
 ## Why Secrets Leak into State
 
-Classic `azurerm_key_vault_secret` uses the `value` attribute:
+Using the `value` attribute within an `azurerm_key_vault_secret` resource is considered a security anti-pattern:
 
 ```hcl
+# DON'T DO THIS!
 resource "azurerm_key_vault_secret" "example" {
   name         = "my-secret"
   value        = "super-secret-value"   # ⚠️ stored in terraform.tfstate in plaintext
@@ -22,6 +23,7 @@ is sent to the provider during `apply` but is never persisted in state. The azur
 provider added support via `value_wo` in **version 4.23**.
 
 ```hcl
+DO THIS INSTEAD
 resource "azurerm_key_vault_secret" "example" {
   name             = "my-secret"
   value_wo         = ""    # write-only: not stored in state

--- a/.github/skills/azure-keyvault-secret/references/write-only-secrets.md
+++ b/.github/skills/azure-keyvault-secret/references/write-only-secrets.md
@@ -1,0 +1,105 @@
+# Write-Only Secrets in Terraform (value_wo)
+
+## Why Secrets Leak into State
+
+Classic `azurerm_key_vault_secret` uses the `value` attribute:
+
+```hcl
+resource "azurerm_key_vault_secret" "example" {
+  name         = "my-secret"
+  value        = "super-secret-value"   # ⚠️ stored in terraform.tfstate in plaintext
+  key_vault_id = azurerm_key_vault.main.id
+}
+```
+
+Terraform records every attribute in the state file. Anyone with access to the state
+backend (blob storage, S3, local file) can read the secret value in plain text.
+
+## The Write-Only Solution
+
+Terraform 1.11 introduced **write-only attributes** (`value_wo`). A write-only attribute
+is sent to the provider during `apply` but is never persisted in state. The azurerm
+provider added support via `value_wo` in **version 4.23**.
+
+```hcl
+resource "azurerm_key_vault_secret" "example" {
+  name             = "my-secret"
+  value_wo         = ""    # write-only: not stored in state
+  value_wo_version = 1     # increment to trigger an update cycle
+  key_vault_id     = azurerm_key_vault.main.id
+}
+```
+
+### value_wo = ""
+
+Setting `value_wo = ""` creates the Key Vault secret as a **placeholder**. The actual
+secret value must be injected through a separate, secure channel after the first
+`terraform apply`:
+
+- Azure CLI: `az keyvault secret set --vault-name <vault> --name <secret> --value <val>`
+- CI/CD pipeline step (GitHub Actions, Azure DevOps)
+- Azure Portal (manual)
+
+This separation of concerns is intentional: Terraform manages the **existence** of the
+secret resource; a secret manager or pipeline manages the **value**.
+
+### value_wo_version
+
+`value_wo_version` is a numeric trigger. Because Terraform cannot diff a write-only
+attribute (it is never read back from state), the only way to tell Terraform "update
+the secret on next apply" is to change `value_wo_version`. Increment it whenever:
+
+- The secret rotation policy requires a new Terraform-triggered write.
+- You change `value_wo` to a new non-empty ephemeral value.
+
+Starting at `1` is the conventional default.
+
+## Version Requirements
+
+| Requirement | Minimum version |
+|---|---|
+| Terraform | **1.11.0** |
+| azurerm provider | **4.23** |
+
+Write-only attributes (`value_wo`) are a Terraform 1.11 language feature; the runtime
+must understand them before the provider can use them. The azurerm provider added
+`value_wo` support for `azurerm_key_vault_secret` in version 4.23.
+
+Two sources pin the Terraform version and both must satisfy `>= 1.11.0`:
+
+- **`.terraform-version`** — plain-text file in the project root used by `tfenv`/`tofuenv`
+  to select the binary. If present, its value must be `>= 1.11.0`.
+- **`required_version`** in a `terraform {}` block inside any `.tf` file — declares the
+  version constraint enforced by Terraform itself at runtime.
+
+A `required_version = ">= 1.11.0"` and an azurerm constraint like `~> 4.0` (or `~> 4.23`)
+satisfy both requirements. Constraints like `~> 1.9`, `~> 3.x`, or `>= 3.116, < 5.0` do not.
+
+## When to Use an Ephemeral Value Instead
+
+If your Terraform code already produces the secret (e.g., a randomly generated
+password), you can pass it directly as an ephemeral value:
+
+```hcl
+ephemeral "random_password" "db" {
+  length  = 32
+  special = true
+}
+
+resource "azurerm_key_vault_secret" "db_password" {
+  name             = "db-password"
+  value_wo         = ephemeral.random_password.db.result
+  value_wo_version = 2
+  key_vault_id     = azurerm_key_vault.main.id
+}
+```
+
+In this case `value_wo` is not empty, but it is still write-only. The `azure-keyvault-secret`
+skill always defaults to `value_wo = ""` because it does not assume any ephemeral
+source is available; adjust if your module provides one.
+
+## References
+
+- [Terraform write-only attributes (1.11)](https://developer.hashicorp.com/terraform/language/resources/ephemeral/write-only)
+- [azurerm_key_vault_secret resource docs](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/key_vault_secret)
+- [azurerm provider changelog 4.23](https://github.com/hashicorp/terraform-provider-azurerm/releases/tag/v4.23.0)

--- a/.github/skills/azure-keyvault-secret/templates/key_vault_secret.tf.tpl
+++ b/.github/skills/azure-keyvault-secret/templates/key_vault_secret.tf.tpl
@@ -10,7 +10,7 @@ resource "azurerm_key_vault_secret" "<RESOURCE_LABEL>" {
   value_wo         = ""
   value_wo_version = 1
 
-  # Optional — remove if not needed
-  content_type = "<CONTENT_TYPE>" # e.g. "text/plain", "application/json"
+  # Optional - use only when needed
+  # content_type = "<CONTENT_TYPE>" # e.g. "text/plain", "application/json"
   tags         = <TAGS_REFERENCE> # e.g. var.tags
 }

--- a/.github/skills/azure-keyvault-secret/templates/key_vault_secret.tf.tpl
+++ b/.github/skills/azure-keyvault-secret/templates/key_vault_secret.tf.tpl
@@ -1,0 +1,16 @@
+# Replace <RESOURCE_LABEL> with a descriptive Terraform identifier (snake_case).
+# Replace placeholder values in angle brackets with the actual values for the project.
+resource "azurerm_key_vault_secret" "<RESOURCE_LABEL>" {
+  name         = "<SECRET_NAME>"          # Azure Key Vault secret name (kebab-case recommended)
+  key_vault_id = <KEY_VAULT_ID_REFERENCE> # e.g. azurerm_key_vault.main.id or var.key_vault_id
+
+  # Write-only: the value is sent to Azure but never persisted in Terraform state.
+  # Set the real secret value through a secure channel (CI/CD, Azure CLI, portal)
+  # after the first apply. Increment value_wo_version to trigger future updates.
+  value_wo         = ""
+  value_wo_version = 1
+
+  # Optional — remove if not needed
+  content_type = "<CONTENT_TYPE>" # e.g. "text/plain", "application/json"
+  tags         = <TAGS_REFERENCE> # e.g. var.tags
+}


### PR DESCRIPTION
This pull request introduces a new skill for securely managing Azure Key Vault secrets in Terraform using the write-only `value_wo` pattern. The changes add documentation, usage instructions, and a resource template to ensure that secret values are never stored in Terraform state files, improving security and compliance for infrastructure-as-code workflows.