### PR TITLE
Update __swap_versions to set traffic to 100% instead of reverting

### DIFF
--- a/.github/workflows/release-azure-containerapp-v1.yaml
+++ b/.github/workflows/release-azure-containerapp-v1.yaml
@@ -26,7 +26,8 @@ on:
         default: PagoPA
         description: Authors names to use as image label
       build_args:
-        description: List of build arguments to use for Dockerfile build, given in env=value format.
+        description: List of build arguments to use for Dockerfile build, given in
+          env=value format.
         type: string
         required: false
       build_platforms:
@@ -231,7 +232,8 @@ jobs:
 
       - name: Get Container App Id
         id: get_container_app_id
-        if: ${{ steps.get_revision_mode.outputs.revision_mode == 'Multiple' && steps.create_new_revision.outputs.skip_remaining_steps == 'false' }}
+        if: ${{ steps.get_revision_mode.outputs.revision_mode == 'Multiple' &&
+          steps.create_new_revision.outputs.skip_remaining_steps == 'false' }}
         run: |
           set -euo
 
@@ -243,15 +245,17 @@ jobs:
           echo "ca_id=$container_app_id" >> $GITHUB_OUTPUT
 
       - name: Check for New Revision Errors and Increment Traffic
-        uses: pagopa/dx/actions/incremental-rollout@main
-        if: ${{ steps.get_revision_mode.outputs.revision_mode == 'Multiple' && steps.create_new_revision.outputs.skip_remaining_steps == 'false' }}
+        uses: pagopa/dx/actions/incremental-rollout@fixes/incremental-rollout
+        if: ${{ steps.get_revision_mode.outputs.revision_mode == 'Multiple' &&
+          steps.create_new_revision.outputs.skip_remaining_steps == 'false' }}
         with:
           resource_group_name: ${{ env.RESOURCE_GROUP_NAME }}
           resource_name: ${{ env.CONTAINER_APP_NAME }}
           resource_type: "containerapp"
 
       - name: Deactivate Old Revision
-        if: ${{ steps.get_revision_mode.outputs.revision_mode == 'Multiple' && steps.create_new_revision.outputs.skip_remaining_steps == 'false' }}
+        if: ${{ steps.get_revision_mode.outputs.revision_mode == 'Multiple' &&
+          steps.create_new_revision.outputs.skip_remaining_steps == 'false' }}
         env:
           CURRENT_REVISION_NAME: ${{ steps.get_current_revision.outputs.current_revision_name }}
         run: |
@@ -260,7 +264,8 @@ jobs:
             --revision "$CURRENT_REVISION_NAME"
 
       - name: Deactivate New Revision
-        if: ${{ failure() && steps.get_revision_mode.outputs.revision_mode == 'Multiple' }}
+        if: ${{ failure() && steps.get_revision_mode.outputs.revision_mode == 'Multiple'
+          }}
         env:
           CURRENT_REVISION_NAME: ${{ steps.get_current_revision.outputs.current_revision_name }}
           NEW_REVISION_NAME: ${{ steps.create_new_revision.outputs.new_revision_name }}

--- a/.github/workflows/release-azure-containerapp-v1.yaml
+++ b/.github/workflows/release-azure-containerapp-v1.yaml
@@ -190,8 +190,7 @@ jobs:
           if [[ "$REVISION_MODE" == "Multiple" ]]; then
             az containerapp ingress traffic set \
               --name "$CONTAINER_APP_NAME" \
-              --revision-weight "$CURRENT_REVISION"=100 \
-              --revision-weight $new_revision=0 \
+              --revision-weight "$CURRENT_REVISION"=100 "$new_revision"=0 \
               --output table
           fi
 
@@ -245,7 +244,7 @@ jobs:
           echo "ca_id=$container_app_id" >> $GITHUB_OUTPUT
 
       - name: Check for New Revision Errors and Increment Traffic
-        uses: pagopa/dx/actions/incremental-rollout@fixes/incremental-rollout
+        uses: pagopa/dx/actions/incremental-rollout@main
         if: ${{ steps.get_revision_mode.outputs.revision_mode == 'Multiple' &&
           steps.create_new_revision.outputs.skip_remaining_steps == 'false' }}
         with:
@@ -272,8 +271,7 @@ jobs:
         run: |
           az containerapp ingress traffic set \
             --name "$CONTAINER_APP_NAME" \
-            --revision-weight "$CURRENT_REVISION_NAME"=100 \
-            --revision-weight "$NEW_REVISION_NAME"=0 \
+            --revision-weight "$CURRENT_REVISION_NAME"=100 "$NEW_REVISION_NAME"=0 \
             --output table
 
           az containerapp revision deactivate \

--- a/actions/incremental-rollout/azure-containerapp.sh
+++ b/actions/incremental-rollout/azure-containerapp.sh
@@ -20,7 +20,7 @@ __set_traffic() {
 }
 
 __swap_versions() {
-  __revert_traffic "$1" "$2"
+  __set_traffic "$1" "$2" "100"
 }
 
 __finalize() { :; }


### PR DESCRIPTION
Fix an issue which prevented the incremental rollout of containers to Container App instances with the deployment mode set to `Multiple`