### PR TITLE
Suppress noisy 404 logs from Octokit for missing release tags

### DIFF
--- a/.nx/version-plans/version-plan-1776276214037.md
+++ b/.nx/version-plans/version-plan-1776276214037.md
@@ -1,0 +1,5 @@
+---
+nx-release: patch
+---
+
+Suppress noisy 404 logs from Octokit when release tags are missing.

--- a/actions/nx-release/scripts/__tests__/sync-tags-releases.test.ts
+++ b/actions/nx-release/scripts/__tests__/sync-tags-releases.test.ts
@@ -1,0 +1,40 @@
+/**
+ * Verifies the release lookup used by nx-release stays quiet for expected
+ * GitHub 404 responses while probing for missing releases by tag.
+ */
+import { Octokit } from "@octokit/rest";
+import { describe, expect, it, vi } from "vitest";
+
+import { releaseExists } from "../sync-tags-releases.js";
+
+describe("releaseExists", () => {
+  it("does not print the noisy 404 emitted when a release tag is missing", async () => {
+    const owner = "pagopa";
+    const repo = "dx";
+    const tag = "@pagopa/azure-tracing@0.4.17";
+
+    const octokit = new Octokit();
+
+    const consoleErrorSpy = vi
+      .spyOn(console, "error")
+      .mockImplementation(() => undefined);
+
+    const consoleWarnSpy = vi
+      .spyOn(console, "warn")
+      .mockImplementation(() => undefined);
+
+    vi.spyOn(octokit.repos, "getReleaseByTag").mockImplementation(
+      async (options) => {
+        options?.request?.log?.error?.(
+          "GET /repos/pagopa/dx/releases/tags/%40pagopa%2Fazure-tracing%400.4.17 - 404 with id F3C0:E6932:1C23C:71622:69CD2BF3 in 183ms",
+        );
+
+        throw Object.assign(new Error("Not Found"), { status: 404 });
+      },
+    );
+
+    await expect(releaseExists(octokit, owner, repo, tag)).resolves.toBe(false);
+    expect(consoleErrorSpy).not.toHaveBeenCalled();
+    expect(consoleWarnSpy).not.toHaveBeenCalled();
+  });
+});

--- a/actions/nx-release/scripts/__tests__/sync-tags-releases.test.ts
+++ b/actions/nx-release/scripts/__tests__/sync-tags-releases.test.ts
@@ -8,6 +8,37 @@ import { describe, expect, it, vi } from "vitest";
 import { releaseExists } from "../sync-tags-releases.js";
 
 describe("releaseExists", () => {
+  it("does print other errors emitted by Octokit", async () => {
+    const owner = "pagopa";
+    const repo = "dx";
+    const tag = "@pagopa/azure-tracing@0.4.17";
+
+    const octokit = new Octokit();
+
+    const consoleErrorSpy = vi
+      .spyOn(console, "error")
+      .mockImplementation(() => undefined);
+
+    vi.spyOn(octokit.repos, "getReleaseByTag").mockImplementation(
+      async (options) => {
+        options?.request?.log?.error?.(
+          "GET /repos/pagopa/dx/releases/tags/%40pagopa%2Fazure-tracing%400.4.17 - 500 with id F3C0:E6932:1C23C:71622:69CD2BF3 in 183ms",
+        );
+
+        throw Object.assign(new Error("Internal Server Error"), {
+          status: 500,
+        });
+      },
+    );
+
+    await expect(releaseExists(octokit, owner, repo, tag)).resolves.toBe(false);
+    expect(consoleErrorSpy).toHaveBeenCalledWith(
+      expect.stringContaining(
+        "GET /repos/pagopa/dx/releases/tags/%40pagopa%2Fazure-tracing%400.4.17 - 500",
+      ),
+    );
+  });
+
   it("does not print the noisy 404 emitted when a release tag is missing", async () => {
     const owner = "pagopa";
     const repo = "dx";

--- a/actions/nx-release/scripts/dist/extract-projects-to-build.js
+++ b/actions/nx-release/scripts/dist/extract-projects-to-build.js
@@ -4210,7 +4210,7 @@ function $constructor(name, initializer3, params) {
   Object.defineProperty(_, "name", { value: name });
   return _;
 }
-var $brand = Symbol("zod_brand");
+var $brand = /* @__PURE__ */ Symbol("zod_brand");
 var $ZodAsyncError = class extends Error {
   constructor() {
     super(`Encountered Promise during synchronous parse. Use .parseAsync() instead.`);
@@ -4355,7 +4355,7 @@ function floatSafeRemainder(val, step) {
   const stepInt = Number.parseInt(step.toFixed(decCount).replace(".", ""));
   return valInt % stepInt / 10 ** decCount;
 }
-var EVALUATING = Symbol("evaluating");
+var EVALUATING = /* @__PURE__ */ Symbol("evaluating");
 function defineLazy(object2, key, getter) {
   let value = void 0;
   Object.defineProperty(object2, key, {
@@ -13428,8 +13428,8 @@ function yo_default() {
 
 // ../../node_modules/.pnpm/zod@4.3.6/node_modules/zod/v4/core/registries.js
 var _a;
-var $output = Symbol("ZodOutput");
-var $input = Symbol("ZodInput");
+var $output = /* @__PURE__ */ Symbol("ZodOutput");
+var $input = /* @__PURE__ */ Symbol("ZodInput");
 var $ZodRegistry = class {
   constructor() {
     this._map = /* @__PURE__ */ new WeakMap();

--- a/actions/nx-release/scripts/dist/extract-tags.js
+++ b/actions/nx-release/scripts/dist/extract-tags.js
@@ -582,7 +582,7 @@ function $constructor(name, initializer3, params) {
   Object.defineProperty(_, "name", { value: name });
   return _;
 }
-var $brand = Symbol("zod_brand");
+var $brand = /* @__PURE__ */ Symbol("zod_brand");
 var $ZodAsyncError = class extends Error {
   constructor() {
     super(`Encountered Promise during synchronous parse. Use .parseAsync() instead.`);
@@ -727,7 +727,7 @@ function floatSafeRemainder(val, step) {
   const stepInt = Number.parseInt(step.toFixed(decCount).replace(".", ""));
   return valInt % stepInt / 10 ** decCount;
 }
-var EVALUATING = Symbol("evaluating");
+var EVALUATING = /* @__PURE__ */ Symbol("evaluating");
 function defineLazy(object2, key, getter) {
   let value = void 0;
   Object.defineProperty(object2, key, {
@@ -9800,8 +9800,8 @@ function yo_default() {
 
 // ../../node_modules/.pnpm/zod@4.3.6/node_modules/zod/v4/core/registries.js
 var _a;
-var $output = Symbol("ZodOutput");
-var $input = Symbol("ZodInput");
+var $output = /* @__PURE__ */ Symbol("ZodOutput");
+var $input = /* @__PURE__ */ Symbol("ZodInput");
 var $ZodRegistry = class {
   constructor() {
     this._map = /* @__PURE__ */ new WeakMap();

--- a/actions/nx-release/scripts/dist/manage-version-pr.js
+++ b/actions/nx-release/scripts/dist/manage-version-pr.js
@@ -703,7 +703,7 @@ function $constructor(name, initializer3, params) {
   Object.defineProperty(_, "name", { value: name });
   return _;
 }
-var $brand = Symbol("zod_brand");
+var $brand = /* @__PURE__ */ Symbol("zod_brand");
 var $ZodAsyncError = class extends Error {
   constructor() {
     super(`Encountered Promise during synchronous parse. Use .parseAsync() instead.`);
@@ -848,7 +848,7 @@ function floatSafeRemainder(val, step) {
   const stepInt = Number.parseInt(step.toFixed(decCount).replace(".", ""));
   return valInt % stepInt / 10 ** decCount;
 }
-var EVALUATING = Symbol("evaluating");
+var EVALUATING = /* @__PURE__ */ Symbol("evaluating");
 function defineLazy(object2, key, getter) {
   let value = void 0;
   Object.defineProperty(object2, key, {
@@ -9921,8 +9921,8 @@ function yo_default() {
 
 // ../../node_modules/.pnpm/zod@4.3.6/node_modules/zod/v4/core/registries.js
 var _a;
-var $output = Symbol("ZodOutput");
-var $input = Symbol("ZodInput");
+var $output = /* @__PURE__ */ Symbol("ZodOutput");
+var $input = /* @__PURE__ */ Symbol("ZodInput");
 var $ZodRegistry = class {
   constructor() {
     this._map = /* @__PURE__ */ new WeakMap();

--- a/actions/nx-release/scripts/dist/shared.js
+++ b/actions/nx-release/scripts/dist/shared.js
@@ -4210,7 +4210,7 @@ function $constructor(name, initializer3, params) {
   Object.defineProperty(_, "name", { value: name });
   return _;
 }
-var $brand = Symbol("zod_brand");
+var $brand = /* @__PURE__ */ Symbol("zod_brand");
 var $ZodAsyncError = class extends Error {
   constructor() {
     super(`Encountered Promise during synchronous parse. Use .parseAsync() instead.`);
@@ -4355,7 +4355,7 @@ function floatSafeRemainder(val, step) {
   const stepInt = Number.parseInt(step.toFixed(decCount).replace(".", ""));
   return valInt % stepInt / 10 ** decCount;
 }
-var EVALUATING = Symbol("evaluating");
+var EVALUATING = /* @__PURE__ */ Symbol("evaluating");
 function defineLazy(object2, key, getter) {
   let value = void 0;
   Object.defineProperty(object2, key, {
@@ -13428,8 +13428,8 @@ function yo_default() {
 
 // ../../node_modules/.pnpm/zod@4.3.6/node_modules/zod/v4/core/registries.js
 var _a;
-var $output = Symbol("ZodOutput");
-var $input = Symbol("ZodInput");
+var $output = /* @__PURE__ */ Symbol("ZodOutput");
+var $input = /* @__PURE__ */ Symbol("ZodInput");
 var $ZodRegistry = class {
   constructor() {
     this._map = /* @__PURE__ */ new WeakMap();

--- a/actions/nx-release/scripts/dist/sync-tags-releases.js
+++ b/actions/nx-release/scripts/dist/sync-tags-releases.js
@@ -703,7 +703,7 @@ function $constructor(name, initializer3, params) {
   Object.defineProperty(_, "name", { value: name });
   return _;
 }
-var $brand = Symbol("zod_brand");
+var $brand = /* @__PURE__ */ Symbol("zod_brand");
 var $ZodAsyncError = class extends Error {
   constructor() {
     super(`Encountered Promise during synchronous parse. Use .parseAsync() instead.`);
@@ -848,7 +848,7 @@ function floatSafeRemainder(val, step) {
   const stepInt = Number.parseInt(step.toFixed(decCount).replace(".", ""));
   return valInt % stepInt / 10 ** decCount;
 }
-var EVALUATING = Symbol("evaluating");
+var EVALUATING = /* @__PURE__ */ Symbol("evaluating");
 function defineLazy(object2, key, getter) {
   let value = void 0;
   Object.defineProperty(object2, key, {
@@ -9921,8 +9921,8 @@ function yo_default() {
 
 // ../../node_modules/.pnpm/zod@4.3.6/node_modules/zod/v4/core/registries.js
 var _a;
-var $output = Symbol("ZodOutput");
-var $input = Symbol("ZodInput");
+var $output = /* @__PURE__ */ Symbol("ZodOutput");
+var $input = /* @__PURE__ */ Symbol("ZodInput");
 var $ZodRegistry = class {
   constructor() {
     this._map = /* @__PURE__ */ new WeakMap();
@@ -17491,9 +17491,24 @@ async function extractChangelogSection(clPath, version2) {
 }
 async function releaseExists(octokit, owner, repo, tag) {
   try {
+    const suppressed404Pattern = new RegExp(
+      `GET /repos/[^\\s]+/[^\\s]+/releases/tags/[^\\s]+ - 404\\b`
+    );
     await octokit.repos.getReleaseByTag({
       owner,
       repo,
+      request: {
+        // Suppress noisy 404 logs from Octokit when release doesn't exist
+        log: {
+          error: (...args) => {
+            const message = args.join(" ");
+            if (suppressed404Pattern.test(message)) {
+              return;
+            }
+            console.error(...args);
+          }
+        }
+      },
       tag
     });
     return true;

--- a/actions/nx-release/scripts/sync-tags-releases.ts
+++ b/actions/nx-release/scripts/sync-tags-releases.ts
@@ -67,6 +67,10 @@ export async function extractChangelogSection(
   }
 }
 
+const suppressed404Pattern = new RegExp(
+  `GET /repos/[^\\s]+/[^\\s]+/releases/tags/[^\\s]+ - 404\\b`,
+);
+
 export async function releaseExists(
   octokit: Octokit,
   owner: string,
@@ -74,9 +78,6 @@ export async function releaseExists(
   tag: string,
 ): Promise<boolean> {
   try {
-    const suppressed404Pattern = new RegExp(
-      `GET /repos/[^\\s]+/[^\\s]+/releases/tags/[^\\s]+ - 404\\b`,
-    );
     await octokit.repos.getReleaseByTag({
       owner,
       repo,
@@ -109,7 +110,7 @@ export async function releaseExists(
 }
 
 export async function run(base: string): Promise<void> {
-  const octokit = createOctokit({ suppressReleaseTag404Logs: true });
+  const octokit = createOctokit();
   const { owner, repo } = await getRepoInfo();
 
   // List merged PRs from nx-release/main branch

--- a/actions/nx-release/scripts/sync-tags-releases.ts
+++ b/actions/nx-release/scripts/sync-tags-releases.ts
@@ -67,9 +67,8 @@ export async function extractChangelogSection(
   }
 }
 
-const suppressed404Pattern = new RegExp(
-  `GET /repos/[^\\s]+/[^\\s]+/releases/tags/[^\\s]+ - 404\\b`,
-);
+const getReleaseByTag404Error =
+  /GET \/repos\/[^/]+\/[^/]+\/releases\/tags\/[^/]+ - 404\b/;
 
 export async function releaseExists(
   octokit: Octokit,
@@ -86,7 +85,7 @@ export async function releaseExists(
         log: {
           error: (...args: unknown[]) => {
             const message = args.join(" ");
-            if (suppressed404Pattern.test(message)) {
+            if (getReleaseByTag404Error.test(message)) {
               // Suppress this specific 404 error
               return;
             }

--- a/actions/nx-release/scripts/sync-tags-releases.ts
+++ b/actions/nx-release/scripts/sync-tags-releases.ts
@@ -74,14 +74,30 @@ export async function releaseExists(
   tag: string,
 ): Promise<boolean> {
   try {
+    const suppressed404Pattern = new RegExp(
+      `GET /repos/[^\\s]+/[^\\s]+/releases/tags/[^\\s]+ - 404\\b`,
+    );
     await octokit.repos.getReleaseByTag({
       owner,
       repo,
+      request: {
+        // Suppress noisy 404 logs from Octokit when release doesn't exist
+        log: {
+          error: (...args: unknown[]) => {
+            const message = args.join(" ");
+            if (suppressed404Pattern.test(message)) {
+              // Suppress this specific 404 error
+              return;
+            }
+            // Log other errors normally
+            console.error(...args);
+          },
+        },
+      },
       tag,
     });
     return true;
   } catch (err: unknown) {
-    // 404 means release doesn't exist
     const errorCheck = OctokitErrorSchema.safeParse(err);
     if (errorCheck.success && errorCheck.data.status === 404) {
       return false;
@@ -93,7 +109,7 @@ export async function releaseExists(
 }
 
 export async function run(base: string): Promise<void> {
-  const octokit = createOctokit();
+  const octokit = createOctokit({ suppressReleaseTag404Logs: true });
   const { owner, repo } = await getRepoInfo();
 
   // List merged PRs from nx-release/main branch


### PR DESCRIPTION
Implement a mechanism to suppress noisy 404 logs from Octokit when release tags are missing. Add tests to verify that the logging behavior is as expected.

Close CES-1889