### PR TITLE
Handle pre-initialized remote repository in init command

### DIFF
--- a/.nx/version-plans/version-plan-1775642853734.md
+++ b/.nx/version-plans/version-plan-1775642853734.md
@@ -1,0 +1,9 @@
+---
+'@pagopa/dx-cli': patch
+---
+
+Update the `init` command git flow to handle repositories that are pre-initialized by Terraform (`auto_init`).
+
+Previously the CLI would push an initial commit directly to `main` and then create a feature branch — this fails when the remote already exists with a `main` branch.
+
+The new flow connects to the existing remote, fetches the current state, and creates the feature branch from `origin/main` without checking out remote files (preserving locally generated files). The PR is then opened against `main` as usual.

--- a/apps/cli/src/adapters/commander/commands/init.ts
+++ b/apps/cli/src/adapters/commander/commands/init.ts
@@ -161,9 +161,9 @@ const initializeGitRepository = (repository: Repository) => {
     await git$`git remote add origin ${repository.origin}`;
     await git$`git fetch origin main`;
     await git$`git checkout -b ${branchName}`;
-    // Ignore any changes on the origin/main branch.
-    // Terraform will create the main branch with an initial commit containing the README file,
-    // but we want to replace it with the scaffolded code from the generator.
+    // Terraform creates `main` with an initial README commit.
+    // Reset to `origin/main` so this branch is based on the remote default branch,
+    // while keeping the scaffolded local files in the working tree for a clean PR diff.
     await git$`git reset origin/main`;
     await git$`git add .`;
     await git$`git commit --no-gpg-sign -m "Scaffold workspace"`;

--- a/apps/cli/src/adapters/commander/commands/init.ts
+++ b/apps/cli/src/adapters/commander/commands/init.ts
@@ -158,12 +158,13 @@ const initializeGitRepository = (repository: Repository) => {
   });
   const pushToOrigin = async () => {
     await git$`git init`;
-    await git$`git add README.md`;
-    await git$`git commit --no-gpg-sign -m "Create README.md"`;
-    await git$`git branch -M main`;
     await git$`git remote add origin ${repository.origin}`;
-    await git$`git push -u origin main`;
-    await git$`git switch -c ${branchName}`;
+    await git$`git fetch origin main`;
+    await git$`git checkout -b ${branchName}`;
+    // Ignore any changes on the origin/main branch.
+    // Terraform will create the main branch with an initial commit containing the README file,
+    // but we want to replace it with the scaffolded code from the generator.
+    await git$`git reset origin/main`;
     await git$`git add .`;
     await git$`git commit --no-gpg-sign -m "Scaffold workspace"`;
     await git$`git push -u origin ${branchName}`;


### PR DESCRIPTION
The `init` command previously pushed an initial commit directly to `main` before creating the scaffold feature branch. This fails when the remote repository is already initialized by Terraform (`auto_init`), which creates `main` with a minimal README automatically.

The new git flow:
1. Connects to the existing remote
2. Fetches the current state from `origin`
3. Creates the feature branch pointing at `origin/main`'s commit — without checking out remote files, preserving all locally generated files
4. Commits all scaffold files (with `origin/main` as parent for a clean PR diff)
5. Pushes the feature branch and opens a PR against `main`

Depends on #1574 
Closes CES-1901