### PR TITLE
Insert subscription name in custom roles names

### DIFF
--- a/.nx/version-plans/version-plan-1777970400000.md
+++ b/.nx/version-plans/version-plan-1777970400000.md
@@ -1,0 +1,5 @@
+---
+azure_core_infra: patch
+---
+
+Prefix merged custom role names with the Azure subscription display name to avoid tenant-wide name collisions across subscriptions.

--- a/infra/modules/azure_core_infra/README.md
+++ b/infra/modules/azure_core_infra/README.md
@@ -13,6 +13,19 @@ This Terraform module provisions the core infrastructure required for the initia
 - **Private DNS Zones**: Configures private DNS zones for all resource types.
 - **Log Analytics Workspace**: Creates a Log Analytics Workspace for monitoring and diagnostics.
 - **GitHub Runner**: Provisions a GitHub Runner for CI/CD workflows.
+- **Merged Custom Roles**: Creates subscription-scoped merged custom roles for DX CI/CD identities and Function App storage access.
+
+## Custom Role Naming
+
+Merged custom roles are created at subscription scope and their display name is prefixed with the current Azure subscription display name.
+
+This keeps the role names readable in the Azure portal while avoiding tenant-wide collisions when the same core module is deployed in multiple subscriptions of the same Microsoft Entra tenant.
+
+Example role names:
+
+- `<subscription display name> DX App CI Resource Groups`
+- `<subscription display name> DX Infra CD Subscription`
+- `<subscription display name> DX Function Host Storage`
 
 ## Usage Example
 

--- a/infra/modules/azure_core_infra/custom_roles.tf
+++ b/infra/modules/azure_core_infra/custom_roles.tf
@@ -3,7 +3,7 @@ module "dx_app_cd_resource_group_deploy" {
   version = "~> 0.0"
 
   scope     = data.azurerm_subscription.current.id
-  role_name = "DX App CD Resource Groups"
+  role_name = "${local.subscription_role_name_prefix} DX App CD Resource Groups"
   reason    = "Merged role for DX App CD identities at resource group scope"
   source_roles = [
     "Website Contributor",
@@ -19,7 +19,7 @@ module "dx_app_ci_resource_group_reader" {
   version = "~> 0.0"
 
   scope     = data.azurerm_subscription.current.id
-  role_name = "DX App CI Resource Groups"
+  role_name = "${local.subscription_role_name_prefix} DX App CI Resource Groups"
   reason    = "Merged role for DX App CI identities at resource group scope"
   source_roles = [
     "PagoPA IaC Reader",
@@ -32,7 +32,7 @@ module "dx_infra_cd_private_networking" {
   version = "~> 0.0"
 
   scope     = data.azurerm_subscription.current.id
-  role_name = "DX Infra CD Private Networking"
+  role_name = "${local.subscription_role_name_prefix} DX Infra CD Private Networking"
   reason    = "Merged role for DX Infra CD identities managing private DNS networking"
   source_roles = [
     "Private DNS Zone Contributor",
@@ -45,7 +45,7 @@ module "dx_infra_cd_resource_group_deploy" {
   version = "~> 0.0"
 
   scope     = data.azurerm_subscription.current.id
-  role_name = "DX Infra CD Resource Groups"
+  role_name = "${local.subscription_role_name_prefix} DX Infra CD Resource Groups"
   reason    = "Merged role for DX Infra CD identities at resource group scope"
   source_roles = [
     "Contributor",
@@ -65,7 +65,7 @@ module "dx_infra_cd_subscription_admin" {
   version = "~> 0.0"
 
   scope     = data.azurerm_subscription.current.id
-  role_name = "DX Infra CD Subscription"
+  role_name = "${local.subscription_role_name_prefix} DX Infra CD Subscription"
   reason    = "Merged role for DX Infra CD identities at subscription scope"
   source_roles = [
     "Reader",
@@ -78,7 +78,7 @@ module "dx_infra_ci_resource_group_reader" {
   version = "~> 0.0"
 
   scope     = data.azurerm_subscription.current.id
-  role_name = "DX Infra CI Resource Groups"
+  role_name = "${local.subscription_role_name_prefix} DX Infra CI Resource Groups"
   reason    = "Merged role for DX Infra CI identities at resource group scope"
   source_roles = [
     "DocumentDB Account Contributor",
@@ -98,7 +98,7 @@ module "dx_infra_ci_subscription_reader" {
   version = "~> 0.0"
 
   scope     = data.azurerm_subscription.current.id
-  role_name = "DX Infra CI Subscription"
+  role_name = "${local.subscription_role_name_prefix} DX Infra CI Subscription"
   reason    = "Merged role for DX Infra CI identities at subscription scope"
   source_roles = [
     "Reader",
@@ -112,7 +112,7 @@ module "dx_function_host_storage" {
   version = "~> 0.0"
 
   scope     = data.azurerm_subscription.current.id
-  role_name = "DX Function Host Storage"
+  role_name = "${local.subscription_role_name_prefix} DX Function Host Storage"
   reason    = "Merged role for Function App host storage access"
   source_roles = [
     "Storage Blob Data Owner",
@@ -126,7 +126,7 @@ module "dx_function_durable_storage" {
   version = "~> 0.0"
 
   scope     = data.azurerm_subscription.current.id
-  role_name = "DX Function Durable Storage"
+  role_name = "${local.subscription_role_name_prefix} DX Function Durable Storage"
   reason    = "Merged role for Function App durable storage access"
   source_roles = [
     "Storage Blob Data Contributor",

--- a/infra/modules/azure_core_infra/locals.tf
+++ b/infra/modules/azure_core_infra/locals.tf
@@ -4,6 +4,7 @@ locals {
     "italynorth" = "itn",
     "westeurope" = "weu"
   })[var.environment.location]
+  subscription_role_name_prefix = trimspace(data.azurerm_subscription.current.display_name)
 
   project = "${var.environment.prefix}-${var.environment.env_short}-${local.location_short}"
   naming_config = {

--- a/infra/modules/azure_core_infra/tests/common.tftest.hcl
+++ b/infra/modules/azure_core_infra/tests/common.tftest.hcl
@@ -71,47 +71,27 @@ run "core_is_correct_plan" {
   }
 
   assert {
-    condition     = module.dx_app_cd_resource_group_deploy.custom_role_name == "DX App CD Resource Groups"
-    error_message = "The App CD merged custom role name configuration must be correct"
+    condition     = module.dx_app_ci_resource_group_reader.custom_role_name == "${data.azurerm_subscription.current.display_name} DX App CI Resource Groups"
+    error_message = "The App CI merged custom role must include the subscription display name as prefix"
   }
 
   assert {
-    condition     = module.dx_app_ci_resource_group_reader.custom_role_name == "DX App CI Resource Groups"
-    error_message = "The App CI merged custom role name configuration must be correct"
+    condition     = module.dx_infra_ci_subscription_reader.custom_role_name == "${data.azurerm_subscription.current.display_name} DX Infra CI Subscription"
+    error_message = "The Infra CI merged custom role must include the subscription display name as prefix"
   }
 
   assert {
-    condition     = module.dx_infra_cd_private_networking.custom_role_name == "DX Infra CD Private Networking"
-    error_message = "The Infra CD private networking merged custom role name configuration must be correct"
+    condition     = module.dx_infra_cd_subscription_admin.custom_role_name == "${data.azurerm_subscription.current.display_name} DX Infra CD Subscription"
+    error_message = "The Infra CD merged custom role must include the subscription display name as prefix"
   }
 
   assert {
-    condition     = module.dx_infra_cd_resource_group_deploy.custom_role_name == "DX Infra CD Resource Groups"
-    error_message = "The Infra CD merged custom role name configuration must be correct"
+    condition     = module.dx_function_host_storage.custom_role_name == "${data.azurerm_subscription.current.display_name} DX Function Host Storage"
+    error_message = "The Function App host storage merged custom role must include the subscription display name as prefix"
   }
 
   assert {
-    condition     = module.dx_infra_cd_subscription_admin.custom_role_name == "DX Infra CD Subscription"
-    error_message = "The Infra CD subscription merged custom role name configuration must be correct"
-  }
-
-  assert {
-    condition     = module.dx_infra_ci_resource_group_reader.custom_role_name == "DX Infra CI Resource Groups"
-    error_message = "The Infra CI merged custom role name configuration must be correct"
-  }
-
-  assert {
-    condition     = module.dx_infra_ci_subscription_reader.custom_role_name == "DX Infra CI Subscription"
-    error_message = "The Infra CI subscription merged custom role name configuration must be correct"
-  }
-
-  assert {
-    condition     = module.dx_function_host_storage.custom_role_name == "DX Function Host Storage"
-    error_message = "The Function App host storage merged custom role name configuration must be correct"
-  }
-
-  assert {
-    condition     = module.dx_function_durable_storage.custom_role_name == "DX Function Durable Storage"
-    error_message = "The Function App durable storage merged custom role name configuration must be correct"
+    condition     = module.dx_function_durable_storage.custom_role_name == "${data.azurerm_subscription.current.display_name} DX Function Durable Storage"
+    error_message = "The Function App durable storage merged custom role must include the subscription display name as prefix"
   }
 }


### PR DESCRIPTION
Custom roles are created with the subscription as scope. However, they are available at the tenant level. For this reason, the subscription display name has been introduced in the role definition name.