### PR TITLE
Add DX knowledge base hook and update Terraform best practices skill documentation

### DIFF
--- a/apps/website/CHANGELOG.md
+++ b/apps/website/CHANGELOG.md
@@ -2,13 +2,18 @@
 
 ### 🚀 Features
 
-- Add website docs for DX Copilot plugins ([#1540](https://github.com/pagopa/dx/pull/1540))
+- Add website docs for DX Copilot plugins
+  ([#1540](https://github.com/pagopa/dx/pull/1540))
 
 ### 🩹 Fixes
 
-- Update docs with new nx-release action page ([#1486](https://github.com/pagopa/dx/pull/1486), [#1510](https://github.com/pagopa/dx/issues/1510))
-- Improve documentation for monorepositories and dx-cli init command ([#1487](https://github.com/pagopa/dx/pull/1487))
-- Align documentation for Nx Release instead of Changeset, add new page for Version Plans ([#1570](https://github.com/pagopa/dx/pull/1570))
+- Update docs with new nx-release action page
+  ([#1486](https://github.com/pagopa/dx/pull/1486),
+  [#1510](https://github.com/pagopa/dx/issues/1510))
+- Improve documentation for monorepositories and dx-cli init command
+  ([#1487](https://github.com/pagopa/dx/pull/1487))
+- Align documentation for Nx Release instead of Changeset, add new page for
+  Version Plans ([#1570](https://github.com/pagopa/dx/pull/1570))
 
 ### ❤️ Thank You
 

--- a/apps/website/docs/coding-with-ai/plugin-marketplace.md
+++ b/apps/website/docs/coding-with-ai/plugin-marketplace.md
@@ -53,7 +53,8 @@ full DX repository for documentation and module source code. When using **GitHub
 Copilot CLI** the plugin's `sessionStart` hook handles this automatically.
 
 For the **Copilot coding agent** (cloud) you need to set up a local clone of the
-DX repository in `$HOME/.dx`.
+DX repository. By default, clone it into `$HOME/.dx`; if you need to use a
+different location, set `DX_KB_PATH` to point to that clone.
 
 ## Available Plugins
 

--- a/apps/website/docs/coding-with-ai/plugin-marketplace.md
+++ b/apps/website/docs/coding-with-ai/plugin-marketplace.md
@@ -46,6 +46,15 @@ When a developer opens the project in VS Code with Copilot enabled, the
 marketplace is automatically registered. The enabled plugins appear with a
 recommendation badge in the Extensions view.
 
+## DX Knowledge Base Hook (Coding Agent)
+
+Some plugin skills (e.g., `terraform-best-practices`) need local access to the
+full DX repository for documentation and module source code. When using **GitHub
+Copilot CLI** the plugin's `sessionStart` hook handles this automatically.
+
+For the **Copilot coding agent** (cloud) you need to set up a local clone of the
+DX repository in `$HOME/.dx`.
+
 ## Available Plugins
 
 ### `terraform@pagopa-dx`

--- a/plugins/terraform/.github/plugin.json
+++ b/plugins/terraform/.github/plugin.json
@@ -9,5 +9,6 @@
   "keywords": ["cloud", "infrastructure", "iac", "terraform"],
   "skills": ["./skills"],
   "commands": ["./commands"],
+  "hooks": "hooks.json",
   "mcpServers": ".mcp.json"
 }

--- a/plugins/terraform/hooks.json
+++ b/plugins/terraform/hooks.json
@@ -1,0 +1,12 @@
+{
+  "version": 1,
+  "hooks": {
+    "sessionStart": [
+      {
+        "type": "command",
+        "bash": "./scripts/ensure-dx-kb.sh",
+        "timeoutSec": 120
+      }
+    ]
+  }
+}

--- a/plugins/terraform/scripts/ensure-dx-kb.sh
+++ b/plugins/terraform/scripts/ensure-dx-kb.sh
@@ -1,0 +1,42 @@
+#!/bin/bash
+# ensure-dx-kb.sh — Ensures the PagoPA DX knowledge base is available locally.
+#
+# Called by the sessionStart hook. Clones or updates the pagopa/dx repository
+# to $HOME/.dx so that DX skills can search documentation and module source
+# code on the local filesystem.
+
+set -euo pipefail
+
+DX_KB_PATH="${DX_KB_PATH:-$HOME/.dx}"
+DX_REPO_URL="https://github.com/pagopa/dx.git"
+
+# Read sessionStart input from stdin
+INPUT=$(cat)
+CWD=$(echo "$INPUT" | jq -r '.cwd // empty')
+
+echo "Ensuring DX knowledge base is available at $DX_KB_PATH..."
+
+# --- Case 1: CWD is the DX repo itself ---
+if [ -n "$CWD" ] && [ -d "$CWD/.git" ]; then
+  REMOTE=$(git -C "$CWD" remote get-url origin 2>/dev/null || echo "")
+  if echo "$REMOTE" | grep -q "pagopa/dx"; then
+    # Create a symlink so skills always find content at $DX_KB_PATH
+    if [ ! -e "$DX_KB_PATH" ]; then
+      ln -sf "$CWD" "$DX_KB_PATH"
+    fi
+    exit 0
+  fi
+fi
+
+# --- Case 2: Already cloned — update ---
+if [ -d "$DX_KB_PATH/.git" ]; then
+  git -C "$DX_KB_PATH" pull --ff-only 2>/dev/null || {
+    rm -rf "$DX_KB_PATH"
+    git clone --depth 1 "$DX_REPO_URL" "$DX_KB_PATH" 2>/dev/null
+  }
+  exit 0
+fi
+
+# --- Case 3: Not present — fresh clone ---
+rm -rf "$DX_KB_PATH" 2>/dev/null || true
+git clone --depth 1 "$DX_REPO_URL" "$DX_KB_PATH" 2>/dev/null

--- a/plugins/terraform/scripts/ensure-dx-kb.sh
+++ b/plugins/terraform/scripts/ensure-dx-kb.sh
@@ -10,9 +10,23 @@ set -euo pipefail
 DX_KB_PATH="${DX_KB_PATH:-$HOME/.dx}"
 DX_REPO_URL="https://github.com/pagopa/dx.git"
 
+if ! command -v git >/dev/null 2>&1; then
+  echo "Error: git is required but was not found in PATH." >&2
+  exit 1
+fi
+
 # Read sessionStart input from stdin
 INPUT=$(cat)
-CWD=$(echo "$INPUT" | jq -r '.cwd // empty')
+CWD=""
+if command -v jq >/dev/null 2>&1; then
+  CWD=$(printf '%s' "$INPUT" | jq -r '.cwd // empty' 2>/dev/null || printf '')
+fi
+
+resolve_path() {
+  (
+    cd "$1" 2>/dev/null && pwd -P
+  )
+}
 
 echo "Ensuring DX knowledge base is available at $DX_KB_PATH..."
 
@@ -20,10 +34,19 @@ echo "Ensuring DX knowledge base is available at $DX_KB_PATH..."
 if [ -n "$CWD" ] && [ -d "$CWD/.git" ]; then
   REMOTE=$(git -C "$CWD" remote get-url origin 2>/dev/null || echo "")
   if echo "$REMOTE" | grep -q "pagopa/dx"; then
-    # Create a symlink so skills always find content at $DX_KB_PATH
-    if [ ! -e "$DX_KB_PATH" ]; then
-      ln -sf "$CWD" "$DX_KB_PATH"
+    CWD_RESOLVED=$(resolve_path "$CWD")
+
+    # Ensure skills always find the current DX repo at $DX_KB_PATH
+    if [ -e "$DX_KB_PATH" ]; then
+      DX_KB_RESOLVED=$(resolve_path "$DX_KB_PATH" || true)
+      if [ "$DX_KB_RESOLVED" = "$CWD_RESOLVED" ]; then
+        exit 0
+      fi
+      rm -rf "$DX_KB_PATH"
     fi
+
+    mkdir -p "$(dirname "$DX_KB_PATH")"
+    ln -sfn "$CWD_RESOLVED" "$DX_KB_PATH"
     exit 0
   fi
 fi

--- a/plugins/terraform/scripts/ensure-dx-kb.sh
+++ b/plugins/terraform/scripts/ensure-dx-kb.sh
@@ -42,7 +42,6 @@ if [ -n "$CWD" ] && [ -d "$CWD/.git" ]; then
       if [ "$DX_KB_RESOLVED" = "$CWD_RESOLVED" ]; then
         exit 0
       fi
-      rm -rf "$DX_KB_PATH"
     fi
 
     mkdir -p "$(dirname "$DX_KB_PATH")"
@@ -54,12 +53,10 @@ fi
 # --- Case 2: Already cloned — update ---
 if [ -d "$DX_KB_PATH/.git" ]; then
   git -C "$DX_KB_PATH" pull --ff-only 2>/dev/null || {
-    rm -rf "$DX_KB_PATH"
     git clone --depth 1 "$DX_REPO_URL" "$DX_KB_PATH" 2>/dev/null
   }
   exit 0
 fi
 
 # --- Case 3: Not present — fresh clone ---
-rm -rf "$DX_KB_PATH" 2>/dev/null || true
 git clone --depth 1 "$DX_REPO_URL" "$DX_KB_PATH" 2>/dev/null

--- a/plugins/terraform/skills/terraform-best-practices/SKILL.md
+++ b/plugins/terraform/skills/terraform-best-practices/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: terraform-best-practices
-description: Generate Terraform code following PagoPA DX best practices. Use this skill EVERY TIME you write, create, edit, or modify any Terraform file. Reads DX documentation, enforces module-first usage from the pagopa-dx Registry namespace, discovers module capabilities dynamically, collects required values from the existing workspace, and validates all generated code before presenting it to the user.
+description: Generate Terraform code following PagoPA DX best practices. Use this skill EVERY TIME you write, create, edit, or modify any Terraform file or when deciding on the architecture of a new infrastructure component. This skill covers everything from module usage to code structure, configuration, security, and alignment with the DX Technology Radar.
 ---
 
 # Terraform DX Best Practices (Local)
@@ -13,16 +13,12 @@ When generating Terraform code, follow these instructions:
 
 ### 1. Locate the DX Knowledge Base
 
-The DX repository must be available locally at `$HOME/.dx`.
-This is set up automatically by the plugin's `sessionStart` hook.
-
-If `$HOME/.dx` does not exist, check that the `terraform@pagopa-dx` plugin
-is installed — it includes a hook that clones the repository on session start.
+Ensure that the `pagopa/dx` repository is available locally at `~/.dx`.
 
 ### 2. Read Local DX Documentation Files
 
 **Always read the DX Terraform documentation** before generating code.
-All markdown sources within `$HOME/.dx/apps/website/docs/terraform/` are the authoritative source for DX best practices.
+All markdown sources within `~/.dx/apps/website/docs/terraform/` are the authoritative source for DX best practices.
 
 ### 3. Search Terraform DX Modules Before Writing Any Resource
 
@@ -33,10 +29,10 @@ All markdown sources within `$HOME/.dx/apps/website/docs/terraform/` are the aut
 For each resource you intend to create, start an explorer subagent to look for a matching module and gather its details:
 
 1. **List all available DX modules** — do this once at the start:
-   - Scan the `$HOME/.dx/infra/modules/` directory — each subdirectory is a DX module. List them to build the catalogue.
+   - Scan the `~/.dx/infra/modules/` directory — each subdirectory is a DX module. List them to build the catalogue.
 2. **If a matching module exists**:
    - Read the module's `README.md` and `examples/` to understand its capabilities and usage patterns (see step 4 below).
-   - Get the module's latest version in `$HOME/.dx/infra/modules/<module>/package.json` and pin it with `~> major.minor`.
+   - Get the module's latest version in `~/.dx/infra/modules/<module>/package.json` and pin it with `~> major.minor`.
    - **Use the module instead of raw resources.**
 3. **Only use raw `azurerm_*` / `aws_*` resources** if no DX module covers that resource type.
 
@@ -50,7 +46,7 @@ Whenever the implementation involves managing sensitive values, secrets, or anyt
 
 ### 4. Discover Module Capabilities from Source, Not Just Summaries
 
-For each relevant DX module, inspect the underlying source in `$HOME/.dx/infra/modules/` so you understand what the module can really do, not just its published usage snippet.
+For each relevant DX module, inspect the underlying source in `~/.dx/infra/modules/` so you understand what the module can really do, not just its published usage snippet.
 
 Read these files when available:
 
@@ -73,7 +69,7 @@ Do **not** rely on a hardcoded list of features for a module. Discover them dyna
 
 **Before asking the user, check for values in the existing infrastructure:**
 
-1. **Determine the target folder** from `$HOME/.dx/apps/website/docs/terraform/infra-folder-structure.md` (read in step 2) based on the user's request — for example, ongoing environment resources go in `infra/resources/<env>/`, bootstrapping goes in `infra/bootstrapper/<env>/`. Then look for existing `.tf` files in that folder to extract: `prefix`, `env_short`, `location`, `domain`, `instance_number`, resource group names, subscription ID references, and existing `tags` values (BusinessUnit, ManagementTeam, CostCenter). Ask the user only if the documentation does not clarify which folder to use.
+1. **Determine the target folder** from `~/.dx/apps/website/docs/terraform/infra-folder-structure.md` (read in step 2) based on the user's request — for example, ongoing environment resources go in `infra/resources/<env>/`, bootstrapping goes in `infra/bootstrapper/<env>/`. Then look for existing `.tf` files in that folder to extract: `prefix`, `env_short`, `location`, `domain`, `instance_number`, resource group names, subscription ID references, and existing `tags` values (BusinessUnit, ManagementTeam, CostCenter). Ask the user only if the documentation does not clarify which folder to use.
 
 2. **Check for the core-values-exporter module**: If any `.tf` file in the infra already references a `pagopa-dx/<csp>-core-values-exporter/<azurerm|aws>` module (e.g., `pagopa-dx/azure-core-values-exporter/azurerm`), its outputs expose shared infrastructure values — VNet ID, VNet resource group, PEP subnet ID, and more. Reference them via `module.<name>.<output>` instead of declaring new `data` sources.
 
@@ -111,7 +107,7 @@ under `infra/resources/_modules/<service-name>/`.
 2.  Instantiate the local module from the env file (`infra/resources/<env>/main.tf` or (better) a
     dedicated `<service>.tf`) passing all required variables.
 3.  **Never create `variables.tf` in root env folders** — configuration belongs in `locals.tf`
-    (from `$HOME/.dx/apps/website/docs/terraform/code-style.md`). Pass values to the local module via `locals`.
+    (from `~/.dx/apps/website/docs/terraform/code-style.md`). Pass values to the local module via `locals`.
 
 If the user has not indicated a preference, ask:
 
@@ -268,7 +264,7 @@ If the user explicitly confirms they want to proceed, generate the code but add 
 - [ ] DX provider configured for resource naming (`pagopa-dx/azure` or `pagopa-dx/aws`)
 - [ ] `provider::dx::resource_name()` used for all resource names
 - [ ] **For every new subnet, use `dx_available_subnet_cidr` resource** to automatically allocate non-overlapping CIDR blocks
-  - Required by DX standards, see `$HOME/.dx/apps/website/docs/terraform/code-style.md`
+  - Required by DX standards, see `~/.dx/apps/website/docs/terraform/code-style.md`
   - Never manually calculate or hardcode new subnet CIDRs
 - [ ] Module versions specified using `~>` operator with major and minor versions only (e.g., `~> 1.5`)
   - Ensures compatibility while allowing patch updates
@@ -313,8 +309,8 @@ If the user explicitly confirms they want to proceed, generate the code but add 
 
 For detailed documentation, search the local DX knowledge:
 
-- `$HOME/.dx/apps/website/docs/` — DX documentation.
-- `$HOME/.dx/apps/website/docs/terraform/` - DX Terraform best practices are documented here, including folder structure, code style, module usage, and more.
-- `$HOME/.dx/infra/modules/` — source code of all DX Terraform modules, which you should read to understand their capabilities before using them.
-- `$HOME/.dx/infra/modules/<module>/README.md` and `examples/` — detailed documentation and usage examples for each DX module.
-- `$HOME/.dx/apps/website/docs/azure` — Azure-related documentation.
+- `~/.dx/apps/website/docs/` — DX documentation.
+- `~/.dx/apps/website/docs/terraform/` - DX Terraform best practices are documented here, including folder structure, code style, module usage, and more.
+- `~/.dx/infra/modules/` — source code of all DX Terraform modules, which you should read to understand their capabilities before using them.
+- `~/.dx/infra/modules/<module>/README.md` and `examples/` — detailed documentation and usage examples for each DX module.
+- `~/.dx/apps/website/docs/azure` — Azure-related documentation.

--- a/plugins/terraform/skills/terraform-best-practices/SKILL.md
+++ b/plugins/terraform/skills/terraform-best-practices/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: terraform-best-practices
-description: Generate Terraform code following PagoPA DX best practices. Reads DX documentation, enforces module-first usage from the pagopa-dx Registry namespace, discovers module capabilities dynamically, collects required values from the existing workspace, and validates all generated code before presenting it to the user.
+description: Generate Terraform code following PagoPA DX best practices. Use this skill EVERY TIME you write, create, edit, or modify any Terraform file. Reads DX documentation, enforces module-first usage from the pagopa-dx Registry namespace, discovers module capabilities dynamically, collects required values from the existing workspace, and validates all generated code before presenting it to the user.
 ---
 
 # Terraform DX Best Practices (Local)
@@ -11,23 +11,18 @@ When generating Terraform code, follow these instructions:
 
 > **⚡ Parallelism**: Steps 2 (read DX docs), 3 (search modules), and 12 (fetch Technology Radar) are fully independent. **Launch them in parallel using subagents** whenever possible — do not wait for one to finish before starting the next. Merge all results before proceeding to code generation.
 
-### 1. Clone the DX Repository locally
+### 1. Locate the DX Knowledge Base
 
-Clone `https://github.com/pagopa/dx` into the current working directory
-or pull it to ensure the documentation is up to date:
+The DX repository must be available locally at `$HOME/.dx`.
+This is set up automatically by the plugin's `sessionStart` hook.
 
-```bash
-if [ ! -d ".dx" ]; then
-  git clone --depth 1 https://github.com/pagopa/dx ".dx"
-else
-  git -C ".dx" pull --ff-only
-fi
-```
+If `$HOME/.dx` does not exist, check that the `terraform@pagopa-dx` plugin
+is installed — it includes a hook that clones the repository on session start.
 
 ### 2. Read Local DX Documentation Files
 
 **Always read the DX Terraform documentation** before generating code.
-All markdown sources within `.dx/apps/website/docs/terraform/` are the authoritative source for DX best practices.
+All markdown sources within `$HOME/.dx/apps/website/docs/terraform/` are the authoritative source for DX best practices.
 
 ### 3. Search Terraform DX Modules Before Writing Any Resource
 
@@ -38,10 +33,10 @@ All markdown sources within `.dx/apps/website/docs/terraform/` are the authorita
 For each resource you intend to create, start an explorer subagent to look for a matching module and gather its details:
 
 1. **List all available DX modules** — do this once at the start:
-   - Scan the `.dx/infra/modules/` directory — each subdirectory is a DX module. List them to build the catalogue.
+   - Scan the `$HOME/.dx/infra/modules/` directory — each subdirectory is a DX module. List them to build the catalogue.
 2. **If a matching module exists**:
    - Read the module's `README.md` and `examples/` to understand its capabilities and usage patterns (see step 4 below).
-   - Get the module's latest version in `.dx/infra/modules/<module>/package.json` and pin it with `~> major.minor`.
+   - Get the module's latest version in `$HOME/.dx/infra/modules/<module>/package.json` and pin it with `~> major.minor`.
    - **Use the module instead of raw resources.**
 3. **Only use raw `azurerm_*` / `aws_*` resources** if no DX module covers that resource type.
 
@@ -55,7 +50,7 @@ Whenever the implementation involves managing sensitive values, secrets, or anyt
 
 ### 4. Discover Module Capabilities from Source, Not Just Summaries
 
-For each relevant DX module, inspect the underlying source in `.dx/infra/modules/` so you understand what the module can really do, not just its published usage snippet.
+For each relevant DX module, inspect the underlying source in `$HOME/.dx/infra/modules/` so you understand what the module can really do, not just its published usage snippet.
 
 Read these files when available:
 
@@ -78,7 +73,7 @@ Do **not** rely on a hardcoded list of features for a module. Discover them dyna
 
 **Before asking the user, check for values in the existing infrastructure:**
 
-1. **Determine the target folder** from `.dx/apps/website/docs/terraform/infra-folder-structure.md` (read in step 2) based on the user's request — for example, ongoing environment resources go in `infra/resources/<env>/`, bootstrapping goes in `infra/bootstrapper/<env>/`. Then look for existing `.tf` files in that folder to extract: `prefix`, `env_short`, `location`, `domain`, `instance_number`, resource group names, subscription ID references, and existing `tags` values (BusinessUnit, ManagementTeam, CostCenter). Ask the user only if the documentation does not clarify which folder to use.
+1. **Determine the target folder** from `$HOME/.dx/apps/website/docs/terraform/infra-folder-structure.md` (read in step 2) based on the user's request — for example, ongoing environment resources go in `infra/resources/<env>/`, bootstrapping goes in `infra/bootstrapper/<env>/`. Then look for existing `.tf` files in that folder to extract: `prefix`, `env_short`, `location`, `domain`, `instance_number`, resource group names, subscription ID references, and existing `tags` values (BusinessUnit, ManagementTeam, CostCenter). Ask the user only if the documentation does not clarify which folder to use.
 
 2. **Check for the core-values-exporter module**: If any `.tf` file in the infra already references a `pagopa-dx/<csp>-core-values-exporter/<azurerm|aws>` module (e.g., `pagopa-dx/azure-core-values-exporter/azurerm`), its outputs expose shared infrastructure values — VNet ID, VNet resource group, PEP subnet ID, and more. Reference them via `module.<name>.<output>` instead of declaring new `data` sources.
 
@@ -116,7 +111,7 @@ under `infra/resources/_modules/<service-name>/`.
 2.  Instantiate the local module from the env file (`infra/resources/<env>/main.tf` or (better) a
     dedicated `<service>.tf`) passing all required variables.
 3.  **Never create `variables.tf` in root env folders** — configuration belongs in `locals.tf`
-    (from `.dx/apps/website/docs/terraform/code-style.md`). Pass values to the local module via `locals`.
+    (from `$HOME/.dx/apps/website/docs/terraform/code-style.md`). Pass values to the local module via `locals`.
 
 If the user has not indicated a preference, ask:
 
@@ -273,7 +268,7 @@ If the user explicitly confirms they want to proceed, generate the code but add 
 - [ ] DX provider configured for resource naming (`pagopa-dx/azure` or `pagopa-dx/aws`)
 - [ ] `provider::dx::resource_name()` used for all resource names
 - [ ] **For every new subnet, use `dx_available_subnet_cidr` resource** to automatically allocate non-overlapping CIDR blocks
-  - Required by DX standards, see `.dx/apps/website/docs/terraform/code-style.md`
+  - Required by DX standards, see `$HOME/.dx/apps/website/docs/terraform/code-style.md`
   - Never manually calculate or hardcode new subnet CIDRs
 - [ ] Module versions specified using `~>` operator with major and minor versions only (e.g., `~> 1.5`)
   - Ensures compatibility while allowing patch updates
@@ -318,8 +313,8 @@ If the user explicitly confirms they want to proceed, generate the code but add 
 
 For detailed documentation, search the local DX knowledge:
 
-- `.dx/apps/website/docs/` — DX documentation.
-- `.dx/apps/website/docs/terraform/` - DX Terraform best practices are documented here, including folder structure, code style, module usage, and more.
-- `.dx/infra/modules/` — source code of all DX Terraform modules, which you should read to understand their capabilities before using them.
-- `.dx/infra/modules/<module>/README.md` and `examples/` — detailed documentation and usage examples for each DX module.
-- `.dx/apps/website/docs/azure` — Azure-related documentation.
+- `$HOME/.dx/apps/website/docs/` — DX documentation.
+- `$HOME/.dx/apps/website/docs/terraform/` - DX Terraform best practices are documented here, including folder structure, code style, module usage, and more.
+- `$HOME/.dx/infra/modules/` — source code of all DX Terraform modules, which you should read to understand their capabilities before using them.
+- `$HOME/.dx/infra/modules/<module>/README.md` and `examples/` — detailed documentation and usage examples for each DX module.
+- `$HOME/.dx/apps/website/docs/azure` — Azure-related documentation.


### PR DESCRIPTION
Introduce a hook that ensures the DX knowledge base is available locally for Terraform skills. Update the Terraform best practices documentation to reflect the new setup process and emphasize the importance of using the local DX repository.

Why this? Currently, the DX terraform skill contains instructions to clone the DX repository locally in order to provide the DX knowledge base to the coding agent (e.g,. Copilot) when generating code. This PR moves this step into a deterministic hook which works when using the Copilot CLI.

