### PR TITLE
Improve terraform projects discovery

### DIFF
--- a/.nx/version-plans/version-plan-1776329201422.md
+++ b/.nx/version-plans/version-plan-1776329201422.md
@@ -1,0 +1,5 @@
+---
+"@pagopa/nx-terraform-plugin": preminor
+---
+
+Skip creating Nx projects for Terraform files located under tests/\_tests and examples/example directories

--- a/.nx/version-plans/version-plan-1776329242535.md
+++ b/.nx/version-plans/version-plan-1776329242535.md
@@ -1,0 +1,5 @@
+---
+"@pagopa/nx-terraform-plugin": preminor
+---
+
+Add projectType to generated project configurations, classifying paths under modules/\_modules as library and others as application

--- a/packages/nx-terraform-plugin/src/index.ts
+++ b/packages/nx-terraform-plugin/src/index.ts
@@ -2,11 +2,14 @@ import {
   CreateDependencies,
   createNodesFromFiles,
   CreateNodesV2,
+  ProjectType,
 } from "@nx/devkit";
 import path from "node:path";
 
 import { getStaticDependenciesFromFile } from "./fs.ts";
 import { getProjectNameFromRoot, getTerraformProjectFiles } from "./project.ts";
+
+const ignoreModules = ["tests", "_tests", "examples", "example"];
 
 export const createNodesV2: CreateNodesV2<unknown> = [
   // We create a terraform project for each directory containing .tf files
@@ -15,6 +18,15 @@ export const createNodesV2: CreateNodesV2<unknown> = [
     await createNodesFromFiles(
       (configFile) => {
         const root = path.dirname(configFile);
+
+        const rootSegments = new Set(root.split(path.sep));
+
+        if (ignoreModules.some((module) => rootSegments.has(module))) {
+          return {
+            projects: {},
+          };
+        }
+
         const name = getProjectNameFromRoot(root);
         return {
           projects: {

--- a/packages/nx-terraform-plugin/src/index.ts
+++ b/packages/nx-terraform-plugin/src/index.ts
@@ -28,10 +28,17 @@ export const createNodesV2: CreateNodesV2<unknown> = [
         }
 
         const name = getProjectNameFromRoot(root);
+
+        const projectType: ProjectType =
+          rootSegments.has("modules") || rootSegments.has("_modules")
+            ? "library"
+            : "application";
+
         return {
           projects: {
             [root]: {
               name,
+              projectType,
               // We assign the 'terraform' tag to all projects created from Terraform configuration files
               // So that they can be easily targeted in Nx commands with --projects=tag:terraform
               tags: ["terraform"],


### PR DESCRIPTION
- Skip creating Nx projects for Terraform files located under `tests`/`_tests` and `examples`/`example` directories.
- Add `projectType` to generated project configurations, classifying paths under `modules`/`_modules` as `library` and others as `application`.

### How to test

```bash
# list all terraform apps (modules that can be applied)
nx show projects --type app --projects tag:terraform 
```

```bash
# list all libraries
nx show projects --type lib --projects tag:terraform
```