### PR TITLE
Replace start script on standalone build

### DIFF
--- a/.github/workflows/_validate-next-bundle.yaml
+++ b/.github/workflows/_validate-next-bundle.yaml
@@ -89,7 +89,8 @@ jobs:
           temp_dir=$(mktemp -d)
           unzip -d "$temp_dir" -q "$ARTIFACT_PATH"
 
-          PORT=$(($RANDOM+1024)) node "$temp_dir/server.js" &
+          cd "$temp_dir"
+          PORT=$(($RANDOM+1024)) npm start &
           sleep 2
 
           pid=$!

--- a/actions/make-artifact/action.yaml
+++ b/actions/make-artifact/action.yaml
@@ -34,6 +34,7 @@ runs:
         if grep -rq --include='next.config.*' 'standalone' .; then
           echo "::debug::The workspace contains a Next.js standalone app"
           mv .next/static .next/standalone/"$WORKSPACE_PATH"/.next
+          mv package.json .next/standalone/"$WORKSPACE_PATH"/
           if [ -d public ]; then
             mv public .next/standalone/"$WORKSPACE_PATH"
           fi
@@ -45,6 +46,10 @@ runs:
             mv .next/standalone/node_modules .next/standalone/"$WORKSPACE_PATH"
           fi
           cd .next/standalone/"$WORKSPACE_PATH"
+          # replace start script with "node ." and set main to server.js
+          # this is needed because the standalone build does not have the next CLI
+          PACKAGE_JSON=$(cat package.json)
+          jq '. += {"scripts": { "start": "node ." }, "main": "server.js"}' <<< "$PACKAGE_JSON" > package.json
           zip -r -q "$BUNDLE_NAME".zip .
           echo "artifact-path=$(realpath "$BUNDLE_NAME.zip")" >> "$GITHUB_OUTPUT"
           exit 0


### PR DESCRIPTION
## Issue
Azure App Service starts Node.js projects by running `npm start` (if present) or `node server.js`. The standalone build behave differently on different Next.js versions:
- `13, 14` the build doesn't include the `package.json` file, Azure App Service runs `node server.js`, everything works ✅ 
- `15, 16` the build includes a broken `package.json` file, with `next start` as `npm start` script, but the standalone artifact does not have `next cli` installed. Result: fail to start a project. ❌

## Fix
Write a working `package.json` file with `node server.js` as `npm start` script. Force the presence of a `package.json` file even on Next 13, 14.

Closes CES-1932