### PR TITLE
Document Azure token validation

### DIFF
--- a/.nx/version-plans/version-plan-1776247234159.md
+++ b/.nx/version-plans/version-plan-1776247234159.md
@@ -1,7 +1,0 @@
----
-'@pagopa/dx-cli': patch
----
-
-Remove `az group list` execution since the output is not used.
-
-This will speed up the preconditions check improving the DX CLI performance.

--- a/.nx/version-plans/version-plan-1776247234159.md
+++ b/.nx/version-plans/version-plan-1776247234159.md
@@ -4,4 +4,4 @@
 
 Remove `az group list` execution since the output is not used.
 
-This will speed up the preconditions check improving the DX CLI performances.
+This will speed up the preconditions check improving the DX CLI performance.

--- a/.nx/version-plans/version-plan-1776247234159.md
+++ b/.nx/version-plans/version-plan-1776247234159.md
@@ -1,0 +1,7 @@
+---
+'@pagopa/dx-cli': patch
+---
+
+Remove `az group list` execution since the output is not used.
+
+This will speed up the preconditions check improving the DX CLI performances.

--- a/apps/cli/src/adapters/commander/commands/init.ts
+++ b/apps/cli/src/adapters/commander/commands/init.ts
@@ -106,6 +106,9 @@ const azureAccountSchema = z.object({
 
 const ensureAzLogin = async (): Promise<string> => {
   const { stdout } = await tf$`az account show`;
+  // `az account show` reads the cached CLI context, but `az group list`
+  // fails when the current session token has expired.
+  await tf$`az group list`;
   const parsed = JSON.parse(stdout);
   const { user } = azureAccountSchema.parse(parsed);
   return user.name;

--- a/apps/cli/src/adapters/commander/commands/init.ts
+++ b/apps/cli/src/adapters/commander/commands/init.ts
@@ -106,7 +106,6 @@ const azureAccountSchema = z.object({
 
 const ensureAzLogin = async (): Promise<string> => {
   const { stdout } = await tf$`az account show`;
-  await tf$`az group list`;
   const parsed = JSON.parse(stdout);
   const { user } = azureAccountSchema.parse(parsed);
   return user.name;


### PR DESCRIPTION
This pull request documents why the DX CLI still runs `az group list` during the Azure precondition check.

The extra command is intentional: `az account show` reads the cached CLI context, while `az group list` fails when the current Azure session token has expired. Keeping that behavior documented makes the precondition check easier to understand and avoids future regressions during cleanup work.