### PR TITLE
Update fp-ts status to hold with deprecation rationale

### DIFF
--- a/.nx/version-plans/version-plan-1775753944939.md
+++ b/.nx/version-plans/version-plan-1775753944939.md
@@ -1,0 +1,5 @@
+---
+docs: minor
+---
+
+Move fp-ts entry in Tech Radar to hold, and add deprecation rationale.

--- a/apps/website/radar-docs/fp-ts.md
+++ b/apps/website/radar-docs/fp-ts.md
@@ -8,15 +8,15 @@ The [fp-ts](https://gcanti.github.io/fp-ts/) library brings functional
 programming concepts to TypeScript. It helped us model errors explicitly,
 compose asynchronous flows, and write more declarative business logic.
 
-## Deprecation rationale
+## Why we put fp-ts on hold
 
 After evaluating it thoroughly in real projects, we are now putting fp-ts on
 hold. While the library gave us real benefits, we also found important drawbacks
 that now outweigh those advantages for our context.
 
 The main showstopper is that fp-ts is no longer actively maintained. This
-creates a concrete risk that it may not keep working with future TypeScript
-versions, especially with TypeScript >= 6.
+creates a concrete risk that it may not keep working with future major
+TypeScript versions.
 
 On top of that, fp-ts has a steep learning curve and relies on jargon and
 abstractions that are not familiar to many developers. This makes onboarding

--- a/apps/website/radar-docs/fp-ts.md
+++ b/apps/website/radar-docs/fp-ts.md
@@ -1,37 +1,24 @@
 ---
 title: "fp-ts"
-ring: trial
+ring: hold
 tags: [typescript, library]
 ---
 
-The [fp-ts](https://gcanti.github.io/fp-ts/) is a powerful library that brings
-functional programming concepts to TypeScript development. It provides a set of
-functional programming abstractions and utilities for building robust and
-type-safe applications. Leveraging algebraic data types, type classes, and
-immutable data structures, fp-ts enables developers to write functional,
-expressive, and statically-typed code in TypeScript.
+The [fp-ts](https://gcanti.github.io/fp-ts/) library brings functional
+programming concepts to TypeScript. It helped us model errors explicitly,
+compose asynchronous flows, and write more declarative business logic.
 
-## Use cases
+## Deprecation rationale
 
-- Error Handling: Replace error-prone checks and exceptions with structured
-  error handling using `Either` and `Option`.
-- Asynchronous Programming: Manage asynchronous operations using `Task` and
-  `TaskEither` monads in a composable and predictable way.
-- Expressive Business Logic: Simplify and clarify core application logic using
-  functional abstractions like function composition and pipe.
-- Pure Side Effect: Represent side effects with the `IO` monad to keep the code
-  pure and free of hidden side effect.
-- Dependency Injection: Manage connections between different parts of the code
-  with the `Reader` monad, promoting modularity and testability.
+After evaluating it thoroughly in real projects, we are now putting fp-ts on
+hold. While the library gave us real benefits, we also found important drawbacks
+that now outweigh those advantages for our context.
 
-## Reference of usage in our organization
+The main showstopper is that fp-ts is no longer actively maintained. This
+creates a concrete risk that it may not keep working with future TypeScript
+versions, especially with TypeScript >= 6.
 
-There are
-[many projects](https://github.com/search?q=org%3Apagopa+path%3A**%2Fpackage.json+%22%5C%22fp-ts%5C%22%22+&type=code)
-using fp-ts.
-
-## Resources
-
-- [Learning resources](https://gcanti.github.io/fp-ts/learning-resources/)
-- [fp-ts Training Material](https://github.com/inato/fp-ts-training)
-- [fp-ts Tutorial Series on YouTube](https://www.youtube.com/playlist?list=PLUMXrUa_EuePN94nJ2hAui5nWDj8RO3lH)
+On top of that, fp-ts has a steep learning curve and relies on jargon and
+abstractions that are not familiar to many developers. This makes onboarding
+harder, slows down day-to-day development, and negatively impacts both
+productivity and developer experience.


### PR DESCRIPTION
Change the status of fp-ts in the Tech Radar to hold and provide a rationale for its deprecation, highlighting the lack of maintenance and challenges in onboarding and productivity.

Close CES-1919