### PR TITLE
Update the tracing package to be compatible with Managed Identity

### DIFF
--- a/.nx/version-plans/version-plan-1776249973156.md
+++ b/.nx/version-plans/version-plan-1776249973156.md
@@ -1,0 +1,7 @@
+---
+'@pagopa/azure-tracing': minor
+---
+
+Add Microsoft Entra ID (Managed Identity) authentication support via `APPLICATIONINSIGHTS_ENTRA_ID_AUTH_ENABLED` env var. 
+
+Connection-string-only auth remains the default for backward compatibility but is now deprecated and will be removed in the next major release. Set `APPLICATIONINSIGHTS_ENTRA_ID_AUTH_ENABLED=true` to adopt the new secure authentication.

--- a/packages/azure-tracing/README.md
+++ b/packages/azure-tracing/README.md
@@ -43,10 +43,16 @@ For more background on this workaround, see:
 
 In order to enable tracing, you also need to set the following environment variables:
 
-| **Name**                                  | **Required** | **Default** |
-| ----------------------------------------- | ------------ | ----------- |
-| **APPINSIGHTS_SAMPLING_PERCENTAGE**       | false        | 5           |
-| **APPLICATIONINSIGHTS_CONNECTION_STRING** | true         | -           |
+| **Name**                                      | **Required** | **Default** |
+| --------------------------------------------- | ------------ | ----------- |
+| **APPINSIGHTS_SAMPLING_PERCENTAGE**           | false        | 5           |
+| **APPLICATIONINSIGHTS_CONNECTION_STRING**     | true         | -           |
+| **APPLICATIONINSIGHTS_ENTRA_ID_AUTH_ENABLED** | false        | false       |
+
+> [!WARNING]
+> Connection-string-only authentication (the current default) is **deprecated** and will be removed in the next major version.
+> Set `APPLICATIONINSIGHTS_ENTRA_ID_AUTH_ENABLED=true` to adopt Microsoft Entra ID authentication now.
+> See [Microsoft Entra ID Authentication](#microsoft-entra-id-authentication) for details.
 
 #### Step 2: Register Azure Function Lifecycle Hooks
 
@@ -118,6 +124,24 @@ emitCustomEvent("taskCreated", { id: task.id })("CreateTaskHandler");
 ```
 
 This is especially useful for tracing domain-specific actions (e.g., resource creation, user actions, error tracking).
+
+## Microsoft Entra ID Authentication
+
+> [!IMPORTANT]
+> Microsoft Entra ID authentication is the **recommended** and more secure way to connect to Application Insights.
+> Connection-string-only authentication is deprecated and will be removed in the **next major release**.
+
+Set `APPLICATIONINSIGHTS_ENTRA_ID_AUTH_ENABLED=true` to enable [Microsoft Entra ID authentication](https://learn.microsoft.com/en-us/azure/azure-monitor/app/azure-ad-authentication).
+The package uses [`DefaultAzureCredential`](https://learn.microsoft.com/en-us/azure/developer/javascript/sdk/authentication/credential-chains#use-defaultazurecredential-for-flexibility) from `@azure/identity`, which automatically resolves the right credential for the environment:
+
+- **Azure (production)**: uses the Managed Identity assigned to the resource (App Service, Azure Function, Container App, etc.)
+- **Local development**: falls back to Azure CLI, Azure Developer CLI, or service principal env vars
+
+The connection string (`APPLICATIONINSIGHTS_CONNECTION_STRING`) is still required in both modes — it identifies the Application Insights resource.
+
+### Required Azure RBAC role
+
+The managed identity (or other principal) must have the **Monitoring Metrics Publisher** role on the Application Insights resource.
 
 ## Dependency Constraints
 

--- a/packages/azure-tracing/package.json
+++ b/packages/azure-tracing/package.json
@@ -65,6 +65,7 @@
     }
   },
   "dependencies": {
+    "@azure/identity": "catalog:",
     "@azure/monitor-opentelemetry": "catalog:opentelemetry",
     "@azure/monitor-opentelemetry-exporter": "catalog:opentelemetry",
     "@opentelemetry/api": "catalog:opentelemetry",

--- a/packages/azure-tracing/src/azure/monitor/__tests__/env.test.ts
+++ b/packages/azure-tracing/src/azure/monitor/__tests__/env.test.ts
@@ -1,0 +1,89 @@
+/**
+ * Tests for env.ts — validates that loadEnv() correctly parses and validates
+ * environment variables used to configure the Azure Monitor integration.
+ */
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+describe("loadEnv", () => {
+  afterEach(() => {
+    vi.unstubAllEnvs();
+  });
+
+  const stubRequiredEnvVariables = () => {
+    vi.stubEnv(
+      "APPLICATIONINSIGHTS_CONNECTION_STRING",
+      "InstrumentationKey=test-key",
+    );
+  };
+
+  it("succeeds with only the connection string (backward-compatible default)", async () => {
+    stubRequiredEnvVariables();
+    const { loadEnv } = await import("../env.js");
+
+    const env = loadEnv();
+
+    expect(env).toStrictEqual({
+      APPINSIGHTS_SAMPLING_PERCENTAGE: 0.05,
+      APPLICATIONINSIGHTS_CONNECTION_STRING: "InstrumentationKey=test-key",
+      APPLICATIONINSIGHTS_ENTRA_ID_AUTH_ENABLED: false,
+    });
+  });
+
+  it("throws when required environment variable is missing", async () => {
+    const { loadEnv } = await import("../env.js");
+
+    expect(() => loadEnv()).toThrow();
+  });
+
+  it("parses APPLICATIONINSIGHTS_ENTRA_ID_AUTH_ENABLED=true", async () => {
+    stubRequiredEnvVariables();
+    vi.stubEnv("APPLICATIONINSIGHTS_ENTRA_ID_AUTH_ENABLED", "true");
+    const { loadEnv } = await import("../env.js");
+
+    const env = loadEnv();
+
+    expect(env).toStrictEqual({
+      APPINSIGHTS_SAMPLING_PERCENTAGE: 0.05,
+      APPLICATIONINSIGHTS_CONNECTION_STRING: "InstrumentationKey=test-key",
+      APPLICATIONINSIGHTS_ENTRA_ID_AUTH_ENABLED: true,
+    });
+  });
+
+  it("parses APPLICATIONINSIGHTS_ENTRA_ID_AUTH_ENABLED=false", async () => {
+    stubRequiredEnvVariables();
+    vi.stubEnv("APPLICATIONINSIGHTS_ENTRA_ID_AUTH_ENABLED", "false");
+    const { loadEnv } = await import("../env.js");
+
+    const env = loadEnv();
+
+    expect(env).toStrictEqual({
+      APPINSIGHTS_SAMPLING_PERCENTAGE: 0.05,
+      APPLICATIONINSIGHTS_CONNECTION_STRING: "InstrumentationKey=test-key",
+      APPLICATIONINSIGHTS_ENTRA_ID_AUTH_ENABLED: false,
+    });
+  });
+
+  it("rejects invalid APPLICATIONINSIGHTS_ENTRA_ID_AUTH_ENABLED values", async () => {
+    stubRequiredEnvVariables();
+    vi.stubEnv("APPLICATIONINSIGHTS_ENTRA_ID_AUTH_ENABLED", "anInvalidValue");
+    const { loadEnv } = await import("../env.js");
+
+    expect(() => loadEnv()).toThrow(
+      /APPLICATIONINSIGHTS_ENTRA_ID_AUTH_ENABLED[\s\S]*Invalid option/i,
+    );
+  });
+
+  it("parses environment variables", async () => {
+    stubRequiredEnvVariables();
+    vi.stubEnv("APPINSIGHTS_SAMPLING_PERCENTAGE", "60");
+    vi.stubEnv("APPLICATIONINSIGHTS_ENTRA_ID_AUTH_ENABLED", "true");
+    const { loadEnv } = await import("../env.js");
+
+    const env = loadEnv();
+    expect(env).toStrictEqual({
+      APPINSIGHTS_SAMPLING_PERCENTAGE: 0.6,
+      APPLICATIONINSIGHTS_CONNECTION_STRING: "InstrumentationKey=test-key",
+      APPLICATIONINSIGHTS_ENTRA_ID_AUTH_ENABLED: true,
+    });
+  });
+});

--- a/packages/azure-tracing/src/azure/monitor/__tests__/start-from-env.test.ts
+++ b/packages/azure-tracing/src/azure/monitor/__tests__/start-from-env.test.ts
@@ -1,0 +1,96 @@
+/**
+ * Tests for start-from-env.ts — validates that initFromEnv() configures Azure Monitor
+ * correctly depending on the Entra ID auth env var.
+ */
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+// Mock the Azure Monitor SDK to avoid real telemetry setup in tests
+vi.mock("@azure/monitor-opentelemetry", () => ({
+  useAzureMonitor: vi.fn(),
+}));
+
+// Mock @azure/identity so we can assert DefaultAzureCredential is used
+vi.mock("@azure/identity", () => ({
+  DefaultAzureCredential: vi.fn().mockImplementation(() => ({
+    getToken: vi.fn(),
+  })),
+}));
+
+describe("initFromEnv", () => {
+  const CONNECTION_STRING = "InstrumentationKey=test-key";
+
+  afterEach(() => {
+    vi.resetModules();
+    vi.unstubAllEnvs();
+    vi.restoreAllMocks();
+    vi.clearAllMocks();
+  });
+
+  it("calls useAzureMonitor WITHOUT credential when Entra ID auth is not enabled (default)", async () => {
+    vi.stubEnv("APPLICATIONINSIGHTS_CONNECTION_STRING", CONNECTION_STRING);
+
+    const { useAzureMonitor } = await import("@azure/monitor-opentelemetry");
+    const { initFromEnv } = await import("../start-from-env.js");
+
+    initFromEnv();
+
+    expect(useAzureMonitor).toHaveBeenCalledOnce();
+    const calledOptions = vi.mocked(useAzureMonitor).mock.calls[0]?.[0];
+    expect(
+      calledOptions?.azureMonitorExporterOptions?.credential,
+    ).toBeUndefined();
+    expect(calledOptions?.azureMonitorExporterOptions?.connectionString).toBe(
+      CONNECTION_STRING,
+    );
+  });
+
+  it("calls useAzureMonitor WITH DefaultAzureCredential when Entra ID auth is enabled", async () => {
+    vi.stubEnv("APPLICATIONINSIGHTS_CONNECTION_STRING", CONNECTION_STRING);
+    vi.stubEnv("APPLICATIONINSIGHTS_ENTRA_ID_AUTH_ENABLED", "true");
+
+    const { DefaultAzureCredential } = await import("@azure/identity");
+    const { useAzureMonitor } = await import("@azure/monitor-opentelemetry");
+    const { initFromEnv } = await import("../start-from-env.js");
+
+    initFromEnv();
+
+    expect(DefaultAzureCredential).toHaveBeenCalledOnce();
+    expect(useAzureMonitor).toHaveBeenCalledOnce();
+    const calledOptions = vi.mocked(useAzureMonitor).mock.calls[0]?.[0];
+    expect(
+      calledOptions?.azureMonitorExporterOptions?.credential,
+    ).toBeDefined();
+    expect(calledOptions?.azureMonitorExporterOptions?.connectionString).toBe(
+      CONNECTION_STRING,
+    );
+  });
+
+  it("passes samplingRatio and tracesPerSecond when Entra ID auth is not enabled", async () => {
+    vi.stubEnv("APPLICATIONINSIGHTS_CONNECTION_STRING", CONNECTION_STRING);
+    vi.stubEnv("APPINSIGHTS_SAMPLING_PERCENTAGE", "10");
+
+    const { useAzureMonitor } = await import("@azure/monitor-opentelemetry");
+    const { initFromEnv } = await import("../start-from-env.js");
+
+    initFromEnv();
+
+    const calledOptions = vi.mocked(useAzureMonitor).mock.calls[0]?.[0];
+    expect(calledOptions?.samplingRatio).toBeCloseTo(0.1);
+    expect(calledOptions?.tracesPerSecond).toBe(0);
+  });
+
+  it("passes samplingRatio and tracesPerSecond when Entra ID auth is enabled", async () => {
+    vi.stubEnv("APPLICATIONINSIGHTS_CONNECTION_STRING", CONNECTION_STRING);
+    vi.stubEnv("APPINSIGHTS_SAMPLING_PERCENTAGE", "10");
+    vi.stubEnv("APPLICATIONINSIGHTS_ENTRA_ID_AUTH_ENABLED", "true");
+
+    const { useAzureMonitor } = await import("@azure/monitor-opentelemetry");
+    const { initFromEnv } = await import("../start-from-env.js");
+
+    initFromEnv();
+
+    const calledOptions = vi.mocked(useAzureMonitor).mock.calls[0]?.[0];
+    expect(calledOptions?.samplingRatio).toBeCloseTo(0.1);
+    expect(calledOptions?.tracesPerSecond).toBe(0);
+  });
+});

--- a/packages/azure-tracing/src/azure/monitor/env.ts
+++ b/packages/azure-tracing/src/azure/monitor/env.ts
@@ -35,5 +35,14 @@ export const loadEnv = () =>
       APPLICATIONINSIGHTS_CONNECTION_STRING: z
         .string()
         .describe("The connection string for Application Insights."),
+      APPLICATIONINSIGHTS_ENTRA_ID_AUTH_ENABLED: z
+        .enum(["true", "false"])
+        .optional()
+        .transform((value) => value === "true")
+        .describe(
+          "When set to 'true', enables Microsoft Entra ID (Managed Identity) authentication for Application Insights. " +
+            "Defaults to false (connection-string-only auth). " +
+            "This will become the default in the next major release.",
+        ),
     },
   });

--- a/packages/azure-tracing/src/azure/monitor/start-from-env.ts
+++ b/packages/azure-tracing/src/azure/monitor/start-from-env.ts
@@ -1,18 +1,32 @@
-import { useAzureMonitor } from "@azure/monitor-opentelemetry";
+import { DefaultAzureCredential } from "@azure/identity";
+import {
+  type AzureMonitorOpenTelemetryOptions,
+  useAzureMonitor,
+} from "@azure/monitor-opentelemetry";
 
-import { loadEnv } from "./env";
+import { loadEnv } from "./env.js";
 
 export const initFromEnv = () => {
   const env = loadEnv();
 
-  return useAzureMonitor({
+  const azureMonitorOptions: AzureMonitorOpenTelemetryOptions = {
     azureMonitorExporterOptions: {
       connectionString: env.APPLICATIONINSIGHTS_CONNECTION_STRING,
+      ...(env.APPLICATIONINSIGHTS_ENTRA_ID_AUTH_ENABLED
+        ? {
+            // Entra ID (Managed Identity) authentication via DefaultAzureCredential.
+            // DefaultAzureCredential tries multiple credential providers in order:
+            // Managed Identity in production, Azure CLI / service principal for local dev.
+            credential: new DefaultAzureCredential(),
+          }
+        : {}),
     },
     enableLiveMetrics: true,
     samplingRatio: env.APPINSIGHTS_SAMPLING_PERCENTAGE,
     // Disable rate limiter introduced in @azure/monitor-opentelemetry@1.16.0
     // (default: 5 req/s). A value of 0 means no limit.
     tracesPerSecond: 0,
-  });
+  };
+
+  return useAzureMonitor(azureMonitorOptions);
 };

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -902,6 +902,9 @@ importers:
 
   packages/azure-tracing:
     dependencies:
+      '@azure/identity':
+        specifier: 'catalog:'
+        version: 4.13.0
       '@azure/monitor-opentelemetry':
         specifier: catalog:opentelemetry
         version: 1.16.0

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -904,7 +904,7 @@ importers:
     dependencies:
       '@azure/identity':
         specifier: 'catalog:'
-        version: 4.13.0
+        version: 4.13.1
       '@azure/monitor-opentelemetry':
         specifier: catalog:opentelemetry
         version: 1.16.0


### PR DESCRIPTION
This pull request introduces support for Microsoft Entra ID (Managed Identity) authentication in the `@pagopa/azure-tracing` package, making it possible to securely connect to Application Insights using Azure credentials instead of only a connection string. The connection-string-only authentication remains the default for backward compatibility but is now deprecated and will be removed in the next major release. The documentation and environment handling have been updated accordingly, and comprehensive tests have been added to ensure correct behavior in both authentication modes.