### PR TITLE
Replace deprecated property in EventHub diagnostic settings

### DIFF
--- a/.nx/version-plans/version-plan-1776418828840.md
+++ b/.nx/version-plans/version-plan-1776418828840.md
@@ -1,0 +1,5 @@
+---
+azure_event_hub: patch
+---
+
+Replace deprecated property of diagnostic setting resource

--- a/infra/modules/azure_event_hub/monitor.tf
+++ b/infra/modules/azure_event_hub/monitor.tf
@@ -43,7 +43,7 @@ resource "azurerm_monitor_diagnostic_setting" "event_hub_namespace" {
     category_group = "allLogs"
   }
 
-  metric {
+  enabled_metric {
     category = "AllMetrics"
   }
 }


### PR DESCRIPTION
Update the diagnostic setting resource to replace a deprecated property with the new equivalent.