### PR TITLE
Upgrade Terraform setup action to version 4.0.0

### DIFF
--- a/.github/actions/terraform-setup/action.yaml
+++ b/.github/actions/terraform-setup/action.yaml
@@ -22,7 +22,7 @@ runs:
       with:
         override_version: ${{ inputs.terraform_version }}
 
-    - uses: hashicorp/setup-terraform@a1502cd9e758c50496cc9ac5308c4843bcd56d36 # v3.0.0
+    - uses: hashicorp/setup-terraform@5e8dbf3c6d9deaf4193ca7a8fb23f2ac83bb6c85 # v4.0.0
       name: Setup Terraform
       with:
         terraform_version: ${{ inputs.terraform_version || steps.get-version.outputs.terraform_version }}


### PR DESCRIPTION
Upgrade terraform setup action to v4.0.0 due to imminent node20 deprecation on GitHub runners