### PR TITLE
Upgrade Terraform mcp server

### DIFF
--- a/plugins/terraform/.mcp.json
+++ b/plugins/terraform/.mcp.json
@@ -6,7 +6,7 @@
     },
     "terraform": {
       "command": "docker",
-      "args": ["run", "-i", "--rm", "hashicorp/terraform-mcp-server:0.4.0"]
+      "args": ["run", "-i", "--rm", "hashicorp/terraform-mcp-server:0.5.1"]
     }
   },
   "inputs": []


### PR DESCRIPTION
Upgrade Terraform MCP server used in DX plugins to `0.5.1`