### PR TITLE
Add AD group management to authorization workflow

### DIFF
--- a/.nx/version-plans/version-plan-17760680773N.md
+++ b/.nx/version-plans/version-plan-17760680773N.md
@@ -1,0 +1,5 @@
+---
+'@pagopa/dx-cli': patch
+---
+
+Add AD group management to the authorization workflow

--- a/apps/cli/src/adapters/commander/commands/__tests__/add.test.ts
+++ b/apps/cli/src/adapters/commander/commands/__tests__/add.test.ts
@@ -92,6 +92,8 @@ describe("authorizeCloudAccounts", () => {
     expect(authService.requestAuthorization).toHaveBeenCalledWith(
       expect.objectContaining({
         bootstrapIdentityId: "dx-d-itn-bootstrap-id-01",
+        envShort: "d",
+        prefix: "dx",
         subscriptionName: "DEV-FooBar",
       }),
     );
@@ -125,6 +127,8 @@ describe("authorizeCloudAccounts", () => {
     expect(authService.requestAuthorization).toHaveBeenCalledWith(
       expect.objectContaining({
         bootstrapIdentityId: "io-p-weu-bootstrap-id-01",
+        envShort: "p",
+        prefix: "io",
         subscriptionName: "PROD-Bar",
       }),
     );

--- a/apps/cli/src/adapters/commander/commands/__tests__/add.test.ts
+++ b/apps/cli/src/adapters/commander/commands/__tests__/add.test.ts
@@ -194,7 +194,7 @@ describe("authorizeCloudAccounts", () => {
     expect(prs[0]).toEqual(expectedPr);
   });
 
-  it("returns empty array when authorization is a no-op (nothing changed)", async () => {
+  it("returns a no-op authorization result when nothing changed", async () => {
     const authService = mock<AuthorizationService>();
     const account = {
       csp: "azure" as const,

--- a/apps/cli/src/adapters/commander/commands/__tests__/add.test.ts
+++ b/apps/cli/src/adapters/commander/commands/__tests__/add.test.ts
@@ -12,7 +12,6 @@ import {
   AuthorizationError,
   AuthorizationResult,
   AuthorizationService,
-  IdentityAlreadyExistsError,
 } from "../../../../domain/authorization.js";
 import { authorizeCloudAccounts } from "../add.js";
 
@@ -195,7 +194,7 @@ describe("authorizeCloudAccounts", () => {
     expect(prs[0]).toEqual(expectedPr);
   });
 
-  it("handles IdentityAlreadyExistsError gracefully", async () => {
+  it("returns empty array when authorization is a no-op (nothing changed)", async () => {
     const authService = mock<AuthorizationService>();
     const account = {
       csp: "azure" as const,
@@ -204,8 +203,9 @@ describe("authorizeCloudAccounts", () => {
       id: "sub-exists",
     };
 
+    // No-op result: Ok with no URL (identity + groups already configured)
     authService.requestAuthorization.mockReturnValue(
-      errAsync(new IdentityAlreadyExistsError("dx-d-itn-bootstrap-id-01")),
+      okAsync(new AuthorizationResult()),
     );
 
     const envPayload = makeEnvPayload({
@@ -215,6 +215,9 @@ describe("authorizeCloudAccounts", () => {
     const result = await authorizeCloudAccounts(authService)(envPayload);
 
     expect(result.isOk()).toBe(true);
-    expect(result._unsafeUnwrap()).toEqual([]);
+    // The no-op result is still collected but has no URL
+    const prs = result._unsafeUnwrap();
+    expect(prs).toHaveLength(1);
+    expect(prs[0].url).toBeUndefined();
   });
 });

--- a/apps/cli/src/adapters/commander/commands/add.ts
+++ b/apps/cli/src/adapters/commander/commands/add.ts
@@ -108,9 +108,12 @@ const displaySummary = (result: AddResult) => {
 
   let step = 1;
   console.log(chalk.green.bold("\nNext Steps:"));
-  if (authorizationPrs.length > 0) {
+  const prsWithUrl = authorizationPrs.filter(
+    (pr): pr is AuthorizationResult & { url: string } => pr.url != null,
+  );
+  if (prsWithUrl.length > 0) {
     console.log(`${step++}. Review the Azure authorization Pull Request(s):`);
-    for (const authPr of authorizationPrs) {
+    for (const authPr of prsWithUrl) {
       console.log(`   - ${chalk.underline(authPr.url)}`);
     }
   }

--- a/apps/cli/src/adapters/commander/commands/add.ts
+++ b/apps/cli/src/adapters/commander/commands/add.ts
@@ -63,6 +63,8 @@ export const authorizeCloudAccounts =
         const locShort = locationShort[account.defaultLocation];
         const input = requestAuthorizationInputSchema.safeParse({
           bootstrapIdentityId: `${prefix}-${envShort}-${locShort}-bootstrap-id-01`,
+          envShort,
+          prefix,
           repoName: envPayload.github.repo,
           subscriptionName: account.displayName,
         });

--- a/apps/cli/src/adapters/pagopa-technology/__tests__/authorization.test.ts
+++ b/apps/cli/src/adapters/pagopa-technology/__tests__/authorization.test.ts
@@ -76,17 +76,17 @@ describe("PagoPA AuthorizationService", () => {
         "https://github.com/pagopa/eng-azure-authorization/pull/42",
       );
 
+      expect(gitHubService.getFileContent).toHaveBeenCalledWith({
+        owner: "pagopa",
+        path: FILE_PATH,
+        ref: "main",
+        repo: "eng-azure-authorization",
+      });
+
       expect(gitHubService.createBranch).toHaveBeenCalledWith({
         branchName: "feats/add-test-repo-test-subscription-bootstrap-identity",
         fromRef: "main",
         owner: "pagopa",
-        repo: "eng-azure-authorization",
-      });
-
-      expect(gitHubService.getFileContent).toHaveBeenCalledWith({
-        owner: "pagopa",
-        path: FILE_PATH,
-        ref: "feats/add-test-repo-test-subscription-bootstrap-identity",
         repo: "eng-azure-authorization",
       });
 
@@ -375,6 +375,195 @@ describe("PagoPA AuthorizationService", () => {
         "existing-identity",
       );
     });
+
+    it("should use identity-only messages when groups are already correct", async () => {
+      const { authorizationService, gitHubService } = makeEnv();
+      const input = makeSampleInput();
+      // Groups already correct, but identity is missing
+      const allGroups = DEFAULT_GROUP_SPECS.map((spec) => ({
+        members: [],
+        name: makeGroupName("test", "d", spec.groupName),
+        roles: [...spec.roles],
+      }));
+      const originalContent = JSON.stringify(
+        {
+          directory_readers: { service_principals_name: [] },
+          groups: allGroups,
+        },
+        null,
+        2,
+      );
+
+      gitHubService.getFileContent.mockResolvedValue({
+        content: originalContent,
+        sha: "sha-identity-only",
+      });
+      gitHubService.createBranch.mockResolvedValue(undefined);
+      gitHubService.updateFile.mockResolvedValue(undefined);
+      gitHubService.createPullRequest.mockResolvedValue(
+        new PullRequest(
+          "https://github.com/pagopa/eng-azure-authorization/pull/60",
+        ),
+      );
+
+      const result = await authorizationService.requestAuthorization(input);
+
+      expect(result.isOk()).toBe(true);
+
+      expect(gitHubService.updateFile).toHaveBeenCalledWith(
+        expect.objectContaining({
+          message: "Add bootstrap identity for test-subscription",
+        }),
+      );
+      expect(gitHubService.createPullRequest).toHaveBeenCalledWith(
+        expect.objectContaining({
+          body: "This PR adds the bootstrap identity `test-bootstrap-identity-id` to the directory readers for subscription `test-subscription`.",
+          title: "Add bootstrap identity for test-subscription",
+        }),
+      );
+    });
+
+    it("should use groups-only messages when identity already exists", async () => {
+      const { authorizationService, gitHubService } = makeEnv();
+      const input = makeSampleInput();
+      // Identity present, no groups yet
+      const originalContent = JSON.stringify(
+        {
+          directory_readers: {
+            service_principals_name: ["test-bootstrap-identity-id"],
+          },
+        },
+        null,
+        2,
+      );
+
+      gitHubService.getFileContent.mockResolvedValue({
+        content: originalContent,
+        sha: "sha-groups-only",
+      });
+      gitHubService.createBranch.mockResolvedValue(undefined);
+      gitHubService.updateFile.mockResolvedValue(undefined);
+      gitHubService.createPullRequest.mockResolvedValue(
+        new PullRequest(
+          "https://github.com/pagopa/eng-azure-authorization/pull/61",
+        ),
+      );
+
+      const result = await authorizationService.requestAuthorization(input);
+
+      expect(result.isOk()).toBe(true);
+
+      expect(gitHubService.updateFile).toHaveBeenCalledWith(
+        expect.objectContaining({
+          message: "Configure AD groups for test-subscription",
+        }),
+      );
+      expect(gitHubService.createPullRequest).toHaveBeenCalledWith(
+        expect.objectContaining({
+          body: "This PR configures AD groups for subscription `test-subscription`.",
+          title: "Configure AD groups for test-subscription",
+        }),
+      );
+    });
+
+    it("should preserve original group order and append missing defaults at end", async () => {
+      const { authorizationService, gitHubService } = makeEnv();
+      const input = makeSampleInput();
+      // Start with custom group + one default group (externals) in deliberate order
+      const originalContent = JSON.stringify(
+        {
+          directory_readers: { service_principals_name: [] },
+          groups: [
+            {
+              members: ["carol@pagopa.it"],
+              name: "test-d-adgroup-custom-team",
+              roles: ["Contributor"],
+            },
+            {
+              members: ["alice@pagopa.it"],
+              name: "test-d-adgroup-externals",
+              roles: ["Owner"],
+            },
+          ],
+        },
+        null,
+        2,
+      );
+
+      gitHubService.getFileContent.mockResolvedValue({
+        content: originalContent,
+        sha: "sha-order",
+      });
+      gitHubService.createBranch.mockResolvedValue(undefined);
+      gitHubService.updateFile.mockResolvedValue(undefined);
+      gitHubService.createPullRequest.mockResolvedValue(
+        new PullRequest(
+          "https://github.com/pagopa/eng-azure-authorization/pull/62",
+        ),
+      );
+
+      const result = await authorizationService.requestAuthorization(input);
+
+      expect(result.isOk()).toBe(true);
+      const updateCall = gitHubService.updateFile.mock.calls[0][0];
+      const updatedParsed = JSON.parse(updateCall.content);
+      const groupNames = updatedParsed.groups.map(
+        (g: { name: string }) => g.name,
+      );
+
+      // Original groups preserve their order
+      expect(groupNames[0]).toBe("test-d-adgroup-custom-team");
+      expect(groupNames[1]).toBe("test-d-adgroup-externals");
+      // Missing defaults appended after existing groups
+      expect(groupNames.length).toBe(DEFAULT_GROUP_SPECS.length + 1);
+    });
+
+    it("should preserve extra fields on group entries through round-trip", async () => {
+      const { authorizationService, gitHubService } = makeEnv();
+      const input = makeSampleInput();
+      // Group with extra metadata field
+      const originalContent = JSON.stringify(
+        {
+          directory_readers: { service_principals_name: [] },
+          groups: [
+            {
+              members: ["alice@pagopa.it"],
+              metadata: { created_by: "automation" },
+              name: "test-d-adgroup-admin",
+              roles: ["Owner"],
+            },
+          ],
+        },
+        null,
+        2,
+      );
+
+      gitHubService.getFileContent.mockResolvedValue({
+        content: originalContent,
+        sha: "sha-extra-fields",
+      });
+      gitHubService.createBranch.mockResolvedValue(undefined);
+      gitHubService.updateFile.mockResolvedValue(undefined);
+      gitHubService.createPullRequest.mockResolvedValue(
+        new PullRequest(
+          "https://github.com/pagopa/eng-azure-authorization/pull/63",
+        ),
+      );
+
+      const result = await authorizationService.requestAuthorization(input);
+
+      expect(result.isOk()).toBe(true);
+      const updateCall = gitHubService.updateFile.mock.calls[0][0];
+      const updatedParsed = JSON.parse(updateCall.content);
+
+      const adminGroup = updatedParsed.groups.find(
+        (g: { name: string }) => g.name === "test-d-adgroup-admin",
+      );
+      // Extra field preserved
+      expect(adminGroup.metadata).toEqual({ created_by: "automation" });
+      // Members preserved
+      expect(adminGroup.members).toContain("alice@pagopa.it");
+    });
   });
 
   // eslint-disable-next-line max-lines-per-function
@@ -383,7 +572,6 @@ describe("PagoPA AuthorizationService", () => {
       const { authorizationService, gitHubService } = makeEnv();
       const input = makeSampleInput();
 
-      gitHubService.createBranch.mockResolvedValue(undefined);
       gitHubService.getFileContent.mockRejectedValue(
         new FileNotFoundError(FILE_PATH),
       );
@@ -395,6 +583,7 @@ describe("PagoPA AuthorizationService", () => {
       expect(error.message).toContain("Unable to get");
       expect(error.message).toContain("terraform.tfvars.json");
 
+      expect(gitHubService.createBranch).not.toHaveBeenCalled();
       expect(gitHubService.updateFile).not.toHaveBeenCalled();
     });
 
@@ -467,7 +656,6 @@ describe("PagoPA AuthorizationService", () => {
         2,
       );
 
-      gitHubService.createBranch.mockResolvedValue(undefined);
       gitHubService.getFileContent.mockResolvedValue({
         content,
         sha: "sha-noop",
@@ -479,7 +667,8 @@ describe("PagoPA AuthorizationService", () => {
       expect(result.isOk()).toBe(true);
       expect(result._unsafeUnwrap().url).toBeUndefined();
 
-      // File and PR must not be touched
+      // Branch, file update, and PR must not be touched
+      expect(gitHubService.createBranch).not.toHaveBeenCalled();
       expect(gitHubService.updateFile).not.toHaveBeenCalled();
       expect(gitHubService.createPullRequest).not.toHaveBeenCalled();
     });
@@ -544,7 +733,6 @@ describe("PagoPA AuthorizationService", () => {
       const { authorizationService, gitHubService } = makeEnv();
       const input = makeSampleInput();
 
-      gitHubService.createBranch.mockResolvedValue(undefined);
       gitHubService.getFileContent.mockResolvedValue({
         content: "not valid json {{",
         sha: "sha-123",
@@ -557,6 +745,7 @@ describe("PagoPA AuthorizationService", () => {
         InvalidAuthorizationFileFormatError,
       );
 
+      expect(gitHubService.createBranch).not.toHaveBeenCalled();
       expect(gitHubService.updateFile).not.toHaveBeenCalled();
     });
 
@@ -564,7 +753,6 @@ describe("PagoPA AuthorizationService", () => {
       const { authorizationService, gitHubService } = makeEnv();
       const input = makeSampleInput();
 
-      gitHubService.createBranch.mockResolvedValue(undefined);
       gitHubService.getFileContent.mockResolvedValue({
         content: JSON.stringify({ unexpected_key: {} }),
         sha: "sha-123",
@@ -577,13 +765,23 @@ describe("PagoPA AuthorizationService", () => {
         InvalidAuthorizationFileFormatError,
       );
 
+      expect(gitHubService.createBranch).not.toHaveBeenCalled();
       expect(gitHubService.updateFile).not.toHaveBeenCalled();
     });
 
     it("should return error when branch creation fails", async () => {
       const { authorizationService, gitHubService } = makeEnv();
       const input = makeSampleInput();
+      const content = JSON.stringify(
+        { directory_readers: { service_principals_name: [] } },
+        null,
+        2,
+      );
 
+      gitHubService.getFileContent.mockResolvedValue({
+        content,
+        sha: "sha-123",
+      });
       gitHubService.createBranch.mockRejectedValue(
         new Error("Failed to create branch: branch already exists"),
       );
@@ -595,7 +793,6 @@ describe("PagoPA AuthorizationService", () => {
         "Unable to create branch",
       );
 
-      expect(gitHubService.getFileContent).not.toHaveBeenCalled();
       expect(gitHubService.updateFile).not.toHaveBeenCalled();
     });
 

--- a/apps/cli/src/adapters/pagopa-technology/__tests__/authorization.test.ts
+++ b/apps/cli/src/adapters/pagopa-technology/__tests__/authorization.test.ts
@@ -7,8 +7,10 @@ import { mock } from "vitest-mock-extended";
 
 import {
   AuthorizationResult,
+  DEFAULT_GROUP_SPECS,
   IdentityAlreadyExistsError,
   InvalidAuthorizationFileFormatError,
+  makeGroupName,
   RequestAuthorizationInput,
   requestAuthorizationInputSchema,
 } from "../../../domain/authorization.js";
@@ -32,6 +34,8 @@ const makeEnv = () => {
 const makeSampleInput = (): RequestAuthorizationInput =>
   requestAuthorizationInputSchema.parse({
     bootstrapIdentityId: "test-bootstrap-identity-id",
+    envShort: "d",
+    prefix: "test",
     repoName: "test-repo",
     subscriptionName: "test-subscription",
   });
@@ -41,6 +45,7 @@ const FILE_PATH =
 
 // eslint-disable-next-line max-lines-per-function
 describe("PagoPA AuthorizationService", () => {
+  // eslint-disable-next-line max-lines-per-function
   describe("happy path", () => {
     it("should create a pull request when all steps succeed", async () => {
       const { authorizationService, gitHubService } = makeEnv();
@@ -89,7 +94,7 @@ describe("PagoPA AuthorizationService", () => {
       expect(gitHubService.updateFile).toHaveBeenCalledWith(
         expect.objectContaining({
           branch: "feats/add-test-repo-test-subscription-bootstrap-identity",
-          message: "Add directory reader for test-subscription",
+          message: "Add bootstrap identity and AD groups for test-subscription",
           owner: "pagopa",
           path: FILE_PATH,
           repo: "eng-azure-authorization",
@@ -99,12 +104,189 @@ describe("PagoPA AuthorizationService", () => {
 
       expect(gitHubService.createPullRequest).toHaveBeenCalledWith({
         base: "main",
-        body: "This PR adds the bootstrap identity `test-bootstrap-identity-id` to the directory readers for subscription `test-subscription`.",
+        body: "This PR adds the bootstrap identity `test-bootstrap-identity-id` to the directory readers and configures AD groups for subscription `test-subscription`.",
         head: "feats/add-test-repo-test-subscription-bootstrap-identity",
         owner: "pagopa",
         repo: "eng-azure-authorization",
-        title: "Add directory reader for test-subscription",
+        title: "Add bootstrap identity and AD groups for test-subscription",
       });
+    });
+
+    it("should add all default AD groups when none exist", async () => {
+      const { authorizationService, gitHubService } = makeEnv();
+      const input = makeSampleInput();
+      const originalContent = JSON.stringify(
+        { directory_readers: { service_principals_name: [] } },
+        null,
+        2,
+      );
+
+      gitHubService.createBranch.mockResolvedValue(undefined);
+      gitHubService.getFileContent.mockResolvedValue({
+        content: originalContent,
+        sha: "sha-groups-1",
+      });
+      gitHubService.updateFile.mockResolvedValue(undefined);
+      gitHubService.createPullRequest.mockResolvedValue(
+        new PullRequest(
+          "https://github.com/pagopa/eng-azure-authorization/pull/50",
+        ),
+      );
+
+      const result = await authorizationService.requestAuthorization(input);
+
+      expect(result.isOk()).toBe(true);
+      const updateCall = gitHubService.updateFile.mock.calls[0][0];
+      const updatedParsed = JSON.parse(updateCall.content);
+
+      expect(updatedParsed.groups).toHaveLength(DEFAULT_GROUP_SPECS.length);
+      for (const spec of DEFAULT_GROUP_SPECS) {
+        const groupName = makeGroupName("test", "d", spec.groupName);
+        const found = updatedParsed.groups.find(
+          (g: { name: string }) => g.name === groupName,
+        );
+        expect(found).toBeDefined();
+        expect(found.roles).toEqual(spec.roles);
+        expect(found.members).toEqual([]);
+      }
+    });
+
+    it("should preserve existing members and add missing groups", async () => {
+      const { authorizationService, gitHubService } = makeEnv();
+      const input = makeSampleInput();
+      const originalContent = JSON.stringify(
+        {
+          directory_readers: { service_principals_name: [] },
+          groups: [
+            {
+              members: ["alice@pagopa.it"],
+              name: "test-d-adgroup-admin",
+              roles: ["Owner"],
+            },
+          ],
+        },
+        null,
+        2,
+      );
+
+      gitHubService.createBranch.mockResolvedValue(undefined);
+      gitHubService.getFileContent.mockResolvedValue({
+        content: originalContent,
+        sha: "sha-groups-2",
+      });
+      gitHubService.updateFile.mockResolvedValue(undefined);
+      gitHubService.createPullRequest.mockResolvedValue(
+        new PullRequest(
+          "https://github.com/pagopa/eng-azure-authorization/pull/51",
+        ),
+      );
+
+      const result = await authorizationService.requestAuthorization(input);
+
+      expect(result.isOk()).toBe(true);
+      const updateCall = gitHubService.updateFile.mock.calls[0][0];
+      const updatedParsed = JSON.parse(updateCall.content);
+
+      // All default groups should be present
+      expect(updatedParsed.groups).toHaveLength(DEFAULT_GROUP_SPECS.length);
+
+      // Admin group should preserve existing member
+      const adminGroup = updatedParsed.groups.find(
+        (g: { name: string }) => g.name === "test-d-adgroup-admin",
+      );
+      expect(adminGroup.members).toContain("alice@pagopa.it");
+    });
+
+    it("should update roles on existing group while preserving members", async () => {
+      const { authorizationService, gitHubService } = makeEnv();
+      const input = makeSampleInput();
+      const originalContent = JSON.stringify(
+        {
+          directory_readers: { service_principals_name: [] },
+          groups: [
+            {
+              // externals normally gets "Owner" but file has "Reader"
+              members: ["bob@pagopa.it"],
+              name: "test-d-adgroup-externals",
+              roles: ["Reader"],
+            },
+          ],
+        },
+        null,
+        2,
+      );
+
+      gitHubService.createBranch.mockResolvedValue(undefined);
+      gitHubService.getFileContent.mockResolvedValue({
+        content: originalContent,
+        sha: "sha-groups-3",
+      });
+      gitHubService.updateFile.mockResolvedValue(undefined);
+      gitHubService.createPullRequest.mockResolvedValue(
+        new PullRequest(
+          "https://github.com/pagopa/eng-azure-authorization/pull/52",
+        ),
+      );
+
+      const result = await authorizationService.requestAuthorization(input);
+
+      expect(result.isOk()).toBe(true);
+      const updateCall = gitHubService.updateFile.mock.calls[0][0];
+      const updatedParsed = JSON.parse(updateCall.content);
+
+      const externalsGroup = updatedParsed.groups.find(
+        (g: { name: string }) => g.name === "test-d-adgroup-externals",
+      );
+      // Roles updated to default
+      expect(externalsGroup.roles).toEqual(["Owner"]);
+      // Members preserved
+      expect(externalsGroup.members).toContain("bob@pagopa.it");
+    });
+
+    it("should preserve custom (non-default) groups", async () => {
+      const { authorizationService, gitHubService } = makeEnv();
+      const input = makeSampleInput();
+      const originalContent = JSON.stringify(
+        {
+          directory_readers: { service_principals_name: [] },
+          groups: [
+            {
+              members: ["carol@pagopa.it"],
+              name: "test-d-adgroup-custom-team",
+              roles: ["Contributor"],
+            },
+          ],
+        },
+        null,
+        2,
+      );
+
+      gitHubService.createBranch.mockResolvedValue(undefined);
+      gitHubService.getFileContent.mockResolvedValue({
+        content: originalContent,
+        sha: "sha-groups-4",
+      });
+      gitHubService.updateFile.mockResolvedValue(undefined);
+      gitHubService.createPullRequest.mockResolvedValue(
+        new PullRequest(
+          "https://github.com/pagopa/eng-azure-authorization/pull/53",
+        ),
+      );
+
+      const result = await authorizationService.requestAuthorization(input);
+
+      expect(result.isOk()).toBe(true);
+      const updateCall = gitHubService.updateFile.mock.calls[0][0];
+      const updatedParsed = JSON.parse(updateCall.content);
+
+      // Custom group preserved
+      const customGroup = updatedParsed.groups.find(
+        (g: { name: string }) => g.name === "test-d-adgroup-custom-team",
+      );
+      expect(customGroup).toBeDefined();
+      expect(customGroup.members).toContain("carol@pagopa.it");
+      // All defaults also present
+      expect(updatedParsed.groups).toHaveLength(DEFAULT_GROUP_SPECS.length + 1);
     });
 
     it("should preserve existing fields in the JSON file", async () => {
@@ -144,19 +326,16 @@ describe("PagoPA AuthorizationService", () => {
       const updateCall = gitHubService.updateFile.mock.calls[0][0];
       const updatedParsed = JSON.parse(updateCall.content);
 
-      expect(updatedParsed).toStrictEqual({
-        directory_readers: {
-          service_principals_name: [
-            "existing-identity",
-            "test-bootstrap-identity-id",
-          ],
-          some_other_field: "keep-me",
-        },
-        entra_groups: {
-          readers: ["reader-group"],
-        },
-        other_top_level: true,
-      });
+      // Identity added
+      expect(updatedParsed.directory_readers.service_principals_name).toContain(
+        "test-bootstrap-identity-id",
+      );
+      // Extra fields preserved
+      expect(updatedParsed.directory_readers.some_other_field).toBe("keep-me");
+      expect(updatedParsed.entra_groups).toEqual({ readers: ["reader-group"] });
+      expect(updatedParsed.other_top_level).toBe(true);
+      // All default groups added
+      expect(updatedParsed.groups).toHaveLength(DEFAULT_GROUP_SPECS.length);
     });
 
     it("should append identity to an existing non-empty list", async () => {

--- a/apps/cli/src/adapters/pagopa-technology/__tests__/authorization.test.ts
+++ b/apps/cli/src/adapters/pagopa-technology/__tests__/authorization.test.ts
@@ -8,7 +8,6 @@ import { mock } from "vitest-mock-extended";
 import {
   AuthorizationResult,
   DEFAULT_GROUP_SPECS,
-  IdentityAlreadyExistsError,
   InvalidAuthorizationFileFormatError,
   makeGroupName,
   RequestAuthorizationInput,
@@ -398,9 +397,10 @@ describe("PagoPA AuthorizationService", () => {
       expect(gitHubService.updateFile).not.toHaveBeenCalled();
     });
 
-    it("should return error when identity already exists", async () => {
+    it("should upsert groups and create PR when identity already exists", async () => {
       const { authorizationService, gitHubService } = makeEnv();
       const input = makeSampleInput();
+      // Identity already present, no groups yet
       const content = JSON.stringify(
         {
           directory_readers: {
@@ -416,15 +416,127 @@ describe("PagoPA AuthorizationService", () => {
         content,
         sha: "sha-123",
       });
+      gitHubService.updateFile.mockResolvedValue(undefined);
+      gitHubService.createPullRequest.mockResolvedValue(
+        new PullRequest(
+          "https://github.com/pagopa/eng-azure-authorization/pull/55",
+        ),
+      );
 
       const result = await authorizationService.requestAuthorization(input);
 
-      expect(result.isErr()).toBe(true);
-      expect(result._unsafeUnwrapErr()).toBeInstanceOf(
-        IdentityAlreadyExistsError,
+      expect(result.isOk()).toBe(true);
+      const authResult = result._unsafeUnwrap();
+      expect(authResult.url).toBe(
+        "https://github.com/pagopa/eng-azure-authorization/pull/55",
       );
 
+      // Identity must NOT be duplicated
+      const updateCall = gitHubService.updateFile.mock.calls[0][0];
+      const updatedParsed = JSON.parse(updateCall.content);
+      expect(
+        updatedParsed.directory_readers.service_principals_name,
+      ).toHaveLength(1);
+      expect(
+        updatedParsed.directory_readers.service_principals_name,
+      ).toContain("test-bootstrap-identity-id");
+
+      // All default groups must be created
+      expect(updatedParsed.groups).toHaveLength(DEFAULT_GROUP_SPECS.length);
+    });
+
+    it("should skip update and PR when identity exists and groups are already correct", async () => {
+      const { authorizationService, gitHubService } = makeEnv();
+      const input = makeSampleInput();
+
+      // Build a file where the identity is present and all groups are already correct
+      const allGroups = DEFAULT_GROUP_SPECS.map((spec) => ({
+        members: [],
+        name: makeGroupName("test", "d", spec.groupName),
+        roles: [...spec.roles],
+      }));
+      const content = JSON.stringify(
+        {
+          directory_readers: {
+            service_principals_name: ["test-bootstrap-identity-id"],
+          },
+          groups: allGroups,
+        },
+        null,
+        2,
+      );
+
+      gitHubService.createBranch.mockResolvedValue(undefined);
+      gitHubService.getFileContent.mockResolvedValue({
+        content,
+        sha: "sha-noop",
+      });
+
+      const result = await authorizationService.requestAuthorization(input);
+
+      // Should succeed as a no-op (no PR created)
+      expect(result.isOk()).toBe(true);
+      expect(result._unsafeUnwrap().url).toBeUndefined();
+
+      // File and PR must not be touched
       expect(gitHubService.updateFile).not.toHaveBeenCalled();
+      expect(gitHubService.createPullRequest).not.toHaveBeenCalled();
+    });
+
+    it("should update group roles and create PR when identity exists with wrong roles", async () => {
+      const { authorizationService, gitHubService } = makeEnv();
+      const input = makeSampleInput();
+
+      // Identity present, but externals group has wrong roles
+      const content = JSON.stringify(
+        {
+          directory_readers: {
+            service_principals_name: ["test-bootstrap-identity-id"],
+          },
+          groups: [
+            {
+              members: ["bob@pagopa.it"],
+              name: "test-d-adgroup-externals",
+              roles: ["Reader"],
+            },
+          ],
+        },
+        null,
+        2,
+      );
+
+      gitHubService.createBranch.mockResolvedValue(undefined);
+      gitHubService.getFileContent.mockResolvedValue({
+        content,
+        sha: "sha-roles",
+      });
+      gitHubService.updateFile.mockResolvedValue(undefined);
+      gitHubService.createPullRequest.mockResolvedValue(
+        new PullRequest(
+          "https://github.com/pagopa/eng-azure-authorization/pull/56",
+        ),
+      );
+
+      const result = await authorizationService.requestAuthorization(input);
+
+      expect(result.isOk()).toBe(true);
+      expect(result._unsafeUnwrap().url).toBe(
+        "https://github.com/pagopa/eng-azure-authorization/pull/56",
+      );
+
+      const updateCall = gitHubService.updateFile.mock.calls[0][0];
+      const updatedParsed = JSON.parse(updateCall.content);
+
+      const externalsGroup = updatedParsed.groups.find(
+        (g: { name: string }) => g.name === "test-d-adgroup-externals",
+      );
+      expect(externalsGroup.roles).toEqual(["Owner"]);
+      // Member preserved
+      expect(externalsGroup.members).toContain("bob@pagopa.it");
+      // Identity not duplicated
+      expect(
+        updatedParsed.directory_readers.service_principals_name,
+      ).toHaveLength(1);
     });
 
     it("should return error when file content is not valid JSON", async () => {

--- a/apps/cli/src/adapters/pagopa-technology/__tests__/authorization.test.ts
+++ b/apps/cli/src/adapters/pagopa-technology/__tests__/authorization.test.ts
@@ -377,6 +377,7 @@ describe("PagoPA AuthorizationService", () => {
     });
   });
 
+  // eslint-disable-next-line max-lines-per-function
   describe("error handling", () => {
     it("should return error when file is not found", async () => {
       const { authorizationService, gitHubService } = makeEnv();
@@ -437,9 +438,9 @@ describe("PagoPA AuthorizationService", () => {
       expect(
         updatedParsed.directory_readers.service_principals_name,
       ).toHaveLength(1);
-      expect(
-        updatedParsed.directory_readers.service_principals_name,
-      ).toContain("test-bootstrap-identity-id");
+      expect(updatedParsed.directory_readers.service_principals_name).toContain(
+        "test-bootstrap-identity-id",
+      );
 
       // All default groups must be created
       expect(updatedParsed.groups).toHaveLength(DEFAULT_GROUP_SPECS.length);

--- a/apps/cli/src/adapters/pagopa-technology/__tests__/authorization.test.ts
+++ b/apps/cli/src/adapters/pagopa-technology/__tests__/authorization.test.ts
@@ -7,9 +7,7 @@ import { mock } from "vitest-mock-extended";
 
 import {
   AuthorizationResult,
-  DEFAULT_GROUP_SPECS,
   InvalidAuthorizationFileFormatError,
-  makeGroupName,
   RequestAuthorizationInput,
   requestAuthorizationInputSchema,
 } from "../../../domain/authorization.js";
@@ -18,7 +16,11 @@ import {
   GitHubService,
   PullRequest,
 } from "../../../domain/github.js";
-import { makeAuthorizationService } from "../authorization.js";
+import {
+  DEFAULT_GROUP_SPECS,
+  makeAzureAdGroupName as makeGroupName,
+} from "../azure-authorization-config.js";
+import { makeAzureAuthorizationService as makeAuthorizationService } from "../azure-authorization.js";
 
 const makeEnv = () => {
   const gitHubService = mock<GitHubService>();

--- a/apps/cli/src/adapters/pagopa-technology/authorization.ts
+++ b/apps/cli/src/adapters/pagopa-technology/authorization.ts
@@ -248,7 +248,7 @@ export const makeAuthorizationService = (
           }
           const parsed = parseResult.value;
 
-          const { json: withIdentity, identityAdded } = ensureIdentity(
+          const { identityAdded, json: withIdentity } = ensureIdentity(
             parsed,
             bootstrapIdentityId,
           );
@@ -259,7 +259,7 @@ export const makeAuthorizationService = (
             });
           }
 
-          const { json: updatedJson, groupsChanged } = upsertGroups(
+          const { groupsChanged, json: updatedJson } = upsertGroups(
             withIdentity,
             prefix,
             envShort,

--- a/apps/cli/src/adapters/pagopa-technology/authorization.ts
+++ b/apps/cli/src/adapters/pagopa-technology/authorization.ts
@@ -16,7 +16,6 @@ import {
   AuthorizationResult,
   AuthorizationService,
   DEFAULT_GROUP_SPECS,
-  IdentityAlreadyExistsError,
   InvalidAuthorizationFileFormatError,
   makeGroupName,
   RequestAuthorizationInput,
@@ -62,12 +61,16 @@ const rolesAreEqual = (
  * - Missing default groups are added with empty members.
  * - Existing groups with wrong roles have their roles updated; members are preserved.
  * - Custom (non-default) groups are preserved unchanged.
+ * Returns the updated JSON along with a flag indicating whether anything changed.
  */
 const upsertGroups = (
   jsonContent: z.infer<typeof authorizationFileSchema>,
   prefix: string,
   envShort: string,
-): z.infer<typeof authorizationFileSchema> => {
+): {
+  groupsChanged: boolean;
+  json: z.infer<typeof authorizationFileSchema>;
+} => {
   type GroupEntry = { members: string[]; name: string; roles: string[] };
 
   const expectedGroups: GroupEntry[] = DEFAULT_GROUP_SPECS.map((spec) => ({
@@ -83,6 +86,7 @@ const upsertGroups = (
   const processedNames = new Set<string>();
 
   const finalGroups: GroupEntry[] = [];
+  let groupsChanged = false;
 
   for (const expected of expectedGroups) {
     const existing = existingByName.get(expected.name);
@@ -91,6 +95,7 @@ const upsertGroups = (
     if (!existing) {
       // Group is missing — add it with default roles and no members
       finalGroups.push(expected);
+      groupsChanged = true;
     } else if (!rolesAreEqual(existing.roles, expected.roles)) {
       // Roles differ — update roles, preserve members
       finalGroups.push({
@@ -98,6 +103,7 @@ const upsertGroups = (
         name: expected.name,
         roles: [...expected.roles],
       });
+      groupsChanged = true;
     } else {
       // Already correct — keep as-is
       finalGroups.push({ ...existing });
@@ -111,12 +117,14 @@ const upsertGroups = (
     }
   }
 
-  return { ...jsonContent, groups: finalGroups };
+  return { groupsChanged, json: { ...jsonContent, groups: finalGroups } };
 };
 
-const addIdentity = (
+/**
+ * Parses and validates the authorization file content (JSON parsing + schema validation).
+ */
+const parseAuthorizationFile = (
   content: string,
-  identityId: string,
 ): Result<z.infer<typeof authorizationFileSchema>, AuthorizationError> => {
   let parsed;
   try {
@@ -136,24 +144,40 @@ const addIdentity = (
     );
   }
 
-  const jsonContent = result.data;
+  return ok(result.data);
+};
 
+/**
+ * Ensures the given identity is present in the service_principals_name list.
+ * Returns the (possibly updated) JSON and whether the identity was newly added.
+ * Never fails: if the identity already exists it is a no-op with identityAdded = false.
+ */
+const ensureIdentity = (
+  jsonContent: z.infer<typeof authorizationFileSchema>,
+  identityId: string,
+): {
+  identityAdded: boolean;
+  json: z.infer<typeof authorizationFileSchema>;
+} => {
   if (
     jsonContent.directory_readers.service_principals_name.includes(identityId)
   ) {
-    return err(new IdentityAlreadyExistsError(identityId));
+    return { identityAdded: false, json: jsonContent };
   }
 
-  return ok({
-    ...jsonContent,
-    directory_readers: {
-      ...jsonContent.directory_readers,
-      service_principals_name: [
-        ...jsonContent.directory_readers.service_principals_name,
-        identityId,
-      ],
+  return {
+    identityAdded: true,
+    json: {
+      ...jsonContent,
+      directory_readers: {
+        ...jsonContent.directory_readers,
+        service_principals_name: [
+          ...jsonContent.directory_readers.service_principals_name,
+          identityId,
+        ],
+      },
     },
-  });
+  };
 };
 
 const REPO_OWNER = "pagopa";
@@ -212,38 +236,47 @@ export const makeAuthorizationService = (
         .orTee((error) => {
           logger.error(error.message);
         })
-        // Step 3: Add identity and upsert AD groups
-        .andThen(({ content, sha }) =>
-          addIdentity(content, bootstrapIdentityId)
-            .map((withIdentity) => upsertGroups(withIdentity, prefix, envShort))
-            .mapErr((error) => {
-              if (error instanceof IdentityAlreadyExistsError) {
-                logger.warn("Identity already exists", {
-                  identityId: bootstrapIdentityId,
-                  subscription: subscriptionName,
-                });
-              } else {
-                logger.error("Failed to modify tfvars", {
-                  error: error.message,
-                });
-              }
-              return error;
-            })
-            .match(
-              (updatedJson) =>
-                okAsync({
-                  sha,
-                  updatedContent: JSON.stringify(updatedJson, null, 2),
-                }),
-              (error) => errAsync(error),
-            ),
-        )
-        // Update the file on the new branch
-        .andThen(({ sha, updatedContent }) =>
-          ResultAsync.fromPromise(
+        // Step 3: Parse file, ensure identity is present, upsert AD groups.
+        // If nothing changed, short-circuit and skip the file update and PR creation.
+        .andThen(({ content, sha }) => {
+          const parseResult = parseAuthorizationFile(content);
+          if (parseResult.isErr()) {
+            logger.error("Failed to modify tfvars", {
+              error: parseResult.error.message,
+            });
+            return errAsync(parseResult.error);
+          }
+          const parsed = parseResult.value;
+
+          const { json: withIdentity, identityAdded } = ensureIdentity(
+            parsed,
+            bootstrapIdentityId,
+          );
+          if (!identityAdded) {
+            logger.warn("Identity already exists, checking groups", {
+              identityId: bootstrapIdentityId,
+              subscription: subscriptionName,
+            });
+          }
+
+          const { json: updatedJson, groupsChanged } = upsertGroups(
+            withIdentity,
+            prefix,
+            envShort,
+          );
+
+          if (!identityAdded && !groupsChanged) {
+            // Nothing to do — identity was already present and all groups are correct.
+            logger.info("No changes needed, skipping PR", {
+              subscription: subscriptionName,
+            });
+            return okAsync(new AuthorizationResult());
+          }
+
+          return ResultAsync.fromPromise(
             gitHubService.updateFile({
               branch: branchName,
-              content: updatedContent,
+              content: JSON.stringify(updatedJson, null, 2),
               message: `Add bootstrap identity and AD groups for ${subscriptionName}`,
               owner: REPO_OWNER,
               path: filePath,
@@ -254,32 +287,31 @@ export const makeAuthorizationService = (
               new AuthorizationError(
                 `Unable to update ${filePath} on branch ${branchName} in ${REPO_OWNER}/${REPO_NAME}`,
               ),
-          ),
-        )
-        .orTee((error) => {
-          logger.error(error.message);
-        })
-        // Create a pull request for review
-        .andThen(() =>
-          ResultAsync.fromPromise(
-            gitHubService.createPullRequest({
-              base: BASE_BRANCH,
-              body: `This PR adds the bootstrap identity \`${bootstrapIdentityId}\` to the directory readers and configures AD groups for subscription \`${subscriptionName}\`.`,
-              head: branchName,
-              owner: REPO_OWNER,
-              repo: REPO_NAME,
-              title: `Add bootstrap identity and AD groups for ${subscriptionName}`,
-            }),
-            () =>
-              new AuthorizationError(
-                `Unable to create pull request from ${branchName} to ${BASE_BRANCH} in ${REPO_OWNER}/${REPO_NAME}`,
+          )
+            .orTee((error) => {
+              logger.error(error.message);
+            })
+            .andThen(() =>
+              ResultAsync.fromPromise(
+                gitHubService.createPullRequest({
+                  base: BASE_BRANCH,
+                  body: `This PR adds the bootstrap identity \`${bootstrapIdentityId}\` to the directory readers and configures AD groups for subscription \`${subscriptionName}\`.`,
+                  head: branchName,
+                  owner: REPO_OWNER,
+                  repo: REPO_NAME,
+                  title: `Add bootstrap identity and AD groups for ${subscriptionName}`,
+                }),
+                () =>
+                  new AuthorizationError(
+                    `Unable to create pull request from ${branchName} to ${BASE_BRANCH} in ${REPO_OWNER}/${REPO_NAME}`,
+                  ),
               ),
-          ),
-        )
-        .orTee((error) => {
-          logger.error(error.message);
+            )
+            .orTee((error) => {
+              logger.error(error.message);
+            })
+            .map((pr) => new AuthorizationResult(pr.url));
         })
-        .map((pr) => new AuthorizationResult(pr.url))
     );
   },
 });

--- a/apps/cli/src/adapters/pagopa-technology/authorization.ts
+++ b/apps/cli/src/adapters/pagopa-technology/authorization.ts
@@ -15,8 +15,10 @@ import {
   AuthorizationError,
   AuthorizationResult,
   AuthorizationService,
+  DEFAULT_GROUP_SPECS,
   IdentityAlreadyExistsError,
   InvalidAuthorizationFileFormatError,
+  makeGroupName,
   RequestAuthorizationInput,
 } from "../../domain/authorization.js";
 import { GitHubService } from "../../domain/github.js";
@@ -28,13 +30,94 @@ const authorizationFileSchema = z
         service_principals_name: z.array(z.string()),
       })
       .loose(),
+    groups: z
+      .array(
+        z.object({
+          members: z.array(z.string()),
+          name: z.string(),
+          roles: z.array(z.string()),
+        }),
+      )
+      .optional(),
   })
   .loose();
+
+/**
+ * Checks if two role arrays are equivalent (same roles, order-independent).
+ */
+const rolesAreEqual = (
+  roles1: readonly string[],
+  roles2: readonly string[],
+): boolean => {
+  if (roles1.length !== roles2.length) {
+    return false;
+  }
+  const sorted1 = [...roles1].sort();
+  const sorted2 = [...roles2].sort();
+  return sorted1.every((role, idx) => role === sorted2[idx]);
+};
+
+/**
+ * Adds or updates the AD groups array in the parsed authorization JSON.
+ * - Missing default groups are added with empty members.
+ * - Existing groups with wrong roles have their roles updated; members are preserved.
+ * - Custom (non-default) groups are preserved unchanged.
+ */
+const upsertGroups = (
+  jsonContent: z.infer<typeof authorizationFileSchema>,
+  prefix: string,
+  envShort: string,
+): z.infer<typeof authorizationFileSchema> => {
+  type GroupEntry = { members: string[]; name: string; roles: string[] };
+
+  const expectedGroups: GroupEntry[] = DEFAULT_GROUP_SPECS.map((spec) => ({
+    members: [],
+    name: makeGroupName(prefix, envShort, spec.groupName),
+    roles: [...spec.roles],
+  }));
+
+  const existingGroups = jsonContent.groups ?? [];
+  const existingByName = new Map(
+    existingGroups.map((group) => [group.name, group]),
+  );
+  const processedNames = new Set<string>();
+
+  const finalGroups: GroupEntry[] = [];
+
+  for (const expected of expectedGroups) {
+    const existing = existingByName.get(expected.name);
+    processedNames.add(expected.name);
+
+    if (!existing) {
+      // Group is missing — add it with default roles and no members
+      finalGroups.push(expected);
+    } else if (!rolesAreEqual(existing.roles, expected.roles)) {
+      // Roles differ — update roles, preserve members
+      finalGroups.push({
+        members: [...existing.members],
+        name: expected.name,
+        roles: [...expected.roles],
+      });
+    } else {
+      // Already correct — keep as-is
+      finalGroups.push({ ...existing });
+    }
+  }
+
+  // Preserve any custom groups not in the default list
+  for (const existing of existingGroups) {
+    if (!processedNames.has(existing.name)) {
+      finalGroups.push({ ...existing });
+    }
+  }
+
+  return { ...jsonContent, groups: finalGroups };
+};
 
 const addIdentity = (
   content: string,
   identityId: string,
-): Result<string, AuthorizationError> => {
+): Result<z.infer<typeof authorizationFileSchema>, AuthorizationError> => {
   let parsed;
   try {
     parsed = JSON.parse(content);
@@ -61,7 +144,7 @@ const addIdentity = (
     return err(new IdentityAlreadyExistsError(identityId));
   }
 
-  const updated = {
+  return ok({
     ...jsonContent,
     directory_readers: {
       ...jsonContent.directory_readers,
@@ -70,9 +153,7 @@ const addIdentity = (
         identityId,
       ],
     },
-  };
-
-  return ok(JSON.stringify(updated, null, 2));
+  });
 };
 
 const REPO_OWNER = "pagopa";
@@ -86,7 +167,13 @@ export const makeAuthorizationService = (
     input: RequestAuthorizationInput,
   ): ResultAsync<AuthorizationResult, AuthorizationError> {
     const logger = getLogger(["dx-cli", "pagopa-authorization"]);
-    const { bootstrapIdentityId, repoName, subscriptionName } = input;
+    const {
+      bootstrapIdentityId,
+      envShort,
+      prefix,
+      repoName,
+      subscriptionName,
+    } = input;
     const filePath = `src/azure-subscriptions/subscriptions/${subscriptionName}/terraform.tfvars.json`;
     const branchName = `feats/add-${repoName}-${subscriptionName}-bootstrap-identity`;
 
@@ -125,9 +212,10 @@ export const makeAuthorizationService = (
         .orTee((error) => {
           logger.error(error.message);
         })
-        // Modify the file content, detecting duplicates and format errors
+        // Step 3: Add identity and upsert AD groups
         .andThen(({ content, sha }) =>
           addIdentity(content, bootstrapIdentityId)
+            .map((withIdentity) => upsertGroups(withIdentity, prefix, envShort))
             .mapErr((error) => {
               if (error instanceof IdentityAlreadyExistsError) {
                 logger.warn("Identity already exists", {
@@ -142,7 +230,11 @@ export const makeAuthorizationService = (
               return error;
             })
             .match(
-              (updatedContent) => okAsync({ sha, updatedContent }),
+              (updatedJson) =>
+                okAsync({
+                  sha,
+                  updatedContent: JSON.stringify(updatedJson, null, 2),
+                }),
               (error) => errAsync(error),
             ),
         )
@@ -152,7 +244,7 @@ export const makeAuthorizationService = (
             gitHubService.updateFile({
               branch: branchName,
               content: updatedContent,
-              message: `Add directory reader for ${subscriptionName}`,
+              message: `Add bootstrap identity and AD groups for ${subscriptionName}`,
               owner: REPO_OWNER,
               path: filePath,
               repo: REPO_NAME,
@@ -172,11 +264,11 @@ export const makeAuthorizationService = (
           ResultAsync.fromPromise(
             gitHubService.createPullRequest({
               base: BASE_BRANCH,
-              body: `This PR adds the bootstrap identity \`${bootstrapIdentityId}\` to the directory readers for subscription \`${subscriptionName}\`.`,
+              body: `This PR adds the bootstrap identity \`${bootstrapIdentityId}\` to the directory readers and configures AD groups for subscription \`${subscriptionName}\`.`,
               head: branchName,
               owner: REPO_OWNER,
               repo: REPO_NAME,
-              title: `Add directory reader for ${subscriptionName}`,
+              title: `Add bootstrap identity and AD groups for ${subscriptionName}`,
             }),
             () =>
               new AuthorizationError(

--- a/apps/cli/src/adapters/pagopa-technology/authorization.ts
+++ b/apps/cli/src/adapters/pagopa-technology/authorization.ts
@@ -31,11 +31,13 @@ const authorizationFileSchema = z
       .loose(),
     groups: z
       .array(
-        z.object({
-          members: z.array(z.string()),
-          name: z.string(),
-          roles: z.array(z.string()),
-        }),
+        z
+          .object({
+            members: z.array(z.string()),
+            name: z.string(),
+            roles: z.array(z.string()),
+          })
+          .loose(),
       )
       .optional(),
   })
@@ -71,49 +73,43 @@ const upsertGroups = (
   groupsChanged: boolean;
   json: z.infer<typeof authorizationFileSchema>;
 } => {
-  type GroupEntry = { members: string[]; name: string; roles: string[] };
-
-  const expectedGroups: GroupEntry[] = DEFAULT_GROUP_SPECS.map((spec) => ({
-    members: [],
-    name: makeGroupName(prefix, envShort, spec.groupName),
-    roles: [...spec.roles],
-  }));
+  const expectedByName = new Map(
+    DEFAULT_GROUP_SPECS.map((spec) => [
+      makeGroupName(prefix, envShort, spec.groupName),
+      spec,
+    ]),
+  );
 
   const existingGroups = jsonContent.groups ?? [];
-  const existingByName = new Map(
-    existingGroups.map((group) => [group.name, group]),
-  );
-  const processedNames = new Set<string>();
+  const seenDefaults = new Set<string>();
 
-  const finalGroups: GroupEntry[] = [];
+  // Walk existing groups in their original order, updating roles where needed
+  const finalGroups: typeof existingGroups = [];
   let groupsChanged = false;
 
-  for (const expected of expectedGroups) {
-    const existing = existingByName.get(expected.name);
-    processedNames.add(expected.name);
-
-    if (!existing) {
-      // Group is missing — add it with default roles and no members
-      finalGroups.push(expected);
-      groupsChanged = true;
-    } else if (!rolesAreEqual(existing.roles, expected.roles)) {
-      // Roles differ — update roles, preserve members
-      finalGroups.push({
-        members: [...existing.members],
-        name: expected.name,
-        roles: [...expected.roles],
-      });
-      groupsChanged = true;
+  for (const existing of existingGroups) {
+    const spec = expectedByName.get(existing.name);
+    if (!spec) {
+      // Custom group — preserve as-is
+      finalGroups.push(existing);
     } else {
-      // Already correct — keep as-is
-      finalGroups.push({ ...existing });
+      seenDefaults.add(existing.name);
+      if (!rolesAreEqual(existing.roles, spec.roles)) {
+        // Roles differ — update roles, preserve members and any extra fields
+        finalGroups.push({ ...existing, roles: [...spec.roles] });
+        groupsChanged = true;
+      } else {
+        finalGroups.push(existing);
+      }
     }
   }
 
-  // Preserve any custom groups not in the default list
-  for (const existing of existingGroups) {
-    if (!processedNames.has(existing.name)) {
-      finalGroups.push({ ...existing });
+  // Append missing default groups at the end
+  for (const spec of DEFAULT_GROUP_SPECS) {
+    const name = makeGroupName(prefix, envShort, spec.groupName);
+    if (!seenDefaults.has(name)) {
+      finalGroups.push({ members: [], name, roles: [...spec.roles] });
+      groupsChanged = true;
     }
   }
 
@@ -145,6 +141,39 @@ const parseAuthorizationFile = (
   }
 
   return ok(result.data);
+};
+
+/**
+ * Produces commit message, PR title, and PR body tailored to what actually changed.
+ */
+const makeChangeDescription = (
+  subscriptionName: string,
+  bootstrapIdentityId: string,
+  identityAdded: boolean,
+  groupsChanged: boolean,
+): { body: string; message: string; title: string } => {
+  if (identityAdded && groupsChanged) {
+    const title = `Add bootstrap identity and AD groups for ${subscriptionName}`;
+    return {
+      body: `This PR adds the bootstrap identity \`${bootstrapIdentityId}\` to the directory readers and configures AD groups for subscription \`${subscriptionName}\`.`,
+      message: title,
+      title,
+    };
+  }
+  if (identityAdded) {
+    const title = `Add bootstrap identity for ${subscriptionName}`;
+    return {
+      body: `This PR adds the bootstrap identity \`${bootstrapIdentityId}\` to the directory readers for subscription \`${subscriptionName}\`.`,
+      message: title,
+      title,
+    };
+  }
+  const title = `Configure AD groups for ${subscriptionName}`;
+  return {
+    body: `This PR configures AD groups for subscription \`${subscriptionName}\`.`,
+    message: title,
+    title,
+  };
 };
 
 /**
@@ -202,42 +231,23 @@ export const makeAuthorizationService = (
     const branchName = `feats/add-${repoName}-${subscriptionName}-bootstrap-identity`;
 
     return (
-      // Step 1: Create branch first to avoid race condition with main branch updates
+      // Step 1: Read file from main to determine if changes are needed
       ResultAsync.fromPromise(
-        gitHubService.createBranch({
-          branchName,
-          fromRef: BASE_BRANCH,
+        gitHubService.getFileContent({
           owner: REPO_OWNER,
+          path: filePath,
+          ref: BASE_BRANCH,
           repo: REPO_NAME,
         }),
         () =>
           new AuthorizationError(
-            `Unable to create branch ${branchName} in ${REPO_OWNER}/${REPO_NAME}`,
+            `Unable to get ${filePath} in ${REPO_OWNER}/${REPO_NAME}`,
           ),
       )
         .orTee((error) => {
           logger.error(error.message);
         })
-        // Step 2: Fetch file content from the newly created branch
-        .andThen(() =>
-          ResultAsync.fromPromise(
-            gitHubService.getFileContent({
-              owner: REPO_OWNER,
-              path: filePath,
-              ref: branchName,
-              repo: REPO_NAME,
-            }),
-            () =>
-              new AuthorizationError(
-                `Unable to get ${filePath} in ${REPO_OWNER}/${REPO_NAME}`,
-              ),
-          ),
-        )
-        .orTee((error) => {
-          logger.error(error.message);
-        })
-        // Step 3: Parse file, ensure identity is present, upsert AD groups.
-        // If nothing changed, short-circuit and skip the file update and PR creation.
+        // Step 2: Parse file, ensure identity, upsert groups, detect no-op
         .andThen(({ content, sha }) => {
           const parseResult = parseAuthorizationFile(content);
           if (parseResult.isErr()) {
@@ -266,51 +276,80 @@ export const makeAuthorizationService = (
           );
 
           if (!identityAdded && !groupsChanged) {
-            // Nothing to do — identity was already present and all groups are correct.
+            // Nothing to do — no branch created, no PR needed.
             logger.info("No changes needed, skipping PR", {
               subscription: subscriptionName,
             });
             return okAsync(new AuthorizationResult());
           }
 
-          return ResultAsync.fromPromise(
-            gitHubService.updateFile({
-              branch: branchName,
-              content: JSON.stringify(updatedJson, null, 2),
-              message: `Add bootstrap identity and AD groups for ${subscriptionName}`,
-              owner: REPO_OWNER,
-              path: filePath,
-              repo: REPO_NAME,
-              sha,
-            }),
-            () =>
-              new AuthorizationError(
-                `Unable to update ${filePath} on branch ${branchName} in ${REPO_OWNER}/${REPO_NAME}`,
-              ),
-          )
-            .orTee((error) => {
-              logger.error(error.message);
-            })
-            .andThen(() =>
-              ResultAsync.fromPromise(
-                gitHubService.createPullRequest({
-                  base: BASE_BRANCH,
-                  body: `This PR adds the bootstrap identity \`${bootstrapIdentityId}\` to the directory readers and configures AD groups for subscription \`${subscriptionName}\`.`,
-                  head: branchName,
-                  owner: REPO_OWNER,
-                  repo: REPO_NAME,
-                  title: `Add bootstrap identity and AD groups for ${subscriptionName}`,
-                }),
-                () =>
-                  new AuthorizationError(
-                    `Unable to create pull request from ${branchName} to ${BASE_BRANCH} in ${REPO_OWNER}/${REPO_NAME}`,
-                  ),
-              ),
+          const { body, message, title } = makeChangeDescription(
+            subscriptionName,
+            bootstrapIdentityId,
+            identityAdded,
+            groupsChanged,
+          );
+
+          // Step 3: Create branch only when changes are needed
+          return (
+            ResultAsync.fromPromise(
+              gitHubService.createBranch({
+                branchName,
+                fromRef: BASE_BRANCH,
+                owner: REPO_OWNER,
+                repo: REPO_NAME,
+              }),
+              () =>
+                new AuthorizationError(
+                  `Unable to create branch ${branchName} in ${REPO_OWNER}/${REPO_NAME}`,
+                ),
             )
-            .orTee((error) => {
-              logger.error(error.message);
-            })
-            .map((pr) => new AuthorizationResult(pr.url));
+              .orTee((error) => {
+                logger.error(error.message);
+              })
+              // Step 4: Update file on the branch using the SHA read from main
+              .andThen(() =>
+                ResultAsync.fromPromise(
+                  gitHubService.updateFile({
+                    branch: branchName,
+                    content: JSON.stringify(updatedJson, null, 2),
+                    message,
+                    owner: REPO_OWNER,
+                    path: filePath,
+                    repo: REPO_NAME,
+                    sha,
+                  }),
+                  () =>
+                    new AuthorizationError(
+                      `Unable to update ${filePath} on branch ${branchName} in ${REPO_OWNER}/${REPO_NAME}`,
+                    ),
+                ),
+              )
+              .orTee((error) => {
+                logger.error(error.message);
+              })
+              // Step 5: Create PR
+              .andThen(() =>
+                ResultAsync.fromPromise(
+                  gitHubService.createPullRequest({
+                    base: BASE_BRANCH,
+                    body,
+                    head: branchName,
+                    owner: REPO_OWNER,
+                    repo: REPO_NAME,
+                    title,
+                  }),
+                  () =>
+                    new AuthorizationError(
+                      `Unable to create pull request from ${branchName} to ${BASE_BRANCH} in ${REPO_OWNER}/${REPO_NAME}`,
+                    ),
+                ),
+              )
+              .orTee((error) => {
+                logger.error(error.message);
+              })
+              .map((pr) => new AuthorizationResult(pr.url))
+          );
         })
     );
   },

--- a/apps/cli/src/adapters/pagopa-technology/azure-authorization-config.ts
+++ b/apps/cli/src/adapters/pagopa-technology/azure-authorization-config.ts
@@ -1,0 +1,54 @@
+/**
+ * Azure authorization group configuration
+ *
+ * Defines the default Azure AD groups that the PagoPA Technology adapter
+ * keeps aligned inside the subscription authorization repository.
+ */
+
+type AzureAdGroupSpec = {
+  readonly groupName: string;
+  readonly roles: readonly string[];
+};
+
+export const DEFAULT_GROUP_SPECS: readonly AzureAdGroupSpec[] = [
+  { groupName: "admin", roles: ["Owner"] },
+  { groupName: "developers", roles: ["Owner"] },
+  {
+    groupName: "operations",
+    roles: [
+      "Reader",
+      "Monitoring Contributor",
+      "Support Request Contributor",
+      "Storage Blob Data Reader",
+      "Storage Queue Data Reader",
+      "Cosmos DB Account Reader Role",
+    ],
+  },
+  { groupName: "security", roles: ["Reader", "Support Request Contributor"] },
+  {
+    groupName: "technical-project-managers",
+    roles: ["Reader", "Monitoring Contributor", "Support Request Contributor"],
+  },
+  {
+    groupName: "product-owners",
+    roles: ["Reader", "Support Request Contributor"],
+  },
+  { groupName: "externals", roles: ["Owner"] },
+  {
+    groupName: "oncall",
+    roles: [
+      "Reader",
+      "Monitoring Contributor",
+      "Support Request Contributor",
+      "Storage Blob Data Reader",
+      "Storage Queue Data Reader",
+      "Cosmos DB Account Reader Role",
+    ],
+  },
+];
+
+export const makeAzureAdGroupName = (
+  prefix: string,
+  envShort: string,
+  groupName: string,
+): string => `${prefix}-${envShort}-adgroup-${groupName}`;

--- a/apps/cli/src/adapters/pagopa-technology/azure-authorization.ts
+++ b/apps/cli/src/adapters/pagopa-technology/azure-authorization.ts
@@ -1,5 +1,5 @@
 /**
- * PagoPA Technology Authorization Adapter
+ * PagoPA Technology Azure Authorization Adapter
  *
  * Implements the AuthorizationService interface for the PagoPA Azure
  * authorization workflow. Encapsulates all platform-specific details:
@@ -15,14 +15,16 @@ import {
   AuthorizationError,
   AuthorizationResult,
   AuthorizationService,
-  DEFAULT_GROUP_SPECS,
   InvalidAuthorizationFileFormatError,
-  makeGroupName,
   RequestAuthorizationInput,
 } from "../../domain/authorization.js";
 import { GitHubService } from "../../domain/github.js";
+import {
+  DEFAULT_GROUP_SPECS,
+  makeAzureAdGroupName,
+} from "./azure-authorization-config.js";
 
-const authorizationFileSchema = z
+const azureAuthorizationFileSchema = z
   .object({
     directory_readers: z
       .object({
@@ -66,16 +68,16 @@ const rolesAreEqual = (
  * Returns the updated JSON along with a flag indicating whether anything changed.
  */
 const upsertGroups = (
-  jsonContent: z.infer<typeof authorizationFileSchema>,
+  jsonContent: z.infer<typeof azureAuthorizationFileSchema>,
   prefix: string,
   envShort: string,
 ): {
   groupsChanged: boolean;
-  json: z.infer<typeof authorizationFileSchema>;
+  json: z.infer<typeof azureAuthorizationFileSchema>;
 } => {
   const expectedByName = new Map(
     DEFAULT_GROUP_SPECS.map((spec) => [
-      makeGroupName(prefix, envShort, spec.groupName),
+      makeAzureAdGroupName(prefix, envShort, spec.groupName),
       spec,
     ]),
   );
@@ -106,7 +108,7 @@ const upsertGroups = (
 
   // Append missing default groups at the end
   for (const spec of DEFAULT_GROUP_SPECS) {
-    const name = makeGroupName(prefix, envShort, spec.groupName);
+    const name = makeAzureAdGroupName(prefix, envShort, spec.groupName);
     if (!seenDefaults.has(name)) {
       finalGroups.push({ members: [], name, roles: [...spec.roles] });
       groupsChanged = true;
@@ -121,7 +123,7 @@ const upsertGroups = (
  */
 const parseAuthorizationFile = (
   content: string,
-): Result<z.infer<typeof authorizationFileSchema>, AuthorizationError> => {
+): Result<z.infer<typeof azureAuthorizationFileSchema>, AuthorizationError> => {
   let parsed;
   try {
     parsed = JSON.parse(content);
@@ -131,7 +133,7 @@ const parseAuthorizationFile = (
     );
   }
 
-  const result = authorizationFileSchema.safeParse(parsed);
+  const result = azureAuthorizationFileSchema.safeParse(parsed);
   if (!result.success) {
     return err(
       new InvalidAuthorizationFileFormatError(
@@ -182,11 +184,11 @@ const makeChangeDescription = (
  * Never fails: if the identity already exists it is a no-op with identityAdded = false.
  */
 const ensureIdentity = (
-  jsonContent: z.infer<typeof authorizationFileSchema>,
+  jsonContent: z.infer<typeof azureAuthorizationFileSchema>,
   identityId: string,
 ): {
   identityAdded: boolean;
-  json: z.infer<typeof authorizationFileSchema>;
+  json: z.infer<typeof azureAuthorizationFileSchema>;
 } => {
   if (
     jsonContent.directory_readers.service_principals_name.includes(identityId)
@@ -213,13 +215,13 @@ const REPO_OWNER = "pagopa";
 const REPO_NAME = "eng-azure-authorization";
 const BASE_BRANCH = "main";
 
-export const makeAuthorizationService = (
+export const makeAzureAuthorizationService = (
   gitHubService: GitHubService,
 ): AuthorizationService => ({
   requestAuthorization(
     input: RequestAuthorizationInput,
   ): ResultAsync<AuthorizationResult, AuthorizationError> {
-    const logger = getLogger(["dx-cli", "pagopa-authorization"]);
+    const logger = getLogger(["dx-cli", "pagopa-azure-authorization"]);
     const {
       bootstrapIdentityId,
       envShort,

--- a/apps/cli/src/domain/authorization.ts
+++ b/apps/cli/src/domain/authorization.ts
@@ -35,13 +35,107 @@ const BootstrapIdentityId = z
   .brand<"BootstrapIdentityId">();
 
 /**
+ * Branded type for resource prefix (e.g., "dx", "io").
+ * Validates that the prefix contains only lowercase letters to prevent injection.
+ */
+const ResourcePrefix = z
+  .string()
+  .min(1)
+  .regex(/^[a-z]+$/, {
+    message: "Resource prefix may contain only lowercase letters",
+  })
+  .brand<"ResourcePrefix">();
+
+/**
+ * Branded type for environment short name (e.g., "d", "u", "p").
+ * Validates single lowercase letter for environment.
+ */
+const EnvShort = z
+  .string()
+  .min(1)
+  .max(1)
+  .regex(/^[a-z]$/, {
+    message: "Environment short name must be a single lowercase letter",
+  })
+  .brand<"EnvShort">();
+
+/**
  * Input validation schema for the request authorization use case.
  */
 export const requestAuthorizationInputSchema = z.object({
   bootstrapIdentityId: BootstrapIdentityId,
+  envShort: EnvShort,
+  prefix: ResourcePrefix,
   repoName: z.string().min(1),
   subscriptionName: SubscriptionName,
 });
+
+/**
+ * Configuration for an AD group with its roles and members.
+ */
+export type GroupConfig = {
+  readonly members: readonly string[];
+  readonly name: string;
+  readonly roles: readonly string[];
+};
+
+/**
+ * Specification for a default AD group (name suffix + default roles).
+ */
+type DefaultGroupSpec = {
+  readonly groupName: string;
+  readonly roles: readonly string[];
+};
+
+/**
+ * Default AD groups that should exist for each subscription.
+ * Naming pattern: <prefix>-<envShort>-adgroup-<groupName>
+ */
+export const DEFAULT_GROUP_SPECS: readonly DefaultGroupSpec[] = [
+  { groupName: "admin", roles: ["Owner"] },
+  { groupName: "developers", roles: ["Owner"] },
+  {
+    groupName: "operations",
+    roles: [
+      "Reader",
+      "Monitoring Contributor",
+      "Support Request Contributor",
+      "Storage Blob Data Reader",
+      "Storage Queue Data Reader",
+      "Cosmos DB Account Reader Role",
+    ],
+  },
+  { groupName: "security", roles: ["Reader", "Support Request Contributor"] },
+  {
+    groupName: "technical-project-managers",
+    roles: ["Reader", "Monitoring Contributor", "Support Request Contributor"],
+  },
+  {
+    groupName: "product-owners",
+    roles: ["Reader", "Support Request Contributor"],
+  },
+  { groupName: "externals", roles: ["Owner"] },
+  {
+    groupName: "oncall",
+    roles: [
+      "Reader",
+      "Monitoring Contributor",
+      "Support Request Contributor",
+      "Storage Blob Data Reader",
+      "Storage Queue Data Reader",
+      "Cosmos DB Account Reader Role",
+    ],
+  },
+];
+
+/**
+ * Generates the full AD group name from its components.
+ */
+export const makeGroupName = (
+  prefix: string,
+  envShort: string,
+  groupName: string,
+): string => `${prefix}-${envShort}-adgroup-${groupName}`;
 
 /**
  * Service interface for requesting cloud authorization.

--- a/apps/cli/src/domain/authorization.ts
+++ b/apps/cli/src/domain/authorization.ts
@@ -164,19 +164,10 @@ export class AuthorizationError extends Error {
 
 /**
  * Result returned by a successful authorization request.
+ * When url is undefined, the workflow was a no-op (nothing changed, no PR created).
  */
 export class AuthorizationResult {
-  constructor(public readonly url: string) {}
-}
-
-/**
- * Error thrown when attempting to add an identity that already exists.
- */
-export class IdentityAlreadyExistsError extends AuthorizationError {
-  constructor(identityId: string) {
-    super(`Identity "${identityId}" already exists`);
-    this.name = "IdentityAlreadyExistsError";
-  }
+  constructor(public readonly url?: string) {}
 }
 
 /**

--- a/apps/cli/src/domain/authorization.ts
+++ b/apps/cli/src/domain/authorization.ts
@@ -60,7 +60,7 @@ const EnvShort = z
   .brand<"EnvShort">();
 
 /**
- * Input validation schema for the request authorization use case.
+ * Input validation schema for the authorization workflow.
  */
 export const requestAuthorizationInputSchema = z.object({
   bootstrapIdentityId: BootstrapIdentityId,
@@ -69,73 +69,6 @@ export const requestAuthorizationInputSchema = z.object({
   repoName: z.string().min(1),
   subscriptionName: SubscriptionName,
 });
-
-/**
- * Configuration for an AD group with its roles and members.
- */
-export type GroupConfig = {
-  readonly members: readonly string[];
-  readonly name: string;
-  readonly roles: readonly string[];
-};
-
-/**
- * Specification for a default AD group (name suffix + default roles).
- */
-type DefaultGroupSpec = {
-  readonly groupName: string;
-  readonly roles: readonly string[];
-};
-
-/**
- * Default AD groups that should exist for each subscription.
- * Naming pattern: <prefix>-<envShort>-adgroup-<groupName>
- */
-export const DEFAULT_GROUP_SPECS: readonly DefaultGroupSpec[] = [
-  { groupName: "admin", roles: ["Owner"] },
-  { groupName: "developers", roles: ["Owner"] },
-  {
-    groupName: "operations",
-    roles: [
-      "Reader",
-      "Monitoring Contributor",
-      "Support Request Contributor",
-      "Storage Blob Data Reader",
-      "Storage Queue Data Reader",
-      "Cosmos DB Account Reader Role",
-    ],
-  },
-  { groupName: "security", roles: ["Reader", "Support Request Contributor"] },
-  {
-    groupName: "technical-project-managers",
-    roles: ["Reader", "Monitoring Contributor", "Support Request Contributor"],
-  },
-  {
-    groupName: "product-owners",
-    roles: ["Reader", "Support Request Contributor"],
-  },
-  { groupName: "externals", roles: ["Owner"] },
-  {
-    groupName: "oncall",
-    roles: [
-      "Reader",
-      "Monitoring Contributor",
-      "Support Request Contributor",
-      "Storage Blob Data Reader",
-      "Storage Queue Data Reader",
-      "Cosmos DB Account Reader Role",
-    ],
-  },
-];
-
-/**
- * Generates the full AD group name from its components.
- */
-export const makeGroupName = (
-  prefix: string,
-  envShort: string,
-  groupName: string,
-): string => `${prefix}-${envShort}-adgroup-${groupName}`;
 
 /**
  * Service interface for requesting cloud authorization.

--- a/apps/cli/src/index.ts
+++ b/apps/cli/src/index.ts
@@ -12,7 +12,7 @@ import {
   getGitHubPAT,
   OctokitGitHubService,
 } from "./adapters/octokit/index.js";
-import { makeAuthorizationService } from "./adapters/pagopa-technology/authorization.js";
+import { makeAzureAuthorizationService } from "./adapters/pagopa-technology/azure-authorization.js";
 import { getConfig } from "./config.js";
 import { Dependencies } from "./domain/dependencies.js";
 import { getInfo } from "./domain/info.js";
@@ -77,7 +77,7 @@ export const runCli = async (version: string) => {
   });
 
   const gitHubService = new OctokitGitHubService(octokit);
-  const authorizationService = makeAuthorizationService(gitHubService);
+  const authorizationService = makeAzureAuthorizationService(gitHubService);
 
   const deps: Dependencies = {
     authorizationService,

--- a/apps/cli/src/use-cases/__tests__/request-authorization.test.ts
+++ b/apps/cli/src/use-cases/__tests__/request-authorization.test.ts
@@ -10,7 +10,6 @@ import {
   AuthorizationError,
   AuthorizationResult,
   AuthorizationService,
-  IdentityAlreadyExistsError,
   RequestAuthorizationInput,
   requestAuthorizationInputSchema,
 } from "../../domain/authorization.js";
@@ -53,15 +52,13 @@ describe("requestAuthorization", () => {
     const input = makeSampleInput();
 
     authorizationService.requestAuthorization.mockReturnValue(
-      errAsync(new IdentityAlreadyExistsError("test-bootstrap-identity-id")),
+      errAsync(new AuthorizationError("Unable to update file")),
     );
 
     const result = await requestAuthorization(authorizationService)(input);
 
     expect(result.isErr()).toBe(true);
-    expect(result._unsafeUnwrapErr()).toBeInstanceOf(
-      IdentityAlreadyExistsError,
-    );
+    expect(result._unsafeUnwrapErr()).toBeInstanceOf(AuthorizationError);
   });
 
   it("should propagate generic authorization errors", async () => {

--- a/apps/cli/src/use-cases/__tests__/request-authorization.test.ts
+++ b/apps/cli/src/use-cases/__tests__/request-authorization.test.ts
@@ -19,6 +19,8 @@ import { requestAuthorization } from "../request-authorization.js";
 const makeSampleInput = (): RequestAuthorizationInput =>
   requestAuthorizationInputSchema.parse({
     bootstrapIdentityId: "test-bootstrap-identity-id",
+    envShort: "d",
+    prefix: "test",
     repoName: "test-repo",
     subscriptionName: "test-subscription",
   });

--- a/apps/cli/src/use-cases/request-authorization.ts
+++ b/apps/cli/src/use-cases/request-authorization.ts
@@ -2,7 +2,7 @@
  * Request Authorization Use Case
  *
  * Orchestrates an authorization request by delegating to the
- * technology-agnostic AuthorizationService.
+ * AuthorizationService.
  */
 
 import { ResultAsync } from "neverthrow";
@@ -17,7 +17,7 @@ import {
 /**
  * Creates a function that requests authorization for a bootstrap identity.
  *
- * @param authorizationService - The service handling platform-specific authorization logic
+ * @param authorizationService - The service handling authorization logic
  * @returns A function that takes input and returns a ResultAsync with the authorization result
  */
 export const requestAuthorization =


### PR DESCRIPTION
This PR implements AD group management in the CLI `init` (authorization) workflow, re-implementing [#1400](https://github.com/pagopa/dx/pull/1400) on top of the JSON format introduced by #1541.

When the CLI creates a PR in `eng-azure-authorization` to add a bootstrap identity, it now also ensures all **8 default AD groups** are present in the subscription's `terraform.tfvars.json`.

### Default AD groups

`<prefix>-<envShort>-adgroup-{admin,developers,operations,security,technical-project-managers,product-owners,externals,oncall}`

Closes CES-1658