### PR TITLE
Parse Azure authorization with JSON format

### DIFF
--- a/.changeset/curvy-pugs-wave.md
+++ b/.changeset/curvy-pugs-wave.md
@@ -1,0 +1,5 @@
+---
+"@pagopa/dx-cli": patch
+---
+
+Parse Azure authorization with JSON format instead of HCL

--- a/.nx/version-plans/version-plan-1775055766930.md
+++ b/.nx/version-plans/version-plan-1775055766930.md
@@ -1,5 +1,5 @@
 ---
-"@pagopa/dx-cli": patch
+'@pagopa/dx-cli': patch
 ---
 
 Parse Azure authorization with JSON format instead of HCL

--- a/apps/cli/src/adapters/pagopa-technology/__tests__/authorization.test.ts
+++ b/apps/cli/src/adapters/pagopa-technology/__tests__/authorization.test.ts
@@ -144,19 +144,19 @@ describe("PagoPA AuthorizationService", () => {
       const updateCall = gitHubService.updateFile.mock.calls[0][0];
       const updatedParsed = JSON.parse(updateCall.content);
 
-      // New identity was added
-      expect(updatedParsed.directory_readers.service_principals_name).toContain(
-        "test-bootstrap-identity-id",
-      );
-      // Existing identity preserved
-      expect(updatedParsed.directory_readers.service_principals_name).toContain(
-        "existing-identity",
-      );
-      // Extra nested field preserved
-      expect(updatedParsed.directory_readers.some_other_field).toBe("keep-me");
-      // Other top-level objects preserved
-      expect(updatedParsed.entra_groups).toEqual({ readers: ["reader-group"] });
-      expect(updatedParsed.other_top_level).toBe(true);
+      expect(updatedParsed).toStrictEqual({
+        directory_readers: {
+          service_principals_name: [
+            "existing-identity",
+            "test-bootstrap-identity-id",
+          ],
+          some_other_field: "keep-me",
+        },
+        entra_groups: {
+          readers: ["reader-group"],
+        },
+        other_top_level: true,
+      });
     });
 
     it("should append identity to an existing non-empty list", async () => {

--- a/apps/cli/src/adapters/pagopa-technology/__tests__/authorization.test.ts
+++ b/apps/cli/src/adapters/pagopa-technology/__tests__/authorization.test.ts
@@ -127,7 +127,9 @@ describe("PagoPA AuthorizationService", () => {
       });
       gitHubService.updateFile.mockResolvedValue(undefined);
       gitHubService.createPullRequest.mockResolvedValue(
-        new PullRequest("https://github.com/pagopa/eng-azure-authorization/pull/43"),
+        new PullRequest(
+          "https://github.com/pagopa/eng-azure-authorization/pull/43",
+        ),
       );
 
       const result = await authorizationService.requestAuthorization(input);
@@ -136,12 +138,12 @@ describe("PagoPA AuthorizationService", () => {
 
       const updateCall = gitHubService.updateFile.mock.calls[0][0];
       const updatedParsed = JSON.parse(updateCall.content);
-      expect(
-        updatedParsed.directory_readers.service_principals_name,
-      ).toContain("test-bootstrap-identity-id");
-      expect(
-        updatedParsed.directory_readers.service_principals_name,
-      ).toContain("existing-identity");
+      expect(updatedParsed.directory_readers.service_principals_name).toContain(
+        "test-bootstrap-identity-id",
+      );
+      expect(updatedParsed.directory_readers.service_principals_name).toContain(
+        "existing-identity",
+      );
     });
   });
 

--- a/apps/cli/src/adapters/pagopa-technology/__tests__/authorization.test.ts
+++ b/apps/cli/src/adapters/pagopa-technology/__tests__/authorization.test.ts
@@ -36,17 +36,20 @@ const makeSampleInput = (): RequestAuthorizationInput =>
     subscriptionName: "test-subscription",
   });
 
+const FILE_PATH =
+  "src/azure-subscriptions/subscriptions/test-subscription/terraform.tfvars.json";
+
 // eslint-disable-next-line max-lines-per-function
 describe("PagoPA AuthorizationService", () => {
   describe("happy path", () => {
     it("should create a pull request when all steps succeed", async () => {
       const { authorizationService, gitHubService } = makeEnv();
       const input = makeSampleInput();
-      const originalContent = `
-directory_readers = {
-  service_principals_name = []
-}
-`.trim();
+      const originalContent = JSON.stringify(
+        { directory_readers: { service_principals_name: [] } },
+        null,
+        2,
+      );
 
       gitHubService.createBranch.mockResolvedValue(undefined);
       gitHubService.getFileContent.mockResolvedValue({
@@ -78,7 +81,7 @@ directory_readers = {
 
       expect(gitHubService.getFileContent).toHaveBeenCalledWith({
         owner: "pagopa",
-        path: "src/azure-subscriptions/subscriptions/test-subscription/terraform.tfvars",
+        path: FILE_PATH,
         ref: "feats/add-test-repo-test-subscription-bootstrap-identity",
         repo: "eng-azure-authorization",
       });
@@ -88,7 +91,7 @@ directory_readers = {
           branch: "feats/add-test-repo-test-subscription-bootstrap-identity",
           message: "Add directory reader for test-subscription",
           owner: "pagopa",
-          path: "src/azure-subscriptions/subscriptions/test-subscription/terraform.tfvars",
+          path: FILE_PATH,
           repo: "eng-azure-authorization",
           sha: "original-sha-123",
         }),
@@ -103,6 +106,43 @@ directory_readers = {
         title: "Add directory reader for test-subscription",
       });
     });
+
+    it("should append identity to an existing non-empty list", async () => {
+      const { authorizationService, gitHubService } = makeEnv();
+      const input = makeSampleInput();
+      const originalContent = JSON.stringify(
+        {
+          directory_readers: {
+            service_principals_name: ["existing-identity"],
+          },
+        },
+        null,
+        2,
+      );
+
+      gitHubService.createBranch.mockResolvedValue(undefined);
+      gitHubService.getFileContent.mockResolvedValue({
+        content: originalContent,
+        sha: "sha-456",
+      });
+      gitHubService.updateFile.mockResolvedValue(undefined);
+      gitHubService.createPullRequest.mockResolvedValue(
+        new PullRequest("https://github.com/pagopa/eng-azure-authorization/pull/43"),
+      );
+
+      const result = await authorizationService.requestAuthorization(input);
+
+      expect(result.isOk()).toBe(true);
+
+      const updateCall = gitHubService.updateFile.mock.calls[0][0];
+      const updatedParsed = JSON.parse(updateCall.content);
+      expect(
+        updatedParsed.directory_readers.service_principals_name,
+      ).toContain("test-bootstrap-identity-id");
+      expect(
+        updatedParsed.directory_readers.service_principals_name,
+      ).toContain("existing-identity");
+    });
   });
 
   describe("error handling", () => {
@@ -112,9 +152,7 @@ directory_readers = {
 
       gitHubService.createBranch.mockResolvedValue(undefined);
       gitHubService.getFileContent.mockRejectedValue(
-        new FileNotFoundError(
-          "src/azure-subscriptions/subscriptions/test-subscription/terraform.tfvars",
-        ),
+        new FileNotFoundError(FILE_PATH),
       );
 
       const result = await authorizationService.requestAuthorization(input);
@@ -122,7 +160,7 @@ directory_readers = {
       expect(result.isErr()).toBe(true);
       const error = result._unsafeUnwrapErr();
       expect(error.message).toContain("Unable to get");
-      expect(error.message).toContain("test-subscription/terraform.tfvars");
+      expect(error.message).toContain("terraform.tfvars.json");
 
       expect(gitHubService.updateFile).not.toHaveBeenCalled();
     });
@@ -130,13 +168,15 @@ directory_readers = {
     it("should return error when identity already exists", async () => {
       const { authorizationService, gitHubService } = makeEnv();
       const input = makeSampleInput();
-      const content = `
-directory_readers = {
-  service_principals_name = [
-    "test-bootstrap-identity-id"
-  ]
-}
-`.trim();
+      const content = JSON.stringify(
+        {
+          directory_readers: {
+            service_principals_name: ["test-bootstrap-identity-id"],
+          },
+        },
+        null,
+        2,
+      );
 
       gitHubService.createBranch.mockResolvedValue(undefined);
       gitHubService.getFileContent.mockResolvedValue({
@@ -154,14 +194,33 @@ directory_readers = {
       expect(gitHubService.updateFile).not.toHaveBeenCalled();
     });
 
-    it("should return error when tfvars format is invalid", async () => {
+    it("should return error when file content is not valid JSON", async () => {
       const { authorizationService, gitHubService } = makeEnv();
       const input = makeSampleInput();
-      const invalidContent = "invalid content without directory_readers";
 
       gitHubService.createBranch.mockResolvedValue(undefined);
       gitHubService.getFileContent.mockResolvedValue({
-        content: invalidContent,
+        content: "not valid json {{",
+        sha: "sha-123",
+      });
+
+      const result = await authorizationService.requestAuthorization(input);
+
+      expect(result.isErr()).toBe(true);
+      expect(result._unsafeUnwrapErr()).toBeInstanceOf(
+        InvalidAuthorizationFileFormatError,
+      );
+
+      expect(gitHubService.updateFile).not.toHaveBeenCalled();
+    });
+
+    it("should return error when JSON is missing expected keys", async () => {
+      const { authorizationService, gitHubService } = makeEnv();
+      const input = makeSampleInput();
+
+      gitHubService.createBranch.mockResolvedValue(undefined);
+      gitHubService.getFileContent.mockResolvedValue({
+        content: JSON.stringify({ unexpected_key: {} }),
         sha: "sha-123",
       });
 
@@ -197,11 +256,11 @@ directory_readers = {
     it("should return error when file update fails", async () => {
       const { authorizationService, gitHubService } = makeEnv();
       const input = makeSampleInput();
-      const content = `
-directory_readers = {
-  service_principals_name = []
-}
-`.trim();
+      const content = JSON.stringify(
+        { directory_readers: { service_principals_name: [] } },
+        null,
+        2,
+      );
 
       gitHubService.createBranch.mockResolvedValue(undefined);
       gitHubService.getFileContent.mockResolvedValue({
@@ -223,11 +282,11 @@ directory_readers = {
     it("should return error when PR creation fails", async () => {
       const { authorizationService, gitHubService } = makeEnv();
       const input = makeSampleInput();
-      const content = `
-directory_readers = {
-  service_principals_name = []
-}
-`.trim();
+      const content = JSON.stringify(
+        { directory_readers: { service_principals_name: [] } },
+        null,
+        2,
+      );
 
       gitHubService.createBranch.mockResolvedValue(undefined);
       gitHubService.getFileContent.mockResolvedValue({

--- a/apps/cli/src/adapters/pagopa-technology/__tests__/authorization.test.ts
+++ b/apps/cli/src/adapters/pagopa-technology/__tests__/authorization.test.ts
@@ -107,6 +107,58 @@ describe("PagoPA AuthorizationService", () => {
       });
     });
 
+    it("should preserve existing fields in the JSON file", async () => {
+      const { authorizationService, gitHubService } = makeEnv();
+      const input = makeSampleInput();
+      const originalContent = JSON.stringify(
+        {
+          directory_readers: {
+            service_principals_name: ["existing-identity"],
+            some_other_field: "keep-me",
+          },
+          entra_groups: {
+            readers: ["reader-group"],
+          },
+          other_top_level: true,
+        },
+        null,
+        2,
+      );
+
+      gitHubService.createBranch.mockResolvedValue(undefined);
+      gitHubService.getFileContent.mockResolvedValue({
+        content: originalContent,
+        sha: "sha-789",
+      });
+      gitHubService.updateFile.mockResolvedValue(undefined);
+      gitHubService.createPullRequest.mockResolvedValue(
+        new PullRequest(
+          "https://github.com/pagopa/eng-azure-authorization/pull/44",
+        ),
+      );
+
+      const result = await authorizationService.requestAuthorization(input);
+
+      expect(result.isOk()).toBe(true);
+
+      const updateCall = gitHubService.updateFile.mock.calls[0][0];
+      const updatedParsed = JSON.parse(updateCall.content);
+
+      // New identity was added
+      expect(updatedParsed.directory_readers.service_principals_name).toContain(
+        "test-bootstrap-identity-id",
+      );
+      // Existing identity preserved
+      expect(updatedParsed.directory_readers.service_principals_name).toContain(
+        "existing-identity",
+      );
+      // Extra nested field preserved
+      expect(updatedParsed.directory_readers.some_other_field).toBe("keep-me");
+      // Other top-level objects preserved
+      expect(updatedParsed.entra_groups).toEqual({ readers: ["reader-group"] });
+      expect(updatedParsed.other_top_level).toBe(true);
+    });
+
     it("should append identity to an existing non-empty list", async () => {
       const { authorizationService, gitHubService } = makeEnv();
       const input = makeSampleInput();

--- a/apps/cli/src/adapters/pagopa-technology/authorization.ts
+++ b/apps/cli/src/adapters/pagopa-technology/authorization.ts
@@ -3,12 +3,13 @@
  *
  * Implements the AuthorizationService interface for the PagoPA Azure
  * authorization workflow. Encapsulates all platform-specific details:
- * the target GitHub repository, file paths, branch naming, HCL file
+ * the target GitHub repository, file paths, branch naming, JSON file
  * parsing, and pull request creation.
  */
 
 import { getLogger } from "@logtape/logtape";
 import { err, errAsync, ok, okAsync, Result, ResultAsync } from "neverthrow";
+import { z } from "zod";
 
 import {
   AuthorizationError,
@@ -20,17 +21,27 @@ import {
 } from "../../domain/authorization.js";
 import { GitHubService } from "../../domain/github.js";
 
-// Matches the service_principals_name list inside the directory_readers block.
-const DIRECTORY_READERS_REGEX =
-  /(directory_readers\s*=\s*\{[\s\S]*?service_principals_name\s*=\s*\[)([\s\S]*?)(][\s\S]*?})/;
+const authorizationFileSchema = z.object({
+  directory_readers: z.object({
+    service_principals_name: z.array(z.string()),
+  }),
+});
 
 const addIdentity = (
   content: string,
   identityId: string,
 ): Result<string, AuthorizationError> => {
-  const match = content.match(DIRECTORY_READERS_REGEX);
+  let parsed;
+  try {
+    parsed = JSON.parse(content);
+  } catch {
+    return err(
+      new InvalidAuthorizationFileFormatError("File content is not valid JSON"),
+    );
+  }
 
-  if (!match) {
+  const result = authorizationFileSchema.safeParse(parsed);
+  if (!result.success) {
     return err(
       new InvalidAuthorizationFileFormatError(
         "Could not find directory_readers.service_principals_name list",
@@ -38,25 +49,21 @@ const addIdentity = (
     );
   }
 
-  const [, prefix, existingItems, suffix] = match;
+  const { service_principals_name } = result.data.directory_readers;
 
-  if (existingItems.includes(`"${identityId}"`)) {
+  if (service_principals_name.includes(identityId)) {
     return err(new IdentityAlreadyExistsError(identityId));
   }
 
-  // Build the new list content following HCL formatting rules:
-  // - Items are indented with 4 spaces; the LAST item must NOT have a trailing comma
-  const newListContent =
-    existingItems.trim().length > 0
-      ? `${existingItems.replace(/,?\s*$/, "")},\n    "${identityId}"\n  `
-      : `\n    "${identityId}"\n  `;
+  const updated = {
+    ...result.data,
+    directory_readers: {
+      ...result.data.directory_readers,
+      service_principals_name: [...service_principals_name, identityId],
+    },
+  };
 
-  return ok(
-    content.replace(
-      DIRECTORY_READERS_REGEX,
-      `${prefix}${newListContent}${suffix}`,
-    ),
-  );
+  return ok(JSON.stringify(updated, null, 2));
 };
 
 const REPO_OWNER = "pagopa";
@@ -71,7 +78,7 @@ export const makeAuthorizationService = (
   ): ResultAsync<AuthorizationResult, AuthorizationError> {
     const logger = getLogger(["dx-cli", "pagopa-authorization"]);
     const { bootstrapIdentityId, repoName, subscriptionName } = input;
-    const filePath = `src/azure-subscriptions/subscriptions/${subscriptionName}/terraform.tfvars`;
+    const filePath = `src/azure-subscriptions/subscriptions/${subscriptionName}/terraform.tfvars.json`;
     const branchName = `feats/add-${repoName}-${subscriptionName}-bootstrap-identity`;
 
     return (

--- a/apps/cli/src/adapters/pagopa-technology/authorization.ts
+++ b/apps/cli/src/adapters/pagopa-technology/authorization.ts
@@ -21,11 +21,15 @@ import {
 } from "../../domain/authorization.js";
 import { GitHubService } from "../../domain/github.js";
 
-const authorizationFileSchema = z.object({
-  directory_readers: z.object({
-    service_principals_name: z.array(z.string()),
-  }),
-});
+const authorizationFileSchema = z
+  .object({
+    directory_readers: z
+      .object({
+        service_principals_name: z.array(z.string()),
+      })
+      .loose(),
+  })
+  .loose();
 
 const addIdentity = (
   content: string,
@@ -49,17 +53,22 @@ const addIdentity = (
     );
   }
 
-  const { service_principals_name } = result.data.directory_readers;
+  const jsonContent = result.data;
 
-  if (service_principals_name.includes(identityId)) {
+  if (
+    jsonContent.directory_readers.service_principals_name.includes(identityId)
+  ) {
     return err(new IdentityAlreadyExistsError(identityId));
   }
 
   const updated = {
-    ...result.data,
+    ...jsonContent,
     directory_readers: {
-      ...result.data.directory_readers,
-      service_principals_name: [...service_principals_name, identityId],
+      ...jsonContent.directory_readers,
+      service_principals_name: [
+        ...jsonContent.directory_readers.service_principals_name,
+        identityId,
+      ],
     },
   };
 

--- a/nx.json
+++ b/nx.json
@@ -41,6 +41,9 @@
       }
     },
     "test": {
+      "dependsOn": [
+        "^build"
+      ],
       "configurations": {
         "ci": {
           "coverage": true


### PR DESCRIPTION
This pull request updates the PagoPA Azure authorization workflow to use JSON-formatted authorization files instead of HCL, and refactors the related code and tests accordingly. The main changes include switching file parsing and validation to JSON, updating file paths, improving error handling, and enhancing test coverage for the new format.

> [!WARNING]
> Before merging this PR, we need to migrate the files of the Azure Authorization repository to JSON
> Depends on https://github.com/pagopa/eng-azure-authorization/pull/2051

Closes CES-1887