### PR TITLE
Fix Azure Redis entry in Techradar

### DIFF
--- a/apps/website/CHANGELOG.md
+++ b/apps/website/CHANGELOG.md
@@ -2,13 +2,18 @@
 
 ### 🚀 Features
 
-- Add website docs for DX Copilot plugins ([#1540](https://github.com/pagopa/dx/pull/1540))
+- Add website docs for DX Copilot plugins
+  ([#1540](https://github.com/pagopa/dx/pull/1540))
 
 ### 🩹 Fixes
 
-- Update docs with new nx-release action page ([#1486](https://github.com/pagopa/dx/pull/1486), [#1510](https://github.com/pagopa/dx/issues/1510))
-- Improve documentation for monorepositories and dx-cli init command ([#1487](https://github.com/pagopa/dx/pull/1487))
-- Align documentation for Nx Release instead of Changeset, add new page for Version Plans ([#1570](https://github.com/pagopa/dx/pull/1570))
+- Update docs with new nx-release action page
+  ([#1486](https://github.com/pagopa/dx/pull/1486),
+  [#1510](https://github.com/pagopa/dx/issues/1510))
+- Improve documentation for monorepositories and dx-cli init command
+  ([#1487](https://github.com/pagopa/dx/pull/1487))
+- Align documentation for Nx Release instead of Changeset, add new page for
+  Version Plans ([#1570](https://github.com/pagopa/dx/pull/1570))
 
 ### ❤️ Thank You
 

--- a/apps/website/radar-docs/azure-managed-redis.md
+++ b/apps/website/radar-docs/azure-managed-redis.md
@@ -10,7 +10,7 @@ is a fully managed in-memory data store built on
 distribution of Redis by Redis Inc. It is the evolution of Azure Cache for
 Redis, offering higher performance, better reliability, and additional
 capabilities such as active geo-replication, Redis modules (RediSearch,
-RedisJSON, RedisBloom, RedisTimeSeries), and support for Redis 7.4.x.
+RedisJSON, RedisBloom, RedisTimeSeries), and support for current Redis versions.
 
 ## Use cases
 

--- a/apps/website/radar-docs/azure-managed-redis.md
+++ b/apps/website/radar-docs/azure-managed-redis.md
@@ -1,0 +1,21 @@
+---
+title: "Azure Managed Redis"
+ring: adopt
+tags: [cloud, azure, persistence]
+---
+
+[Azure Managed Redis](https://learn.microsoft.com/en-us/azure/azure-cache-for-redis/managed-redis/managed-redis-overview)
+is a fully managed in-memory data store built on
+[Redis Enterprise](https://redis.io/about/redis-enterprise/), the commercial
+distribution of Redis by Redis Inc. It is the evolution of Azure Cache for
+Redis, offering higher performance, better reliability, and additional
+capabilities such as active geo-replication, Redis modules (RediSearch,
+RedisJSON, RedisBloom, RedisTimeSeries), and support for Redis 7.4.x.
+
+## Use cases
+
+Azure Managed Redis is suitable for use cases that require low-latency,
+high-throughput data access at scale. Common scenarios include caching
+frequently accessed database queries, real-time session storage, job and message
+queuing, deduplication with bloom filters, leaderboards via sorted sets, and
+analytics acceleration via the Redis ODBC driver.

--- a/apps/website/radar-docs/azure-redis.md
+++ b/apps/website/radar-docs/azure-redis.md
@@ -14,8 +14,9 @@ automatic scaling, and high availability with geo-replication options.
 ## Status
 
 Microsoft is transitioning towards
-[Azure Managed Redis](./azure-managed-redis.md) as the recommended successor; see
-the [Microsoft documentation](https://learn.microsoft.com/en-us/azure/azure-cache-for-redis/managed-redis/managed-redis-overview)
+[Azure Managed Redis](./azure-managed-redis.md) as the recommended successor;
+see the
+[Microsoft documentation](https://learn.microsoft.com/en-us/azure/azure-cache-for-redis/managed-redis/managed-redis-overview)
 for product details. Azure Managed Redis is built on Redis Enterprise, includes
 advanced modules (RediSearch, RedisJSON, RedisBloom, RedisTimeSeries), and
 offers active geo-replication and better performance characteristics. New

--- a/apps/website/radar-docs/azure-redis.md
+++ b/apps/website/radar-docs/azure-redis.md
@@ -11,7 +11,7 @@ is designed to improve application performance by offloading database queries
 and enabling real-time analytics. The service supports multiple data structures,
 automatic scaling, and high availability with geo-replication options.
 
-## Deprecation
+## Status
 
 Microsoft is transitioning towards
 [Azure Managed Redis](https://learn.microsoft.com/en-us/azure/azure-cache-for-redis/managed-redis/managed-redis-overview)

--- a/apps/website/radar-docs/azure-redis.md
+++ b/apps/website/radar-docs/azure-redis.md
@@ -14,8 +14,9 @@ automatic scaling, and high availability with geo-replication options.
 ## Status
 
 Microsoft is transitioning towards
-[Azure Managed Redis](https://learn.microsoft.com/en-us/azure/azure-cache-for-redis/managed-redis/managed-redis-overview)
-as the recommended successor. Azure Managed Redis is built on Redis Enterprise,
-includes advanced modules (RediSearch, RedisJSON, RedisBloom, RedisTimeSeries),
-and offers active geo-replication and better performance characteristics. New
+[Azure Managed Redis](./azure-managed-redis.md) as the recommended successor; see
+the [Microsoft documentation](https://learn.microsoft.com/en-us/azure/azure-cache-for-redis/managed-redis/managed-redis-overview)
+for product details. Azure Managed Redis is built on Redis Enterprise, includes
+advanced modules (RediSearch, RedisJSON, RedisBloom, RedisTimeSeries), and
+offers active geo-replication and better performance characteristics. New
 projects should use Azure Managed Redis instead.

--- a/apps/website/radar-docs/azure-redis.md
+++ b/apps/website/radar-docs/azure-redis.md
@@ -1,6 +1,6 @@
 ---
 title: "Azure Cache for Redis"
-ring: adopt
+ring: hold
 tags: [cloud, azure, persistence]
 ---
 
@@ -11,16 +11,11 @@ is designed to improve application performance by offloading database queries
 and enabling real-time analytics. The service supports multiple data structures,
 automatic scaling, and high availability with geo-replication options.
 
-## Use cases
+## Deprecation
 
-A common use case for Azure Cache for Redis is to improve application
-performance by caching frequently accessed database queries, reducing latency
-and load on the primary database. It is also used for real-time session storage
-in web applications, enabling fast and scalable user authentication and state
-management.
-
-## Repositories using Azure Cache for Redis
-
-- [infrastructure repository](https://github.com/pagopa/io-infra/blob/888081627bb9da110423d43c42def7dde5b839bf/src/common/_modules/redis/main.tf#L1)
-  to provision Cache for Redis using Terraform
-- [application code](https://github.com/pagopa/io-fims/blob/f1ddfffa0f1ebcfcc79d3035c6a1bbcd931f9f2b/apps/op-app/src/web.ts#L45)
+Microsoft is transitioning towards
+[Azure Managed Redis](https://learn.microsoft.com/en-us/azure/azure-cache-for-redis/managed-redis/managed-redis-overview)
+as the recommended successor. Azure Managed Redis is built on Redis Enterprise,
+includes advanced modules (RediSearch, RedisJSON, RedisBloom, RedisTimeSeries),
+and offers active geo-replication and better performance characteristics. New
+projects should use Azure Managed Redis instead.


### PR DESCRIPTION
Update the Azure Redis documentation to reflect the transition to Azure Managed Redis as the recommended solution. Adjust the status of Azure Cache for Redis to "hold" and provide a new entry for Azure Managed Redis with its features and use cases.