### PR TITLE
DX MCP server security fixes

### DIFF
--- a/.nx/version-plans/version-plan-1775742122765.md
+++ b/.nx/version-plans/version-plan-1775742122765.md
@@ -1,0 +1,5 @@
+---
+'@pagopa/dx-mcpserver': minor
+---
+
+Implement a generation configuration prompt to reduce the scope of requests that a user can submit to the bedrock knowledge base

--- a/apps/mcpserver/src/services/bedrock-retrieve-and-generate.ts
+++ b/apps/mcpserver/src/services/bedrock-retrieve-and-generate.ts
@@ -55,13 +55,13 @@ export async function retrieveAndGenerate(
       },
       retrieveAndGenerateConfiguration: {
         knowledgeBaseConfiguration: {
-          knowledgeBaseId,
-          modelArn,
           generationConfiguration: {
             promptTemplate: {
               textPromptTemplate: SCOPED_PROMPT_TEMPLATE,
             },
           },
+          knowledgeBaseId,
+          modelArn,
           retrievalConfiguration: {
             vectorSearchConfiguration: {
               numberOfResults,

--- a/apps/mcpserver/src/services/bedrock-retrieve-and-generate.ts
+++ b/apps/mcpserver/src/services/bedrock-retrieve-and-generate.ts
@@ -6,8 +6,31 @@ import {
 import { getLogger } from "@logtape/logtape";
 
 /**
+ * Restricts the model to answer only from the retrieved KB documents.
+ * Must include $search_results$ for Bedrock to inject retrieved content.
+ * If the query is off-topic or no relevant docs are found, the model is
+ * instructed to decline rather than fall back to general knowledge.
+ */
+const SCOPED_PROMPT_TEMPLATE = `You are a documentation assistant for PagoPA DX (Developer Experience).
+Your sole purpose is to answer questions about PagoPA DX tools, infrastructure patterns, GitHub workflows, Terraform modules, and developer best practices.
+
+Rules you must always follow:
+1. Answer ONLY using the information in the search results below. Never use external or general knowledge.
+2. If the search results do not contain enough information to answer, respond: "I don't have information about this topic in the PagoPA DX knowledge base."
+3. If the question is unrelated to PagoPA DX (e.g. general trivia, unrelated technologies, off-topic subjects), respond: "This question is outside the scope of the PagoPA DX documentation. I can only help with PagoPA DX tools, infrastructure, and developer workflows."
+4. Never answer questions about unrelated topics, even if you have general knowledge about them.
+
+Search results from the PagoPA DX knowledge base:
+$search_results$
+
+$output_format_instructions$`;
+
+/**
  * Calls Bedrock RetrieveAndGenerate API to get an AI-generated answer
  * based on documents from a knowledge base.
+ *
+ * A scoped prompt template is applied so the model is constrained to answer
+ * only from the retrieved KB documents, refusing off-topic queries.
  *
  * @param knowledgeBaseId The ID of the knowledge base to query
  * @param modelArn The ARN of the Bedrock model to use for generation
@@ -34,6 +57,11 @@ export async function retrieveAndGenerate(
         knowledgeBaseConfiguration: {
           knowledgeBaseId,
           modelArn,
+          generationConfiguration: {
+            promptTemplate: {
+              textPromptTemplate: SCOPED_PROMPT_TEMPLATE,
+            },
+          },
           retrievalConfiguration: {
             vectorSearchConfiguration: {
               numberOfResults,

--- a/infra/core/dev/README.md
+++ b/infra/core/dev/README.md
@@ -15,6 +15,7 @@
 
 | Name | Version |
 |------|---------|
+| <a name="provider_aws"></a> [aws](#provider\_aws) | 0.1.4 |
 | <a name="provider_azuread"></a> [azuread](#provider\_azuread) | 2.53.1 |
 | <a name="provider_azurerm"></a> [azurerm](#provider\_azurerm) | 4.61.0 |
 
@@ -30,6 +31,7 @@
 
 | Name | Type |
 |------|------|
+| [aws_budgets_budget.monthly_budget](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/budgets_budget) | resource |
 | [azurerm_dns_caa_record.dev_dx_pagopa_it](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/dns_caa_record) | resource |
 | [azurerm_dns_zone.dev_dx_pagopa_it](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/dns_zone) | resource |
 | [azurerm_resource_group.stategraph](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/resource_group) | resource |

--- a/infra/core/dev/main.tf
+++ b/infra/core/dev/main.tf
@@ -23,3 +23,39 @@ module "aws" {
 
   tags = local.tags
 }
+
+resource "aws_budgets_budget" "monthly_budget" {
+  name         = "monthly-budget"
+  budget_type  = "COST"
+  limit_amount = "50"
+  limit_unit   = "USD"
+  time_unit    = "MONTHLY"
+
+  cost_types {
+    include_tax = true
+  }
+
+  notification {
+    comparison_operator        = "GREATER_THAN"
+    threshold                  = 50
+    threshold_type             = "PERCENTAGE"
+    notification_type          = "ACTUAL"
+    subscriber_email_addresses = ["team-devex+aws${local.tags.Environment}@pagopa.it"]
+  }
+
+  notification {
+    comparison_operator        = "GREATER_THAN"
+    threshold                  = 75
+    threshold_type             = "PERCENTAGE"
+    notification_type          = "ACTUAL"
+    subscriber_email_addresses = ["team-devex+aws${local.tags.Environment}@pagopa.it"]
+  }
+
+  notification {
+    comparison_operator        = "GREATER_THAN"
+    threshold                  = 100
+    threshold_type             = "PERCENTAGE"
+    notification_type          = "FORECASTED"
+    subscriber_email_addresses = ["team-devex+aws${local.tags.Environment}@pagopa.it"]
+  }
+}

--- a/infra/core/prod/README.md
+++ b/infra/core/prod/README.md
@@ -15,6 +15,7 @@
 
 | Name | Version |
 |------|---------|
+| <a name="provider_aws"></a> [aws](#provider\_aws) | 0.1.4 |
 | <a name="provider_azurerm"></a> [azurerm](#provider\_azurerm) | 4.64.0 |
 
 ## Modules
@@ -28,6 +29,7 @@
 
 | Name | Type |
 |------|------|
+| [aws_budgets_budget.monthly_budget](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/budgets_budget) | resource |
 | [azurerm_dns_caa_record.dx_pagopa_it](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/dns_caa_record) | resource |
 | [azurerm_dns_ns_record.dev_dx_pagopa_it](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/dns_ns_record) | resource |
 | [azurerm_dns_ns_record.e2e_dx_pagopa_it](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/dns_ns_record) | resource |

--- a/infra/core/prod/main.tf
+++ b/infra/core/prod/main.tf
@@ -23,3 +23,39 @@ module "aws" {
 
   tags = local.tags
 }
+
+resource "aws_budgets_budget" "monthly_budget" {
+  name         = "monthly-budget"
+  budget_type  = "COST"
+  limit_amount = "50"
+  limit_unit   = "USD"
+  time_unit    = "MONTHLY"
+
+  cost_types {
+    include_tax = true
+  }
+
+  notification {
+    comparison_operator        = "GREATER_THAN"
+    threshold                  = 50
+    threshold_type             = "PERCENTAGE"
+    notification_type          = "ACTUAL"
+    subscriber_email_addresses = ["team-devex+aws${local.tags.Environment}@pagopa.it"]
+  }
+
+  notification {
+    comparison_operator        = "GREATER_THAN"
+    threshold                  = 75
+    threshold_type             = "PERCENTAGE"
+    notification_type          = "ACTUAL"
+    subscriber_email_addresses = ["team-devex+aws${local.tags.Environment}@pagopa.it"]
+  }
+
+  notification {
+    comparison_operator        = "GREATER_THAN"
+    threshold                  = 100
+    threshold_type             = "PERCENTAGE"
+    notification_type          = "FORECASTED"
+    subscriber_email_addresses = ["team-devex+aws${local.tags.Environment}@pagopa.it"]
+  }
+}

--- a/infra/core/prod/tfmodules.lock.json
+++ b/infra/core/prod/tfmodules.lock.json
@@ -1,9 +1,9 @@
 {
   "azure": {
-    "hash": "cab706c6fd12e6c7f4950223fd72b83570d6c9e96eb1144f2173eaf8cbc33c55",
-    "version": "3.0.0",
+    "hash": "e2238e2d749dc53e6a1426917e34df1160e3d29c74ceb7105b6674ae514352ab",
+    "version": "3.1.1",
     "name": "azure_core_infra",
-    "source": "https://registry.terraform.io/modules/pagopa-dx/azure-core-infra/azurerm/3.0.0"
+    "source": "https://registry.terraform.io/modules/pagopa-dx/azure-core-infra/azurerm/3.1.1"
   },
   "aws": {
     "hash": "02fc245d89d345cb8cc012bc2c4eeca51b6ecca1b436f030b1bc2aec0c2d8746",

--- a/infra/core/uat/README.md
+++ b/infra/core/uat/README.md
@@ -14,6 +14,7 @@
 
 | Name | Version |
 |------|---------|
+| <a name="provider_aws"></a> [aws](#provider\_aws) | 0.1.3 |
 | <a name="provider_azurerm"></a> [azurerm](#provider\_azurerm) | 4.55.0 |
 
 ## Modules
@@ -27,6 +28,7 @@
 
 | Name | Type |
 |------|------|
+| [aws_budgets_budget.monthly_budget](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/budgets_budget) | resource |
 | [azurerm_dns_caa_record.uat_dx_pagopa_it](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/dns_caa_record) | resource |
 | [azurerm_dns_zone.uat_dx_pagopa_it](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/dns_zone) | resource |
 

--- a/infra/core/uat/main.tf
+++ b/infra/core/uat/main.tf
@@ -23,3 +23,39 @@ module "aws" {
 
   tags = local.tags
 }
+
+resource "aws_budgets_budget" "monthly_budget" {
+  name         = "monthly-budget"
+  budget_type  = "COST"
+  limit_amount = "50"
+  limit_unit   = "USD"
+  time_unit    = "MONTHLY"
+
+  cost_types {
+    include_tax = true
+  }
+
+  notification {
+    comparison_operator        = "GREATER_THAN"
+    threshold                  = 50
+    threshold_type             = "PERCENTAGE"
+    notification_type          = "ACTUAL"
+    subscriber_email_addresses = ["team-devex+aws${local.tags.Environment}@pagopa.it"]
+  }
+
+  notification {
+    comparison_operator        = "GREATER_THAN"
+    threshold                  = 75
+    threshold_type             = "PERCENTAGE"
+    notification_type          = "ACTUAL"
+    subscriber_email_addresses = ["team-devex+aws${local.tags.Environment}@pagopa.it"]
+  }
+
+  notification {
+    comparison_operator        = "GREATER_THAN"
+    threshold                  = 100
+    threshold_type             = "PERCENTAGE"
+    notification_type          = "FORECASTED"
+    subscriber_email_addresses = ["team-devex+aws${local.tags.Environment}@pagopa.it"]
+  }
+}

--- a/infra/core/uat/tfmodules.lock.json
+++ b/infra/core/uat/tfmodules.lock.json
@@ -6,9 +6,9 @@
     "source": "https://registry.terraform.io/modules/pagopa-dx/aws-core-infra/aws/0.0.5"
   },
   "azure": {
-    "hash": "cab706c6fd12e6c7f4950223fd72b83570d6c9e96eb1144f2173eaf8cbc33c55",
-    "version": "3.0.0",
+    "hash": "e2238e2d749dc53e6a1426917e34df1160e3d29c74ceb7105b6674ae514352ab",
+    "version": "3.1.1",
     "name": "azure_core_infra",
-    "source": "https://registry.terraform.io/modules/pagopa-dx/azure-core-infra/azurerm/3.0.0"
+    "source": "https://registry.terraform.io/modules/pagopa-dx/azure-core-infra/azurerm/3.1.1"
   }
 }


### PR DESCRIPTION
A generation prompt has been added when invoking the retrieve and generate bedrock API. This will limit the scope of prompts the mcp server will respond to.
Moreover, AWS budget notifications have been introduced.