### PR TITLE
Add version plan for incremental rollout

### DIFF
--- a/.nx/version-plans/version-plan-1776164159536.md
+++ b/.nx/version-plans/version-plan-1776164159536.md
@@ -1,0 +1,5 @@
+---
+incremental-rollout: patch
+---
+
+Fix external link in the GitHub Action message.


### PR DESCRIPTION
Introduce a new version plan for incremental rollout.

Reason: I forgot to add it when fixing the package here: https://github.com/pagopa/dx/pull/1591