### PR TITLE
Fix Storage Account diagram link in documentation

### DIFF
--- a/.nx/version-plans/version-plan-1776784323318.md
+++ b/.nx/version-plans/version-plan-1776784323318.md
@@ -1,0 +1,5 @@
+---
+azure_storage_account: patch
+---
+
+Fix diagram link in documentation

--- a/infra/modules/azure_storage_account/README.md
+++ b/infra/modules/azure_storage_account/README.md
@@ -8,7 +8,7 @@ This Terraform module provisions an Azure Storage Account with optional configur
 
 The following diagram illustrates the architecture and relationships between the main components of this module:
 
-![diagram](diagram.svg)
+![diagram](https://raw.githubusercontent.com/pagopa/dx/main/infra/modules/azure_storage_account/diagram.svg)
 
 ## Features
 


### PR DESCRIPTION
Update the Storage Account diagram link in the documentation to point to the correct URL.