### PR TITLE
Upgrade devcontainer base image version + lock file

### DIFF
--- a/.devcontainer/devcontainer-lock.json
+++ b/.devcontainer/devcontainer-lock.json
@@ -1,0 +1,94 @@
+{
+  "features": {
+    "ghcr.io/devcontainers-extra/features/act:1": {
+      "version": "1.0.15",
+      "resolved": "ghcr.io/devcontainers-extra/features/act@sha256:db4a2194930d1f7ec62822d4f600dd2fa4aff3c33b98cdb0b578b64ffb10924c",
+      "integrity": "sha256:db4a2194930d1f7ec62822d4f600dd2fa4aff3c33b98cdb0b578b64ffb10924c"
+    },
+    "ghcr.io/devcontainers-extra/features/apt-get-packages:1": {
+      "version": "1.0.8",
+      "resolved": "ghcr.io/devcontainers-extra/features/apt-get-packages@sha256:776fa11c30c50fa91d5e1bf050444b0f130827457109c349db92e8e126b750ec",
+      "integrity": "sha256:776fa11c30c50fa91d5e1bf050444b0f130827457109c349db92e8e126b750ec"
+    },
+    "ghcr.io/devcontainers-extra/features/grype:1": {
+      "version": "1.0.10",
+      "resolved": "ghcr.io/devcontainers-extra/features/grype@sha256:849608832dfad2e459e364291aca760aba6207c0317c40c4a67dc15d8fd5677b",
+      "integrity": "sha256:849608832dfad2e459e364291aca760aba6207c0317c40c4a67dc15d8fd5677b"
+    },
+    "ghcr.io/devcontainers-extra/features/nx-npm:1": {
+      "version": "1.0.11",
+      "resolved": "ghcr.io/devcontainers-extra/features/nx-npm@sha256:a8850e9992c06b12209b9be9c5880e2fe3f2746735ca7634abb499b9d84bd6a8",
+      "integrity": "sha256:a8850e9992c06b12209b9be9c5880e2fe3f2746735ca7634abb499b9d84bd6a8"
+    },
+    "ghcr.io/devcontainers-extra/features/pre-commit:2": {
+      "version": "2.0.18",
+      "resolved": "ghcr.io/devcontainers-extra/features/pre-commit@sha256:6e0bb2ce80caca1d94f44dab5d0653d88a1c00984e590adb7c6bce012d0ade6e",
+      "integrity": "sha256:6e0bb2ce80caca1d94f44dab5d0653d88a1c00984e590adb7c6bce012d0ade6e"
+    },
+    "ghcr.io/devcontainers-extra/features/syft:1": {
+      "version": "1.0.10",
+      "resolved": "ghcr.io/devcontainers-extra/features/syft@sha256:1cfd858d0fc6eb4bd49b335cf94af734d6e6bd617a4a5265f54f07dbc72771e9",
+      "integrity": "sha256:1cfd858d0fc6eb4bd49b335cf94af734d6e6bd617a4a5265f54f07dbc72771e9"
+    },
+    "ghcr.io/devcontainers/features/aws-cli:1": {
+      "version": "1.1.4",
+      "resolved": "ghcr.io/devcontainers/features/aws-cli@sha256:1f93c8315b7a6d76982ebb2269f8b0d50413fc0f965c032edf4aee0caceb73ef",
+      "integrity": "sha256:1f93c8315b7a6d76982ebb2269f8b0d50413fc0f965c032edf4aee0caceb73ef"
+    },
+    "ghcr.io/devcontainers/features/azure-cli:1": {
+      "version": "1.2.9",
+      "resolved": "ghcr.io/devcontainers/features/azure-cli@sha256:4549175fbfd3475d1d62e82f6e5425d03954a6ae06027b2515b0ba41a8206417",
+      "integrity": "sha256:4549175fbfd3475d1d62e82f6e5425d03954a6ae06027b2515b0ba41a8206417"
+    },
+    "ghcr.io/devcontainers/features/copilot-cli:1": {
+      "version": "1.1.2",
+      "resolved": "ghcr.io/devcontainers/features/copilot-cli@sha256:757c6c2899dc902c44a9f6164c1f7392832ced13c6bb632d8d60a880f2e92456",
+      "integrity": "sha256:757c6c2899dc902c44a9f6164c1f7392832ced13c6bb632d8d60a880f2e92456"
+    },
+    "ghcr.io/devcontainers/features/docker-outside-of-docker:1": {
+      "version": "1.9.1",
+      "resolved": "ghcr.io/devcontainers/features/docker-outside-of-docker@sha256:dc89605f01ff2f24252c61f7c8ba2a58ccdbc14f2ebf87a7952d9e2b89834850",
+      "integrity": "sha256:dc89605f01ff2f24252c61f7c8ba2a58ccdbc14f2ebf87a7952d9e2b89834850"
+    },
+    "ghcr.io/devcontainers/features/github-cli:1": {
+      "version": "1.1.0",
+      "resolved": "ghcr.io/devcontainers/features/github-cli@sha256:d22f50b70ed75339b4eed1ba9ecde3a1791f90e88d37936517e3bace0bbad671",
+      "integrity": "sha256:d22f50b70ed75339b4eed1ba9ecde3a1791f90e88d37936517e3bace0bbad671"
+    },
+    "ghcr.io/devcontainers/features/go:1": {
+      "version": "1.3.3",
+      "resolved": "ghcr.io/devcontainers/features/go@sha256:f5ef402a387201cf1ace38ea16c176612d61107c0fcd58da1bb84493cd93f6a1",
+      "integrity": "sha256:f5ef402a387201cf1ace38ea16c176612d61107c0fcd58da1bb84493cd93f6a1"
+    },
+    "ghcr.io/devcontainers/features/node:1": {
+      "version": "1.7.1",
+      "resolved": "ghcr.io/devcontainers/features/node@sha256:8c0de46939b61958041700ee89e3493f3b2e4131a06dc46b4d9423427d06e5f6",
+      "integrity": "sha256:8c0de46939b61958041700ee89e3493f3b2e4131a06dc46b4d9423427d06e5f6"
+    },
+    "ghcr.io/devcontainers/features/terraform:1": {
+      "version": "1.4.2",
+      "resolved": "ghcr.io/devcontainers/features/terraform@sha256:250d08e39c99d9e959e091e74527c22c04eeae728b424da99f002423c7902f82",
+      "integrity": "sha256:250d08e39c99d9e959e091e74527c22c04eeae728b424da99f002423c7902f82"
+    },
+    "ghcr.io/pagopa/devcontainer-features/acli:1": {
+      "version": "1.0.0",
+      "resolved": "ghcr.io/pagopa/devcontainer-features/acli@sha256:29d4c33994f0a0dd7d1c97c3b8a241e5ce1575af5b934ce0886497e4186bb931",
+      "integrity": "sha256:29d4c33994f0a0dd7d1c97c3b8a241e5ce1575af5b934ce0886497e4186bb931"
+    },
+    "ghcr.io/pagopa/devcontainer-features/plantuml:1": {
+      "version": "1.0.0",
+      "resolved": "ghcr.io/pagopa/devcontainer-features/plantuml@sha256:0120623a345d2ab95d2d4f80e521b171724668b729f533e5583fc6e05196018a",
+      "integrity": "sha256:0120623a345d2ab95d2d4f80e521b171724668b729f533e5583fc6e05196018a"
+    },
+    "ghcr.io/pagopa/devcontainer-features/shellcheck:1": {
+      "version": "1.0.0",
+      "resolved": "ghcr.io/pagopa/devcontainer-features/shellcheck@sha256:bc519c30ff1519a366aa2322056543ec12e93b9245dea9472550fda932023137",
+      "integrity": "sha256:bc519c30ff1519a366aa2322056543ec12e93b9245dea9472550fda932023137"
+    },
+    "ghcr.io/pagopa/devcontainer-features/trivy:1": {
+      "version": "1.0.1",
+      "resolved": "ghcr.io/pagopa/devcontainer-features/trivy@sha256:6f120026887a7c954a8a2c3a35b1a19807d865b9778af83c9cdb8182e0e9b9ff",
+      "integrity": "sha256:6f120026887a7c954a8a2c3a35b1a19807d865b9778af83c9cdb8182e0e9b9ff"
+    }
+  }
+}

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,5 +1,5 @@
 {
-  "image": "mcr.microsoft.com/devcontainers/base:debian@sha256:a30da48cdf5f9144ff7f2156622e701e752fc258d77ca7bb00120624f1a95938",
+  "image": "mcr.microsoft.com/devcontainers/base:debian@sha256:aa263c6fdd7c1bc990eead3922224fe8afbf5d85eaf3b6b9260786ab94d74933",
   "features": {
     "ghcr.io/devcontainers-extra/features/pre-commit:2": {},
     "ghcr.io/pagopa/devcontainer-features/acli:1": {},
@@ -23,7 +23,9 @@
       "pnpmVersion": "none",
       "nvmInstallPath": "/opt/nvm"
     },
-    "ghcr.io/devcontainers/features/go:1": {},
+    "ghcr.io/devcontainers/features/go:1": {
+      "golangciLintVersion": "2.11.4"
+    },
     "ghcr.io/devcontainers/features/docker-outside-of-docker:1": {
       "moby": false
     },

--- a/.devcontainer/templates/node/.devcontainer/devcontainer.json
+++ b/.devcontainer/templates/node/.devcontainer/devcontainer.json
@@ -1,5 +1,5 @@
 {
-  "image": "mcr.microsoft.com/devcontainers/base:debian@sha256:da67c59f82e057e0ccb81ec7d13fb50464c26f477638018e6de1b2623a008a3a",
+  "image": "mcr.microsoft.com/devcontainers/base:debian@sha256:aa263c6fdd7c1bc990eead3922224fe8afbf5d85eaf3b6b9260786ab94d74933",
   "features": {
     "ghcr.io/devcontainers-extra/features/pre-commit:2": {},
     "ghcr.io/devcontainers/features/azure-cli:1": {},

--- a/.devcontainer/templates/node/devcontainer-template.json
+++ b/.devcontainer/templates/node/devcontainer-template.json
@@ -1,6 +1,6 @@
 {
   "id": "node",
-  "version": "1.2.1",
+  "version": "1.2.2",
   "name": "Node.js",
   "description": "A template for Node.js projects",
   "documentationURL": "https://github.com/pagopa/dx/tree/main/.devcontainer/templates/node",


### PR DESCRIPTION
Upgrade devcontainer base image (template included).
Generated lock file to pin versions and enhancing supply chain security.

N.B. there's an issue with checksum verification for versions `>=2.12.0` of the tool `golangciLintVersion`. Looks like their sbom file doesn't have the right sha, and therefore the installation fails. Downgrading to `2.11.x` fixed it.