### PR TITLE
Give required permissions to GItHub workflows to access Common resource group

### DIFF
--- a/.nx/version-plans/version-plan-1776068362698.md
+++ b/.nx/version-plans/version-plan-1776068362698.md
@@ -1,5 +1,5 @@
 ---
-'@pagopa/dx-cli': patch
+"@pagopa/dx-cli": patch
 ---
 
-When a new environment is initialized, the identities federated with GitHub can access KeyVault and alter roles on the Core's common resource group
+When a new environment is initialized, the identities federated with GitHub can access Key Vault and alter roles on the Core's common resource group

--- a/.nx/version-plans/version-plan-1776068362698.md
+++ b/.nx/version-plans/version-plan-1776068362698.md
@@ -1,0 +1,5 @@
+---
+'@pagopa/dx-cli': patch
+---
+
+When a new environment is initialized, the identities federated with GitHub can access KeyVault and alter roles on the Core's common resource group

--- a/apps/cli/src/adapters/plop/generators/environment/actions.ts
+++ b/apps/cli/src/adapters/plop/generators/environment/actions.ts
@@ -7,11 +7,7 @@ import { Environment } from "../../../../domain/environment.js";
 import { formatTerraformCode } from "../../../terraform/fmt.js";
 import { payloadSchema } from "./prompts.js";
 
-const addModule = (
-  env: Environment,
-  templatesPath: string,
-  extraData: Record<string, unknown> = {},
-) => {
+const addModule = (env: Environment, templatesPath: string, init = false) => {
   const cloudAccountsByCsp = Object.groupBy(
     env.cloudAccounts,
     (account) => account.csp,
@@ -23,7 +19,7 @@ const addModule = (
   return (name: string, terraformBackendKey: string) => [
     {
       base: templatesPath,
-      data: { cloudAccountsByCsp, includesProdIO, ...extraData },
+      data: { cloudAccountsByCsp, includesProdIO, init },
       destination: path.join(cwd, "infra"),
       force: true,
       templateFiles: path.join(templatesPath, name),
@@ -33,7 +29,7 @@ const addModule = (
     },
     {
       base: path.join(templatesPath, "shared"),
-      data: { cloudAccountsByCsp, terraformBackendKey, ...extraData },
+      data: { cloudAccountsByCsp, init, terraformBackendKey },
       destination: path.join(cwd, "infra", name, "{{env.name}}"),
       force: true,
       templateFiles: path.join(templatesPath, "shared"),
@@ -54,9 +50,7 @@ export default function getActions(
 
     const { env, github, init } = payloadSchema.parse(payload);
 
-    const addEnvironmentModule = addModule(env, templatesPath, {
-      init: !!init,
-    });
+    const addEnvironmentModule = addModule(env, templatesPath, !!init);
 
     const actions: ActionType[] = [
       {

--- a/apps/cli/src/adapters/plop/generators/environment/actions.ts
+++ b/apps/cli/src/adapters/plop/generators/environment/actions.ts
@@ -7,7 +7,11 @@ import { Environment } from "../../../../domain/environment.js";
 import { formatTerraformCode } from "../../../terraform/fmt.js";
 import { payloadSchema } from "./prompts.js";
 
-const addModule = (env: Environment, templatesPath: string) => {
+const addModule = (
+  env: Environment,
+  templatesPath: string,
+  extraData: Record<string, unknown> = {},
+) => {
   const cloudAccountsByCsp = Object.groupBy(
     env.cloudAccounts,
     (account) => account.csp,
@@ -19,7 +23,7 @@ const addModule = (env: Environment, templatesPath: string) => {
   return (name: string, terraformBackendKey: string) => [
     {
       base: templatesPath,
-      data: { cloudAccountsByCsp, includesProdIO },
+      data: { cloudAccountsByCsp, includesProdIO, ...extraData },
       destination: path.join(cwd, "infra"),
       force: true,
       templateFiles: path.join(templatesPath, name),
@@ -29,7 +33,7 @@ const addModule = (env: Environment, templatesPath: string) => {
     },
     {
       base: path.join(templatesPath, "shared"),
-      data: { cloudAccountsByCsp, terraformBackendKey },
+      data: { cloudAccountsByCsp, terraformBackendKey, ...extraData },
       destination: path.join(cwd, "infra", name, "{{env.name}}"),
       force: true,
       templateFiles: path.join(templatesPath, "shared"),
@@ -50,7 +54,9 @@ export default function getActions(
 
     const { env, github, init } = payloadSchema.parse(payload);
 
-    const addEnvironmentModule = addModule(env, templatesPath);
+    const addEnvironmentModule = addModule(env, templatesPath, {
+      init: !!init,
+    });
 
     const actions: ActionType[] = [
       {

--- a/apps/cli/templates/environment/bootstrapper/{{env.name}}/main.tf.hbs
+++ b/apps/cli/templates/environment/bootstrapper/{{env.name}}/main.tf.hbs
@@ -120,6 +120,26 @@ module "azure-{{displayName}}_bootstrap" {
 
   tags = local.bootstrapper_tags
 }
+
+{{#if @root.init}}
+resource "azurerm_role_assignment" "infra_cd_user_access_admin_common_rg_{{displayName}}" {
+  scope                = module.azure-{{displayName}}_core_values.common_resource_group_id
+  role_definition_name = "User Access Administrator"
+  principal_id         = module.azure-{{displayName}}_bootstrap.identities.infra.cd.principal_id
+}
+
+resource "azurerm_role_assignment" "infra_cd_kv_secrets_officer_common_{{displayName}}" {
+  scope                = module.azure-{{displayName}}_core_values.common_key_vault.id
+  role_definition_name = "Key Vault Secrets Officer"
+  principal_id         = module.azure-{{displayName}}_bootstrap.identities.infra.cd.principal_id
+}
+
+resource "azurerm_role_assignment" "infra_ci_kv_secrets_user_common_{{displayName}}" {
+  scope                = module.azure-{{displayName}}_core_values.common_key_vault.id
+  role_definition_name = "Key Vault Secrets User"
+  principal_id         = module.azure-{{displayName}}_bootstrap.identities.infra.ci.principal_id
+}
+{{/if}}
 {{/if}}
 {{/each}}
 

--- a/apps/cli/templates/environment/bootstrapper/{{env.name}}/main.tf.hbs
+++ b/apps/cli/templates/environment/bootstrapper/{{env.name}}/main.tf.hbs
@@ -123,18 +123,24 @@ module "azure-{{displayName}}_bootstrap" {
 
 {{#if @root.init}}
 resource "azurerm_role_assignment" "infra_cd_user_access_admin_common_rg_{{displayName}}" {
+  provider = azurerm.{{displayName}}
+
   scope                = module.azure-{{displayName}}_core_values.common_resource_group_id
   role_definition_name = "User Access Administrator"
   principal_id         = module.azure-{{displayName}}_bootstrap.identities.infra.cd.principal_id
 }
 
 resource "azurerm_role_assignment" "infra_cd_kv_secrets_officer_common_{{displayName}}" {
+  provider = azurerm.{{displayName}}
+
   scope                = module.azure-{{displayName}}_core_values.common_key_vault.id
   role_definition_name = "Key Vault Secrets Officer"
   principal_id         = module.azure-{{displayName}}_bootstrap.identities.infra.cd.principal_id
 }
 
 resource "azurerm_role_assignment" "infra_ci_kv_secrets_user_common_{{displayName}}" {
+  provider = azurerm.{{displayName}}
+
   scope                = module.azure-{{displayName}}_core_values.common_key_vault.id
   role_definition_name = "Key Vault Secrets User"
   principal_id         = module.azure-{{displayName}}_bootstrap.identities.infra.ci.principal_id


### PR DESCRIPTION
Enhance the `addModule` function to accept additional data and implement role assignments for identities in the Core's common resource group when a new environment is initialized. This change improves role management and access control in the infrastructure setup.

Resolves CES-1862