### PR TITLE
Fix Container App rollout revisions

### DIFF
--- a/.github/workflows/release-azure-containerapp-v1.yaml
+++ b/.github/workflows/release-azure-containerapp-v1.yaml
@@ -138,16 +138,46 @@ jobs:
 
           echo "revision_mode=$revision_mode" >> $GITHUB_OUTPUT
 
-      - name: Get Container App Current Revision
+      - name: Get Container App Production Revision
         id: get_current_revision
         run: |
           set -euo
 
-          current_revision=$(az containerapp revision list \
+          container_app=$(az containerapp show \
             --name "$CONTAINER_APP_NAME" \
-            --query 'reverse(sort_by([].{Revision:name,Active:properties.active,Created:properties.createdTime}[?Active!=`false`], &Created))| [0].Revision' -o tsv)
+            --output json)
 
-          echo "::notice::Current revision: $current_revision"
+          current_revision=$(echo "$container_app" | jq -r '
+            . as $app
+            | (
+                [
+                  ($app.properties.configuration.ingress.traffic // [])
+                  | map(select((.weight // 0) > 0))
+                  | map(
+                      if (.revisionName // "") != "" then
+                        { revisionName: .revisionName, weight: (.weight // 0) }
+                      elif .latestRevision == true then
+                        { revisionName: $app.properties.latestRevisionName, weight: (.weight // 0) }
+                      else
+                        empty
+                      end
+                    )
+                  | sort_by(.weight, .revisionName)
+                  | last
+                  | .revisionName,
+                  $app.properties.latestReadyRevisionName,
+                  $app.properties.latestRevisionName
+                ]
+                | map(select(. != null and . != ""))
+                | first
+              ) // empty')
+
+          if [[ -z "$current_revision" ]]; then
+            echo "::error::Unable to determine the production revision for $CONTAINER_APP_NAME"
+            exit 1
+          fi
+
+          echo "::notice::Production revision: $current_revision"
           echo "current_revision_name=$current_revision" >> $GITHUB_OUTPUT
 
       - name: Create New Container App Revision
@@ -249,6 +279,8 @@ jobs:
           resource_group_name: ${{ env.RESOURCE_GROUP_NAME }}
           resource_name: ${{ env.CONTAINER_APP_NAME }}
           resource_type: "containerapp"
+          current_revision_name: ${{ steps.get_current_revision.outputs.current_revision_name }}
+          target_revision_name: ${{ steps.create_new_revision.outputs.new_revision_name }}
 
       - name: Deactivate Old Revision
         if: ${{ steps.get_revision_mode.outputs.revision_mode == 'Multiple' && steps.create_new_revision.outputs.skip_remaining_steps == 'false' }}

--- a/actions/incremental-rollout/action.yml
+++ b/actions/incremental-rollout/action.yml
@@ -11,6 +11,12 @@ inputs:
   resource_type:
     description: "Type of Azure resource (e.g., 'appsvc' or 'containerapp')"
     required: true
+  current_revision_name:
+    description: "Current Azure Container App revision receiving production traffic"
+    required: false
+  target_revision_name:
+    description: "Azure Container App revision to receive rollout traffic"
+    required: false
 
 runs:
   using: "composite"
@@ -35,4 +41,6 @@ runs:
         RESOURCE_GROUP_NAME: ${{ inputs.resource_group_name }}
         RESOURCE_NAME: ${{ inputs.resource_name }}
         RESOURCE_TYPE: ${{ inputs.resource_type }}
+        CURRENT_REVISION_NAME: ${{ inputs.current_revision_name }}
+        TARGET_REVISION_NAME: ${{ inputs.target_revision_name }}
       run: rollout.sh "$RESOURCE_GROUP_NAME" "$RESOURCE_NAME" "$RESOURCE_TYPE"

--- a/actions/incremental-rollout/azure-containerapp.sh
+++ b/actions/incremental-rollout/azure-containerapp.sh
@@ -1,26 +1,57 @@
 #!/usr/bin/env bash
 
+__require_revision_names() {
+  local current_revision_name="$1"
+  local target_revision_name="$2"
+
+  if [[ -z "$current_revision_name" || -z "$target_revision_name" ]]; then
+    echo "::error::Container App rollout requires both current and target revision names."
+    exit 1
+  fi
+}
+
 __revert_traffic() {
   local resource_group_name="$1"
   local containerapp_name="$2"
+  local current_revision_name="$3"
+  local target_revision_name="$4"
+
+  __require_revision_names "$current_revision_name" "$target_revision_name"
+
   az containerapp ingress traffic set \
     --resource-group "$resource_group_name" \
     --name "$containerapp_name" \
-    --revision-weight "latest=0"
+    --revision-weight "$current_revision_name"=100 "$target_revision_name"=0
 }
 
 __set_traffic() {
   local resource_group_name="$1"
   local containerapp_name="$2"
   local staging_percentage="$3"
+  local current_revision_name="$4"
+  local target_revision_name="$5"
+  local production_percentage=$((100 - staging_percentage))
+
+  __require_revision_names "$current_revision_name" "$target_revision_name"
+
   az containerapp ingress traffic set \
     --resource-group "$resource_group_name" \
     --name "$containerapp_name" \
-    --revision-weight "latest=${staging_percentage}"
+    --revision-weight "$current_revision_name"="$production_percentage" "$target_revision_name"="$staging_percentage"
 }
 
 __swap_versions() {
-  __revert_traffic "$1" "$2"
+  local resource_group_name="$1"
+  local containerapp_name="$2"
+  local current_revision_name="$3"
+  local target_revision_name="$4"
+
+  __require_revision_names "$current_revision_name" "$target_revision_name"
+
+  az containerapp ingress traffic set \
+    --resource-group "$resource_group_name" \
+    --name "$containerapp_name" \
+    --revision-weight "$current_revision_name"=0 "$target_revision_name"=100
 }
 
 __finalize() { :; }

--- a/actions/incremental-rollout/rollout.sh
+++ b/actions/incremental-rollout/rollout.sh
@@ -3,6 +3,8 @@
 resource_group_name=$1
 resource_name=$2
 resource_type=$3  # e.g., "appsvc" or "containerapp"
+current_revision_name=${CURRENT_REVISION_NAME:-}
+target_revision_name=${TARGET_REVISION_NAME:-}
 
 set -euo pipefail
 
@@ -78,7 +80,7 @@ EOF
 revert_traffic() {
   local reason="$1"
   echo "::error::$reason. Reverting traffic to production."
-  __revert_traffic "$resource_group_name" "$resource_name"
+  __revert_traffic "$resource_group_name" "$resource_name" "$current_revision_name" "$target_revision_name"
   log_canary_event 0
   post_canary_gh_summary "Rollout failed ❌. $reason. Traffic reverted to production."
   exit 1
@@ -88,16 +90,16 @@ set_traffic() {
   local staging_percentage="$1"
   local production_percentage=$((100 - staging_percentage))
   echo "Setting traffic distribution: ${staging_percentage}% staging, ${production_percentage}% production"
-  __set_traffic "$resource_group_name" "$resource_name" "$staging_percentage"
+  __set_traffic "$resource_group_name" "$resource_name" "$staging_percentage" "$current_revision_name" "$target_revision_name"
   log_canary_event "$staging_percentage"
 }
 
 swap_versions() {
-  __swap_versions "$resource_group_name" "$resource_name"
+  __swap_versions "$resource_group_name" "$resource_name" "$current_revision_name" "$target_revision_name"
 }
 
 finalize() {
-  __finalize "$resource_group_name" "$resource_name"
+  __finalize "$resource_group_name" "$resource_name" "$current_revision_name" "$target_revision_name"
 }
 
 if [[ -r ./canary-monitor.sh ]]; then


### PR DESCRIPTION
## Summary
- track the revision that is currently serving traffic before copying and promoting a new Azure Container App revision
- pass the current and target revision names to the incremental rollout action for container apps
- update rollout traffic using explicit revision weights instead of relying on `latest`

## Why
In multiple revision mode, Azure Container Apps can keep older revisions active even when they are not receiving traffic. When that happens, the reusable workflow can deploy from one active revision while ingress traffic still points to another, and the rollout action can leave production traffic on the wrong revision.