### PR TITLE
Fix cdn apex multiple custom domain with same kv

### DIFF
--- a/.nx/version-plans/version-plan-1775634967842.md
+++ b/.nx/version-plans/version-plan-1775634967842.md
@@ -1,0 +1,5 @@
+---
+azure_cdn: patch
+---
+
+Fix duplicate key error in `azurerm_key_vault` data source when multiple apex custom domains share the same Key Vault. The `for_each` expression now uses grouping (`...`) to deduplicate entries by Key Vault.

--- a/infra/modules/azure_cdn/CHANGELOG.md
+++ b/infra/modules/azure_cdn/CHANGELOG.md
@@ -4,6 +4,10 @@
 
 - ce19de2: Add variable to manage origin group health probe configuration
 
+### Patch Changes
+
+- Fix duplicate key vault error when multiple apex domains share the same Key Vault by constructing Key Vault IDs programmatically instead of using a data source. This eliminates unnecessary Azure API calls and simplifies the module.
+
 ## 0.5.2
 
 ### Patch Changes

--- a/infra/modules/azure_cdn/README.md
+++ b/infra/modules/azure_cdn/README.md
@@ -164,7 +164,6 @@ No modules.
 | [azurerm_role_assignment.this](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/role_assignment) | resource |
 | [azurerm_cdn_frontdoor_profile.existing](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/data-sources/cdn_frontdoor_profile) | data source |
 | [azurerm_client_config.current](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/data-sources/client_config) | data source |
-| [azurerm_key_vault.this](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/data-sources/key_vault) | data source |
 
 ## Inputs
 

--- a/infra/modules/azure_cdn/custom_domain.tf
+++ b/infra/modules/azure_cdn/custom_domain.tf
@@ -45,23 +45,13 @@ resource "azurerm_cdn_frontdoor_custom_domain_association" "this" {
   cdn_frontdoor_route_ids        = [azurerm_cdn_frontdoor_route.this.id]
 }
 
-# Data source for key vaults - using composite key to ensure uniqueness
-data "azurerm_key_vault" "this" {
-  for_each = { for custom_domain in var.custom_domains :
-    "${custom_domain.custom_certificate.key_vault_name}:${custom_domain.custom_certificate.key_vault_resource_group_name}" => custom_domain...
-  if lookup(local.is_apex, custom_domain.host_name, false) }
-
-  name                = each.value[0].custom_certificate.key_vault_name
-  resource_group_name = each.value[0].custom_certificate.key_vault_resource_group_name
-}
-
 # Create role assignments for the Front Door's managed identity to access
 # the Key Vault that support RBAC - only once per key vault
 resource "azurerm_role_assignment" "this" {
   for_each = { for k, v in local.unique_key_vaults_rbac : k => v[0] }
 
   description          = "Role assignment for Front Door's managed identity to access the customer certificate in Key Vault"
-  scope                = data.azurerm_key_vault.this[each.key].id
+  scope                = local.key_vault_ids[each.key]
   role_definition_name = "Key Vault Secret User"
   principal_id         = local.profile_identity_id
 }
@@ -71,7 +61,7 @@ resource "azurerm_role_assignment" "this" {
 resource "azurerm_key_vault_access_policy" "this" {
   for_each = { for k, v in local.unique_key_vaults_no_rbac : k => v[0] }
 
-  key_vault_id = data.azurerm_key_vault.this[each.key].id
+  key_vault_id = local.key_vault_ids[each.key]
   tenant_id    = data.azurerm_client_config.current.tenant_id
   object_id    = local.profile_identity_id
 

--- a/infra/modules/azure_cdn/custom_domain.tf
+++ b/infra/modules/azure_cdn/custom_domain.tf
@@ -48,11 +48,11 @@ resource "azurerm_cdn_frontdoor_custom_domain_association" "this" {
 # Data source for key vaults - using composite key to ensure uniqueness
 data "azurerm_key_vault" "this" {
   for_each = { for custom_domain in var.custom_domains :
-    "${custom_domain.custom_certificate.key_vault_name}:${custom_domain.custom_certificate.key_vault_resource_group_name}" => custom_domain
+    "${custom_domain.custom_certificate.key_vault_name}:${custom_domain.custom_certificate.key_vault_resource_group_name}" => custom_domain...
   if lookup(local.is_apex, custom_domain.host_name, false) }
 
-  name                = each.value.custom_certificate.key_vault_name
-  resource_group_name = each.value.custom_certificate.key_vault_resource_group_name
+  name                = each.value[0].custom_certificate.key_vault_name
+  resource_group_name = each.value[0].custom_certificate.key_vault_resource_group_name
 }
 
 # Create role assignments for the Front Door's managed identity to access

--- a/infra/modules/azure_cdn/locals.tf
+++ b/infra/modules/azure_cdn/locals.tf
@@ -43,4 +43,17 @@ locals {
 
   # Check if existing Profile SKU is compatible with WAF
   compatible_sku = var.existing_cdn_frontdoor_profile_id != null ? data.azurerm_cdn_frontdoor_profile.existing[0].sku_name == "Standard_AzureFrontDoor" : true
+
+  # Construct Key Vault IDs from subscription ID and resource details
+  key_vault_ids = {
+    for k, v in merge(local.unique_key_vaults_rbac, local.unique_key_vaults_no_rbac) :
+    k => provider::azurerm::normalise_resource_id(
+      format(
+        "/subscriptions/%s/resourceGroups/%s/providers/Microsoft.KeyVault/vaults/%s",
+        data.azurerm_client_config.current.subscription_id,
+        v[0].custom_certificate.key_vault_resource_group_name,
+        v[0].custom_certificate.key_vault_name
+      )
+    )
+  }
 }

--- a/infra/modules/azure_cdn/tests/unit.tftest.hcl
+++ b/infra/modules/azure_cdn/tests/unit.tftest.hcl
@@ -542,3 +542,65 @@ run "cdn_route_without_custom_domains" {
     error_message = "Route must not link custom domains when none are provided"
   }
 }
+
+run "cdn_apex_domains_shared_key_vault" {
+  command = plan
+
+  override_data {
+    target = data.azurerm_key_vault.this
+    values = {
+      id = "/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/rg-sec/providers/Microsoft.KeyVault/vaults/shared-kv"
+    }
+  }
+
+  variables {
+    custom_domains = [
+      {
+        host_name = "devex.pagopa.it"
+        dns = {
+          zone_name                = "devex.pagopa.it"
+          zone_resource_group_name = "rg-test"
+        }
+        custom_certificate = {
+          key_vault_certificate_versionless_id = "https://shared-kv.vault.azure.net/certificates/cert1"
+          key_vault_name                       = "shared-kv"
+          key_vault_resource_group_name        = "rg-sec"
+          key_vault_has_rbac_support           = true
+        }
+      },
+      {
+        host_name = "other.pagopa.it"
+        dns = {
+          zone_name                = "other.pagopa.it"
+          zone_resource_group_name = "rg-test"
+        }
+        custom_certificate = {
+          key_vault_certificate_versionless_id = "https://shared-kv.vault.azure.net/certificates/cert2"
+          key_vault_name                       = "shared-kv"
+          key_vault_resource_group_name        = "rg-sec"
+          key_vault_has_rbac_support           = true
+        }
+      }
+    ]
+  }
+
+  assert {
+    condition     = length(data.azurerm_key_vault.this) == 1
+    error_message = "Expected exactly one Key Vault data source when two apex domains share the same Key Vault"
+  }
+
+  assert {
+    condition     = length(azurerm_cdn_frontdoor_custom_domain.this) == 2
+    error_message = "Expected two custom domains to be created"
+  }
+
+  assert {
+    condition     = length(azurerm_cdn_frontdoor_secret.certificate) == 2
+    error_message = "Expected two Front Door secrets, one per apex domain"
+  }
+
+  assert {
+    condition     = length(azurerm_role_assignment.this) == 1
+    error_message = "Expected exactly one role assignment for the shared Key Vault"
+  }
+}

--- a/infra/modules/azure_cdn/tests/unit.tftest.hcl
+++ b/infra/modules/azure_cdn/tests/unit.tftest.hcl
@@ -546,13 +546,6 @@ run "cdn_route_without_custom_domains" {
 run "cdn_apex_domains_shared_key_vault" {
   command = plan
 
-  override_data {
-    target = data.azurerm_key_vault.this
-    values = {
-      id = "/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/rg-sec/providers/Microsoft.KeyVault/vaults/shared-kv"
-    }
-  }
-
   variables {
     custom_domains = [
       {
@@ -582,11 +575,6 @@ run "cdn_apex_domains_shared_key_vault" {
         }
       }
     ]
-  }
-
-  assert {
-    condition     = length(data.azurerm_key_vault.this) == 1
-    error_message = "Expected exactly one Key Vault data source when two apex domains share the same Key Vault"
   }
 
   assert {


### PR DESCRIPTION
Fix "Duplicate object key" error when multiple apex custom domains use the same Key Vault.

The azurerm_key_vault data source now uses grouping syntax (...) to deduplicate 
entries by Key Vault. This allows multiple apex domains to safely share a Key Vault 
while creating only one data source instance.