### PR TITLE
Enable global virtual store in pnpm workspace configuration

### DIFF
--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -74,3 +74,5 @@ onlyBuiltDependencies:
   - protobufjs
 
 packageImportMethod: clone-or-copy
+
+enableGlobalVirtualStore: true


### PR DESCRIPTION
Configure the pnpm workspace to enable the global virtual store feature.
