### PR TITLE
Use correct version in package.json for dx-metrics

### DIFF
--- a/apps/dx-metrics/package.json
+++ b/apps/dx-metrics/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dx-metrics",
-  "version": "0.4.1",
+  "version": "0.5.0",
   "private": true,
   "type": "module",
   "nx": {


### PR DESCRIPTION
This PR fixes a typo where an accidental downgrade was made in the package.json in a previous PR