### PR TITLE
The CLI now creates the VPN when instantiating the core infrastructure

### DIFF
--- a/apps/cli/templates/environment/core/{{env.name}}/main.tf.hbs
+++ b/apps/cli/templates/environment/core/{{env.name}}/main.tf.hbs
@@ -2,7 +2,7 @@
 {{#each this}}
 module "azure-{{displayName}}_core" {
   source  = "pagopa-dx/azure-core-infra/azurerm"
-  version = "~> 2.0"
+  version = "~> 3.0"
 
   providers = {
     azurerm = azurerm.{{displayName}}

--- a/apps/cli/templates/environment/core/{{env.name}}/main.tf.hbs
+++ b/apps/cli/templates/environment/core/{{env.name}}/main.tf.hbs
@@ -12,6 +12,8 @@ module "azure-{{displayName}}_core" {
     app_name = "core"
   })
 
+  vpn_enabled = true
+
   tags = merge(local.tags, {
     Source = "https://github.com/{{@root.github.owner}}/{{@root.github.repo}}/blob/main/infra/core/{{@root.env.name}}"
   })


### PR DESCRIPTION
The DX CLI used to generate the core infra module without the `vpn_enabled` flag set to true.
Moreover, the CLI now generates the core infrastructure with module `~> 3.0` instead of `~> 2.0`

Resolves CES-1962