### PR TITLE
Add managed Redis resource naming

### DIFF
--- a/.nx/version-plans/version-plan-1776693686799.md
+++ b/.nx/version-plans/version-plan-1776693686799.md
@@ -2,4 +2,8 @@
 provider-azure: minor
 ---
 
-Add managed_redis resource naming support
+Breaking change: remove the legacy `redis_cache` resource type from the Azure `resource_name` function.
+
+Consumers must migrate any `resource_type = "redis_cache"` usage to the supported `managed_redis` value.
+
+This remains a minor bump because the provider is still in the `0.x` series, where minor releases can carry breaking changes.

--- a/.nx/version-plans/version-plan-1776693686799.md
+++ b/.nx/version-plans/version-plan-1776693686799.md
@@ -2,4 +2,4 @@
 provider-azure: minor
 ---
 
-Add managed_redis resource naming support
+Add `managed_redis` resource naming support

--- a/.nx/version-plans/version-plan-1776693686799.md
+++ b/.nx/version-plans/version-plan-1776693686799.md
@@ -1,0 +1,5 @@
+---
+provider-azure: minor
+---
+
+Add managed_redis resource naming support

--- a/.nx/version-plans/version-plan-1776693686799.md
+++ b/.nx/version-plans/version-plan-1776693686799.md
@@ -2,8 +2,4 @@
 provider-azure: minor
 ---
 
-Breaking change: remove the legacy `redis_cache` resource type from the Azure `resource_name` function.
-
-Consumers must migrate any `resource_type = "redis_cache"` usage to the supported `managed_redis` value.
-
-This remains a minor bump because the provider is still in the `0.x` series, where minor releases can carry breaking changes.
+Add managed_redis resource naming support

--- a/providers/azure/README.md
+++ b/providers/azure/README.md
@@ -233,6 +233,7 @@ The following table lists the resource types and their abbreviations used in the
 | load_testing                              |        lt        |
 | log_analytics                             |       log        |
 | managed_identity                          |        id        |
+| managed_redis                             |       amr        |
 | nat_gateway                               |        ng        |
 | network_security_group                    |       nsg        |
 | postgre_endpoint                          |     psql-ep      |

--- a/providers/azure/README.md
+++ b/providers/azure/README.md
@@ -248,7 +248,6 @@ The following table lists the resource types and their abbreviations used in the
 | function_queue_private_endpoint           |  func-queue-pep  |
 | dfunction_queue_private_endpoint          | dfunc-queue-pep  |
 | queue_storage                             |      queue       |
-| redis_cache                               |      redis       |
 | resource_group                            |        rg        |
 | servicebus_namespace                      |       sbns       |
 | servicebus_private_endpoint               |     sbns-pep     |

--- a/providers/azure/README.md
+++ b/providers/azure/README.md
@@ -248,6 +248,7 @@ The following table lists the resource types and their abbreviations used in the
 | function_queue_private_endpoint           |  func-queue-pep  |
 | dfunction_queue_private_endpoint          | dfunc-queue-pep  |
 | queue_storage                             |      queue       |
+| redis_cache                               |      redis       |
 | resource_group                            |        rg        |
 | servicebus_namespace                      |       sbns       |
 | servicebus_private_endpoint               |     sbns-pep     |

--- a/providers/azure/docs/functions/resource_name.md
+++ b/providers/azure/docs/functions/resource_name.md
@@ -114,6 +114,7 @@ The following table lists the resource types and their abbreviations used in the
 | load_testing                              |        lt        |
 | log_analytics                             |       log        |
 | managed_identity                          |        id        |
+| managed_redis                             |       amr        |
 | nat_gateway                               |        ng        |
 | network_security_group                    |       nsg        |
 | postgre_endpoint                          |     psql-ep      |

--- a/providers/azure/docs/functions/resource_name.md
+++ b/providers/azure/docs/functions/resource_name.md
@@ -129,7 +129,6 @@ The following table lists the resource types and their abbreviations used in the
 | function_queue_private_endpoint           |  func-queue-pep  |
 | dfunction_queue_private_endpoint          | dfunc-queue-pep  |
 | queue_storage                             |      queue       |
-| redis_cache                               |      redis       |
 | resource_group                            |        rg        |
 | servicebus_namespace                      |       sbns       |
 | servicebus_private_endpoint               |     sbns-pep     |

--- a/providers/azure/docs/functions/resource_name.md
+++ b/providers/azure/docs/functions/resource_name.md
@@ -129,6 +129,7 @@ The following table lists the resource types and their abbreviations used in the
 | function_queue_private_endpoint           |  func-queue-pep  |
 | dfunction_queue_private_endpoint          | dfunc-queue-pep  |
 | queue_storage                             |      queue       |
+| redis_cache                               |      redis       |
 | resource_group                            |        rg        |
 | servicebus_namespace                      |       sbns       |
 | servicebus_private_endpoint               |     sbns-pep     |

--- a/providers/azure/internal/provider/function_resource_name.go
+++ b/providers/azure/internal/provider/function_resource_name.go
@@ -124,6 +124,7 @@ func getResourceAbbreviations() map[string]string {
 		"customer_key_cosmos_db_nosql": "cosno-cmk",
 		"postgresql":                   "psql",
 		"postgresql_replica":           "psql-replica",
+		"managed_redis":               "amr",
 		"redis_cache":                  "redis",
 		"mysql":                        "mysql",
 

--- a/providers/azure/internal/provider/function_resource_name.go
+++ b/providers/azure/internal/provider/function_resource_name.go
@@ -124,7 +124,8 @@ func getResourceAbbreviations() map[string]string {
 		"customer_key_cosmos_db_nosql": "cosno-cmk",
 		"postgresql":                   "psql",
 		"postgresql_replica":           "psql-replica",
-		"managed_redis":                "amr",
+		"managed_redis":               "amr",
+		"redis_cache":                  "redis",
 		"mysql":                        "mysql",
 
 		// Integration

--- a/providers/azure/internal/provider/function_resource_name.go
+++ b/providers/azure/internal/provider/function_resource_name.go
@@ -124,7 +124,7 @@ func getResourceAbbreviations() map[string]string {
 		"customer_key_cosmos_db_nosql": "cosno-cmk",
 		"postgresql":                   "psql",
 		"postgresql_replica":           "psql-replica",
-		"managed_redis":               "amr",
+		"managed_redis":                "amr",
 		"redis_cache":                  "redis",
 		"mysql":                        "mysql",
 

--- a/providers/azure/internal/provider/function_resource_name.go
+++ b/providers/azure/internal/provider/function_resource_name.go
@@ -124,8 +124,7 @@ func getResourceAbbreviations() map[string]string {
 		"customer_key_cosmos_db_nosql": "cosno-cmk",
 		"postgresql":                   "psql",
 		"postgresql_replica":           "psql-replica",
-		"managed_redis":               "amr",
-		"redis_cache":                  "redis",
+		"managed_redis":                "amr",
 		"mysql":                        "mysql",
 
 		// Integration

--- a/providers/azure/internal/provider/function_resource_name_test.go
+++ b/providers/azure/internal/provider/function_resource_name_test.go
@@ -406,6 +406,48 @@ func TestResourceNameFunction_NewResourceTypes(t *testing.T) {
 	}
 }
 
+func TestResourceNameFunction_ManagedRedisUsesDistinctAbbreviation(t *testing.T) {
+	t.Parallel()
+
+	resource.UnitTest(t, resource.TestCase{
+		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
+			tfversion.SkipBelow(tfversion.Version1_8_0),
+		},
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: `
+            output "managed" {
+              value = provider::dx::resource_name({
+								prefix = "dx",
+								environment = "d",
+								location = "weu",
+								name = "cache",
+								resource_type = "managed_redis",
+								instance_number = "1"
+							})
+            }
+
+            output "legacy" {
+              value = provider::dx::resource_name({
+								prefix = "dx",
+								environment = "d",
+								location = "weu",
+								name = "cache",
+								resource_type = "redis_cache",
+								instance_number = "1"
+							})
+            }
+            `,
+				ConfigStateChecks: []statecheck.StateCheck{
+					statecheck.ExpectKnownOutputValue("managed", knownvalue.StringExact("dx-d-weu-cache-amr-01")),
+					statecheck.ExpectKnownOutputValue("legacy", knownvalue.StringExact("dx-d-weu-cache-redis-01")),
+				},
+			},
+		},
+	})
+}
+
 func TestResourceNameFunction_InvalidEnvironment(t *testing.T) {
 	t.Parallel()
 	// Test invalid environment values

--- a/providers/azure/internal/provider/function_resource_name_test.go
+++ b/providers/azure/internal/provider/function_resource_name_test.go
@@ -406,7 +406,7 @@ func TestResourceNameFunction_NewResourceTypes(t *testing.T) {
 	}
 }
 
-func TestResourceNameFunction_ManagedRedisUsesDistinctAbbreviation(t *testing.T) {
+func TestResourceNameFunction_ManagedRedisUsesSupportedAbbreviation(t *testing.T) {
 	t.Parallel()
 
 	resource.UnitTest(t, resource.TestCase{
@@ -427,21 +427,9 @@ func TestResourceNameFunction_ManagedRedisUsesDistinctAbbreviation(t *testing.T)
 								instance_number = "1"
 							})
             }
-
-            output "legacy" {
-              value = provider::dx::resource_name({
-								prefix = "dx",
-								environment = "d",
-								location = "weu",
-								name = "cache",
-								resource_type = "redis_cache",
-								instance_number = "1"
-							})
-            }
             `,
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.ExpectKnownOutputValue("managed", knownvalue.StringExact("dx-d-weu-cache-amr-01")),
-					statecheck.ExpectKnownOutputValue("legacy", knownvalue.StringExact("dx-d-weu-cache-redis-01")),
 				},
 			},
 		},
@@ -804,7 +792,6 @@ func TestResourceNameFunction_NameMatchesCompositeAbbreviation(t *testing.T) {
 		},
 	})
 }
-
 
 func TestResourceNameFunction_NameIsBareAbbreviationPrefix(t *testing.T) {
 	t.Parallel()

--- a/providers/azure/internal/provider/function_resource_name_test.go
+++ b/providers/azure/internal/provider/function_resource_name_test.go
@@ -805,7 +805,6 @@ func TestResourceNameFunction_NameMatchesCompositeAbbreviation(t *testing.T) {
 	})
 }
 
-
 func TestResourceNameFunction_NameIsBareAbbreviationPrefix(t *testing.T) {
 	t.Parallel()
 	// Regression test: name="cdn" with cdn_frontdoor_route (abbr="cdnr") must NOT be rejected.

--- a/providers/azure/internal/provider/function_resource_name_test.go
+++ b/providers/azure/internal/provider/function_resource_name_test.go
@@ -406,7 +406,7 @@ func TestResourceNameFunction_NewResourceTypes(t *testing.T) {
 	}
 }
 
-func TestResourceNameFunction_ManagedRedisUsesSupportedAbbreviation(t *testing.T) {
+func TestResourceNameFunction_ManagedRedisUsesDistinctAbbreviation(t *testing.T) {
 	t.Parallel()
 
 	resource.UnitTest(t, resource.TestCase{
@@ -427,9 +427,21 @@ func TestResourceNameFunction_ManagedRedisUsesSupportedAbbreviation(t *testing.T
 								instance_number = "1"
 							})
             }
+
+            output "legacy" {
+              value = provider::dx::resource_name({
+								prefix = "dx",
+								environment = "d",
+								location = "weu",
+								name = "cache",
+								resource_type = "redis_cache",
+								instance_number = "1"
+							})
+            }
             `,
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.ExpectKnownOutputValue("managed", knownvalue.StringExact("dx-d-weu-cache-amr-01")),
+					statecheck.ExpectKnownOutputValue("legacy", knownvalue.StringExact("dx-d-weu-cache-redis-01")),
 				},
 			},
 		},
@@ -792,6 +804,7 @@ func TestResourceNameFunction_NameMatchesCompositeAbbreviation(t *testing.T) {
 		},
 	})
 }
+
 
 func TestResourceNameFunction_NameIsBareAbbreviationPrefix(t *testing.T) {
 	t.Parallel()

--- a/providers/azure/internal/provider/provider.go
+++ b/providers/azure/internal/provider/provider.go
@@ -28,7 +28,7 @@ type dxProviderModel struct {
 	Location    types.String `tfsdk:"location"`
 }
 
-// New crea una nuova istanza del provider
+// New Create a new provider instance
 func New(version string) func() provider.Provider {
 	return func() provider.Provider {
 		return &dxProvider{
@@ -92,6 +92,7 @@ func (p *dxProvider) Resources(ctx context.Context) []func() resource.Resource {
 }
 
 // DataSources
+
 func (p *dxProvider) DataSources(ctx context.Context) []func() datasource.DataSource {
 	return nil
 }

--- a/providers/azure/internal/provider/provider.go
+++ b/providers/azure/internal/provider/provider.go
@@ -28,7 +28,7 @@ type dxProviderModel struct {
 	Location    types.String `tfsdk:"location"`
 }
 
-// New Create a new provider instance
+// New creates a new provider instance.
 func New(version string) func() provider.Provider {
 	return func() provider.Provider {
 		return &dxProvider{

--- a/providers/azure/internal/provider/resource_available_subnet_cidr.go
+++ b/providers/azure/internal/provider/resource_available_subnet_cidr.go
@@ -207,7 +207,7 @@ func (r *availableSubnetCidrResource) Delete(ctx context.Context, req resource.D
 	tflog.Info(ctx, "Deleting available subnet CIDR resource")
 }
 
-// PlanModifiers implements the plan modifiers for this resource
+// ModifyPlan implements the plan modifiers for this resource
 func (r *availableSubnetCidrResource) ModifyPlan(ctx context.Context, req resource.ModifyPlanRequest, resp *resource.ModifyPlanResponse) {
 	// In the creation phase, we don't modify the plan
 	// Leave the cidr_block attribute as "known after apply"


### PR DESCRIPTION
## Summary
- add `managed_redis` with the `amr` abbreviation in the Azure DX provider naming map
- add regression coverage to keep `managed_redis` distinct from `redis_cache`

## Why
Azure Managed Redis needs a dedicated resource type in the provider so downstream modules can generate the expected naming without relying on the legacy `redis_cache` type.

Resolves CES-1958