### PR TITLE
Update deprecated VPN SKUs and inputs in azure-core-infra module

### DIFF
--- a/.nx/version-plans/version-plan-1776864766291.md
+++ b/.nx/version-plans/version-plan-1776864766291.md
@@ -2,4 +2,43 @@
 azure_core_infra: major
 ---
 
-Support only new VPN SKU VpnGW2AZ and remove old one. The new SKU is now set as the default one.
+Support only the new VPN SKU `VpnGw2AZ` and remove the previous non-AZ SKUs. `VpnGw2AZ` is now the only supported option and is used by the `default` VPN use case.
+
+## Migration guide
+
+Version 4 changes the VPN gateway created by `pagopa-dx/azure-core-infra/azurerm`:
+
+- In v3, `vpn_use_case = "default"` created a Generation 1 gateway with SKU `VpnGw1`.
+- In v3, `vpn_use_case = "high_availability"` created a Generation 2 gateway with SKU `VpnGw2`.
+- In v4, only `vpn_use_case = "default"` is supported and it creates a Generation 2 zone-redundant gateway with SKU `VpnGw2AZ`.
+
+To migrate from v3 to v4:
+
+1. Update the module version constraint from `~> 3.0` to `~> 4.0`.
+2. Update the `azurerm` provider in the consuming stack to version `4.69.0` or newer.
+3. If your configuration sets `vpn_use_case = "high_availability"`, remove it or replace it with `vpn_use_case = "default"`.
+4. Run `terraform init -upgrade` in the stack that consumes the module, then run `terraform plan`.
+5. Review the plan carefully: moving from `VpnGw1` or `VpnGw2` to `VpnGw2AZ` can require changes to the Azure VPN gateway and its related public IPs. If the plan shows a replacement, schedule a maintenance window before applying it.
+6. Apply the plan.
+
+Example:
+
+```hcl
+terraform {
+	required_providers {
+		azurerm = {
+			source  = "hashicorp/azurerm"
+			version = ">= 4.69.0, < 5.0.0"
+		}
+	}
+}
+
+module "azure" {
+	source  = "pagopa-dx/azure-core-infra/azurerm"
+	version = "~> 4.0"
+
+	environment = local.azure_environment
+
+	tags = local.tags
+}
+```

--- a/.nx/version-plans/version-plan-1776864766291.md
+++ b/.nx/version-plans/version-plan-1776864766291.md
@@ -10,16 +10,19 @@ Version 4 changes the VPN gateway created by `pagopa-dx/azure-core-infra/azurerm
 
 - In v3, `vpn_use_case = "default"` created a Generation 1 gateway with SKU `VpnGw1`.
 - In v3, `vpn_use_case = "high_availability"` created a Generation 2 gateway with SKU `VpnGw2`.
+- In v3, `vpn_enabled` defaulted to `false`.
 - In v4, only `vpn_use_case = "default"` is supported and it creates a Generation 2 zone-redundant gateway with SKU `VpnGw2AZ`.
+- In v4, `vpn_enabled` defaults to `true`.
 
 To migrate from v3 to v4:
 
 1. Update the module version constraint from `~> 3.0` to `~> 4.0`.
-2. Update the `azurerm` provider in the consuming stack to version `4.69.0` or newer.
-3. If your configuration sets `vpn_use_case = "high_availability"`, remove it or replace it with `vpn_use_case = "default"`.
-4. Run `terraform init -upgrade` in the stack that consumes the module, then run `terraform plan`.
-5. Review the plan carefully: moving from `VpnGw1` or `VpnGw2` to `VpnGw2AZ` can require changes to the Azure VPN gateway and its related public IPs. If the plan shows a replacement, schedule a maintenance window before applying it.
-6. Apply the plan.
+2. Update the `azurerm` provider in the consuming stack to version `4.62.0` or newer.
+3. If you do not want the module to provision a VPN, set `vpn_enabled = false` explicitly in the consuming stack. In v4, omitting this variable enables the VPN by default.
+4. If your configuration sets `vpn_use_case = "high_availability"`, remove it or replace it with `vpn_use_case = "default"`.
+5. Run `terraform init -upgrade` in the stack that consumes the module, then run `terraform plan`.
+6. Review the plan carefully: moving from `VpnGw1` or `VpnGw2` to `VpnGw2AZ` can require changes to the Azure VPN gateway and its related public IPs. If the plan shows a replacement, schedule a maintenance window before applying it.
+7. Apply the plan.
 
 Example:
 
@@ -28,7 +31,7 @@ terraform {
 	required_providers {
 		azurerm = {
 			source  = "hashicorp/azurerm"
-			version = ">= 4.69.0, < 5.0.0"
+			version = "~> 4.62"
 		}
 	}
 }

--- a/.nx/version-plans/version-plan-1776864766291.md
+++ b/.nx/version-plans/version-plan-1776864766291.md
@@ -1,0 +1,5 @@
+---
+azure_core_infra: major
+---
+
+Support only new VPN SKU VpnGW2AZ and remove old one. The new SKU is now set as the default one.

--- a/.nx/version-plans/version-plan-1776868272254.md
+++ b/.nx/version-plans/version-plan-1776868272254.md
@@ -1,0 +1,5 @@
+---
+'@pagopa/dx-cli': patch
+---
+
+Update azure-core-infra module version from ~> 3.0 to ~> 4.0

--- a/apps/cli/templates/environment/core/{{env.name}}/main.tf.hbs
+++ b/apps/cli/templates/environment/core/{{env.name}}/main.tf.hbs
@@ -2,7 +2,7 @@
 {{#each this}}
 module "azure-{{displayName}}_core" {
   source  = "pagopa-dx/azure-core-infra/azurerm"
-  version = "~> 3.0"
+  version = "~> 4.0"
 
   providers = {
     azurerm = azurerm.{{displayName}}
@@ -11,8 +11,6 @@ module "azure-{{displayName}}_core" {
   environment = merge(local.environment, local.azure_accounts.{{displayName}}, {
     app_name = "core"
   })
-
-  vpn_enabled = true
 
   tags = merge(local.tags, {
     Source = "https://github.com/{{@root.github.owner}}/{{@root.github.repo}}/blob/main/infra/core/{{@root.env.name}}"

--- a/infra/modules/azure_core_infra/README.md
+++ b/infra/modules/azure_core_infra/README.md
@@ -26,7 +26,7 @@ For detailed usage examples, refer to the [examples folder](https://github.com/p
 
 | Name | Version |
 |------|---------|
-| <a name="requirement_azurerm"></a> [azurerm](#requirement\_azurerm) | ~>4.42 |
+| <a name="requirement_azurerm"></a> [azurerm](#requirement\_azurerm) | ~> 4.62 |
 | <a name="requirement_dx"></a> [dx](#requirement\_dx) | ~> 0.8 |
 
 ## Modules

--- a/infra/modules/azure_core_infra/README.md
+++ b/infra/modules/azure_core_infra/README.md
@@ -63,8 +63,8 @@ For detailed usage examples, refer to the [examples folder](https://github.com/p
 | <a name="input_tags"></a> [tags](#input\_tags) | A map of tags to assign to the resources. | `map(any)` | n/a | yes |
 | <a name="input_test_enabled"></a> [test\_enabled](#input\_test\_enabled) | A boolean flag to enable or disable the creation of testing resources. | `bool` | `false` | no |
 | <a name="input_virtual_network_cidr"></a> [virtual\_network\_cidr](#input\_virtual\_network\_cidr) | The CIDR block defining the IP address range for the virtual network. | `string` | `"10.0.0.0/16"` | no |
-| <a name="input_vpn_enabled"></a> [vpn\_enabled](#input\_vpn\_enabled) | A boolean flag to enable or disable the creation of a VPN. | `bool` | `false` | no |
-| <a name="input_vpn_use_case"></a> [vpn\_use\_case](#input\_vpn\_use\_case) | Site-to-Site VPN use case. Allowed values: 'default', 'high\_availability'. | `string` | `"default"` | no |
+| <a name="input_vpn_enabled"></a> [vpn\_enabled](#input\_vpn\_enabled) | A boolean flag to enable or disable the creation of a VPN. | `bool` | `true` | no |
+| <a name="input_vpn_use_case"></a> [vpn\_use\_case](#input\_vpn\_use\_case) | Site-to-Site VPN use case. Allowed values: 'default'. | `string` | `"default"` | no |
 
 ## Outputs
 

--- a/infra/modules/azure_core_infra/_modules/vpn/locals.tf
+++ b/infra/modules/azure_core_infra/_modules/vpn/locals.tf
@@ -3,7 +3,7 @@ locals {
     "default" = {
       generation             = "2"
       sku                    = "VpnGw2AZ"
-      vpn_connections_number = 2
+      vpn_connections_number = 1
     }
   }
 

--- a/infra/modules/azure_core_infra/_modules/vpn/locals.tf
+++ b/infra/modules/azure_core_infra/_modules/vpn/locals.tf
@@ -1,13 +1,8 @@
 locals {
   use_cases = {
     "default" = {
-      generation             = "1"
-      sku                    = "VpnGw1"
-      vpn_connections_number = 1
-    }
-    "high_availability" = {
       generation             = "2"
-      sku                    = "VpnGw2"
+      sku                    = "VpnGw2AZ"
       vpn_connections_number = 2
     }
   }

--- a/infra/modules/azure_core_infra/_modules/vpn/vpn.tf
+++ b/infra/modules/azure_core_infra/_modules/vpn/vpn.tf
@@ -1,9 +1,10 @@
 resource "azurerm_public_ip" "this" {
   count = local.use_cases[var.vpn_use_case].vpn_connections_number
-  name = "${provider::dx::resource_name(merge(var.naming_config, {
-    name          = "vpn"
-    resource_type = "public_ip"
-  }))}-${count.index + 1}"
+  name = provider::dx::resource_name(merge(var.naming_config, {
+    name            = "vpn"
+    resource_type   = "public_ip"
+    instance_number = format("%02d", count.index + 1)
+  }))
   location            = var.location
   resource_group_name = var.resource_group_name
   allocation_method   = "Static"
@@ -25,7 +26,7 @@ resource "azurerm_virtual_network_gateway" "this" {
 
   type          = "Vpn"
   vpn_type      = "RouteBased"
-  active_active = local.use_cases[var.vpn_use_case].vpn_connections_number > 1 ? true : false
+  active_active = false
   enable_bgp    = var.cross_cloud_dns_enabled
   sku           = local.use_cases[var.vpn_use_case].sku
   generation    = "Generation${local.use_cases[var.vpn_use_case].generation}"

--- a/infra/modules/azure_core_infra/_modules/vpn/vpn.tf
+++ b/infra/modules/azure_core_infra/_modules/vpn/vpn.tf
@@ -8,6 +8,7 @@ resource "azurerm_public_ip" "this" {
   location            = var.location
   resource_group_name = var.resource_group_name
   allocation_method   = "Static"
+  zones               = ["1", "2"]
   tags                = var.tags
 }
 

--- a/infra/modules/azure_core_infra/_modules/vpn/vpn.tf
+++ b/infra/modules/azure_core_infra/_modules/vpn/vpn.tf
@@ -27,7 +27,7 @@ resource "azurerm_virtual_network_gateway" "this" {
   type          = "Vpn"
   vpn_type      = "RouteBased"
   active_active = false
-  enable_bgp    = var.cross_cloud_dns_enabled
+  bgp_enabled   = var.cross_cloud_dns_enabled
   sku           = local.use_cases[var.vpn_use_case].sku
   generation    = "Generation${local.use_cases[var.vpn_use_case].generation}"
 

--- a/infra/modules/azure_core_infra/main.tf
+++ b/infra/modules/azure_core_infra/main.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     azurerm = {
       source  = "hashicorp/azurerm"
-      version = "~>4.42"
+      version = "~> 4.62"
     }
     dx = {
       source  = "pagopa-dx/azure"

--- a/infra/modules/azure_core_infra/tests/setup/README.md
+++ b/infra/modules/azure_core_infra/tests/setup/README.md
@@ -5,7 +5,7 @@
 
 | Name | Version |
 |------|---------|
-| <a name="requirement_azurerm"></a> [azurerm](#requirement\_azurerm) | ~> 4.10 |
+| <a name="requirement_azurerm"></a> [azurerm](#requirement\_azurerm) | ~> 4.62 |
 
 ## Modules
 

--- a/infra/modules/azure_core_infra/tests/setup/main.tf
+++ b/infra/modules/azure_core_infra/tests/setup/main.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     azurerm = {
       source  = "hashicorp/azurerm"
-      version = "~> 4.10"
+      version = "~> 4.62"
     }
   }
 }

--- a/infra/modules/azure_core_infra/variables.tf
+++ b/infra/modules/azure_core_infra/variables.tf
@@ -43,17 +43,17 @@ variable "nat_enabled" {
 variable "vpn_enabled" {
   type        = bool
   description = "A boolean flag to enable or disable the creation of a VPN."
-  default     = false
+  default     = true
 }
 
 variable "vpn_use_case" {
   type        = string
-  description = "Site-to-Site VPN use case. Allowed values: 'default', 'high_availability'."
+  description = "Site-to-Site VPN use case. Allowed values: 'default'."
   default     = "default"
 
   validation {
-    condition     = contains(["default", "high_availability"], var.vpn_use_case)
-    error_message = "vpn_use_case must be either 'default' or 'high_availability'."
+    condition     = contains(["default"], var.vpn_use_case)
+    error_message = "vpn_use_case must be 'default'."
   }
 }
 


### PR DESCRIPTION
The SKUs used by the azure-core-infra VPN have been lately deprecated. Other input variables have also been updated to reflect the newest azurerm provider versions. 
Changes to the SKU and IP configurations require recreation, hence the release of a major version is mandatory.

Resolves CES-1964