### PR TITLE
Add Copilot instruction about comments in Terraform Test skill

### DIFF
--- a/.github/skills/terraform-tests/SKILL.md
+++ b/.github/skills/terraform-tests/SKILL.md
@@ -3,7 +3,7 @@ name: terraform-tests
 description: Generate tests for Terraform modules. Use everytime tests are missing or need to be updated.
 metadata:
   author: pagopa-dx
-  version: "1.0"
+  version: "1.1"
 compatibility: requires terraform, go, and access to the internet
 ---
 
@@ -205,6 +205,7 @@ When a module has legacy tests (single file, no modern structure):
 - Integration and E2E infrastructures are completely separate
 - Always execute unit and contract tests after modifications to verify they pass
 - Do not run integration/e2e tests during development (slow, expensive)
+- Do not add comments to state the obvious (e.g. this file contains unit tests) or to declare what the specific test does (e.g. `3. Development use case`)
 
 ## Reference Documentation
 

--- a/.github/skills/terraform-tests/SKILL.md
+++ b/.github/skills/terraform-tests/SKILL.md
@@ -205,7 +205,7 @@ When a module has legacy tests (single file, no modern structure):
 - Integration and E2E infrastructures are completely separate
 - Always execute unit and contract tests after modifications to verify they pass
 - Do not run integration/e2e tests during development (slow, expensive)
-- Do not add comments to state the obvious (e.g. this file contains unit tests) or to declare what the specific test does (e.g. `3. Development use case`)
+- Do not add comments that merely restate the obvious or act as decorative/redundant headers (for example, `this file contains unit tests` or `3. Development use case` when the `run` name already conveys that); comments are fine when they add necessary context such as non-obvious intent, workarounds, assumptions, or edge cases
 
 ## Reference Documentation
 


### PR DESCRIPTION
When writing Terraform tests, Copilot usually add useless comments at the beginning of each test stating the obvious with weird pattern.

Examples:
```hcl
# ── 1. Security defaults ────────────────────────────────────────────────────
run "storage_account_security_defaults" {
```

```hcl
# ── 2. Default use case ─────────────────────────────────────────────────────
run "storage_account_default_use_case" {
```

```hcl
# ── 3. Development use case ─────────────────────────────────────────────────
run "storage_account_development_use_case" {
```