### PR TITLE
Migrate mcpserver to Zod v4

### DIFF
--- a/.nx/version-plans/version-plan-1777989128434.md
+++ b/.nx/version-plans/version-plan-1777989128434.md
@@ -1,0 +1,5 @@
+---
+'@pagopa/dx-mcpserver': patch
+---
+
+Migrate the MCP server to Zod v4

--- a/apps/mcpserver/package.json
+++ b/apps/mcpserver/package.json
@@ -28,7 +28,7 @@
     "@pagopa/azure-tracing": "workspace:^",
     "@pagopa/dx-mcpprompts": "workspace:^",
     "axios": "^1.16.0",
-    "zod": "^3.25.76"
+    "zod": "catalog:"
   },
   "devDependencies": {
     "@pagopa/eslint-config": "workspace:^",

--- a/apps/mcpserver/src/handlers/ask.ts
+++ b/apps/mcpserver/src/handlers/ask.ts
@@ -16,10 +16,7 @@ import {
 
 const AskBodySchema = z.object({
   query: z
-    .string({
-      invalid_type_error: "Missing required field: query",
-      required_error: "Missing required field: query",
-    })
+    .string({ error: "Missing required field: query" })
     .trim()
     .min(1, "Missing required field: query"),
 });
@@ -42,7 +39,11 @@ export async function handleAskEndpoint(
     const result = AskBodySchema.safeParse(jsonBody);
 
     if (!result.success) {
-      return sendErrorResponse(res, 400, result.error.errors[0].message);
+      const firstIssue = result.error.issues[0];
+      if (!firstIssue) {
+        throw new Error("Request validation failed without any issues");
+      }
+      return sendErrorResponse(res, 400, firstIssue.message);
     }
 
     const { query } = result.data;

--- a/apps/mcpserver/src/handlers/search.ts
+++ b/apps/mcpserver/src/handlers/search.ts
@@ -15,19 +15,14 @@ import {
 
 const SearchBodySchema = z.object({
   number_of_results: z
-    .number({
-      invalid_type_error: "number_of_results must be between 1 and 20",
-    })
+    .number({ error: "number_of_results must be between 1 and 20" })
     .int()
     .min(1, "number_of_results must be between 1 and 20")
     .max(20, "number_of_results must be between 1 and 20")
     .optional()
     .default(5),
   query: z
-    .string({
-      invalid_type_error: "Missing required field: query",
-      required_error: "Missing required field: query",
-    })
+    .string({ error: "Missing required field: query" })
     .trim()
     .min(1, "Missing required field: query"),
 });
@@ -50,7 +45,11 @@ export async function handleSearchEndpoint(
     const result = SearchBodySchema.safeParse(jsonBody);
 
     if (!result.success) {
-      return sendErrorResponse(res, 400, result.error.errors[0].message);
+      const firstIssue = result.error.issues[0];
+      if (!firstIssue) {
+        throw new Error("Request validation failed without any issues");
+      }
+      return sendErrorResponse(res, 400, firstIssue.message);
     }
 
     const { number_of_results: numberOfResults, query } = result.data;

--- a/apps/mcpserver/src/mcp/server.ts
+++ b/apps/mcpserver/src/mcp/server.ts
@@ -89,8 +89,7 @@ export function createServer({
     // Build Zod schema from prompt arguments
     const argsSchemaShape: Record<
       string,
-      | z.ZodOptional<z.ZodType<string, z.ZodTypeDef, string>>
-      | z.ZodType<string, z.ZodTypeDef, string>
+      z.ZodOptional<z.ZodString> | z.ZodString
     > = {};
     for (const arg of catalogEntry.prompt.arguments) {
       const fieldSchema = z.string().describe(arg.description);
@@ -99,12 +98,10 @@ export function createServer({
         : fieldSchema.optional();
     }
 
-    const zodObject = z.object(argsSchemaShape);
-
     mcpServer.registerPrompt(
       catalogEntry.prompt.name,
       {
-        argsSchema: zodObject.shape,
+        argsSchema: argsSchemaShape,
         description: catalogEntry.prompt.description,
       },
       async (args: Record<string, unknown>): Promise<GetPromptResultType> => {

--- a/apps/mcpserver/src/tools/__tests__/QueryValidation.test.ts
+++ b/apps/mcpserver/src/tools/__tests__/QueryValidation.test.ts
@@ -28,7 +28,7 @@ describe("Query Validation", () => {
       shortQueries.forEach((input) => {
         const result = queryDocSchema.safeParse(input);
         expect(result.success).toBe(false);
-        expect(result.error?.errors[0].message).toBe(
+        expect(result.error?.issues[0]?.message).toBe(
           "Query must be at least 3 characters",
         );
       });
@@ -39,7 +39,7 @@ describe("Query Validation", () => {
       const result = queryDocSchema.safeParse(longQuery);
 
       expect(result.success).toBe(false);
-      expect(result.error?.errors[0].message).toBe(
+      expect(result.error?.issues[0]?.message).toBe(
         "Query must not exceed 500 characters",
       );
     });

--- a/apps/mcpserver/src/utils/__tests__/error-handling.test.ts
+++ b/apps/mcpserver/src/utils/__tests__/error-handling.test.ts
@@ -2,7 +2,7 @@ import type { InternalAxiosRequestConfig } from "axios";
 
 import { AxiosError, AxiosHeaders } from "axios";
 import { describe, expect, it } from "vitest";
-import { ZodError } from "zod";
+import { z, ZodError } from "zod";
 
 import { handleApiError, isAxiosError, isZodError } from "../error-handling.js";
 
@@ -117,55 +117,63 @@ describe("handleApiError - Axios network errors", () => {
 
 describe("handleApiError - Zod validation errors", () => {
   it("should format single validation error", () => {
-    const error = new ZodError([
-      {
-        code: "too_small",
-        inclusive: true,
-        message: "String must contain at least 3 character(s)",
-        minimum: 3,
-        path: ["query"],
-        type: "string",
-      },
-    ]);
-    expect(handleApiError(error)).toBe(
+    const result = z
+      .object({
+        query: z.string().min(3, "String must contain at least 3 character(s)"),
+      })
+      .safeParse({ query: "" });
+
+    expect(result.success).toBe(false);
+    if (result.success) {
+      throw new Error("Expected validation to fail");
+    }
+
+    expect(handleApiError(result.error)).toBe(
       "Error: Invalid input - query: String must contain at least 3 character(s)",
     );
   });
 
   it("should format multiple validation errors", () => {
-    const error = new ZodError([
-      {
-        code: "too_small",
-        inclusive: true,
-        message: "String must contain at least 3 character(s)",
-        minimum: 3,
-        path: ["query"],
-        type: "string",
-      },
-      {
-        code: "invalid_type",
-        expected: "number",
-        message: "Expected number, received string",
-        path: ["page"],
-        received: "string",
-      },
-    ]);
-    expect(handleApiError(error)).toBe(
+    const result = z
+      .intersection(
+        z.object({
+          query: z
+            .string()
+            .min(3, "String must contain at least 3 character(s)"),
+        }),
+        z.object({
+          page: z.number({ error: "Expected number, received string" }),
+        }),
+      )
+      .safeParse({ page: "one", query: "" });
+
+    expect(result.success).toBe(false);
+    if (result.success) {
+      throw new Error("Expected validation to fail");
+    }
+
+    expect(handleApiError(result.error)).toBe(
       "Error: Invalid input - query: String must contain at least 3 character(s); page: Expected number, received string",
     );
   });
 
   it("should handle nested path errors", () => {
-    const error = new ZodError([
-      {
-        code: "invalid_type",
-        expected: "string",
-        message: "Required",
-        path: ["data", "nested", "field"],
-        received: "undefined",
-      },
-    ]);
-    expect(handleApiError(error)).toBe(
+    const result = z
+      .object({
+        data: z.object({
+          nested: z.object({
+            field: z.string({ error: "Required" }),
+          }),
+        }),
+      })
+      .safeParse({ data: { nested: {} } });
+
+    expect(result.success).toBe(false);
+    if (result.success) {
+      throw new Error("Expected validation to fail");
+    }
+
+    expect(handleApiError(result.error)).toBe(
       "Error: Invalid input - data.nested.field: Required",
     );
   });

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -667,7 +667,7 @@ importers:
         version: 1.3.8
       '@modelcontextprotocol/sdk':
         specifier: 'catalog:'
-        version: 1.29.0(zod@3.25.76)
+        version: 1.29.0(zod@4.4.2)
       '@octokit/rest':
         specifier: ^22.0.1
         version: 22.0.1
@@ -681,8 +681,8 @@ importers:
         specifier: ^1.16.0
         version: 1.16.0
       zod:
-        specifier: ^3.25.76
-        version: 3.25.76
+        specifier: 'catalog:'
+        version: 4.4.2
     devDependencies:
       '@pagopa/eslint-config':
         specifier: workspace:^
@@ -12983,9 +12983,6 @@ packages:
     peerDependencies:
       zod: ^3.25.0 || ^4.0.0
 
-  zod@3.25.76:
-    resolution: {integrity: sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==}
-
   zod@4.4.2:
     resolution: {integrity: sha512-IynmDyxsEsb9RKzO3J9+4SxXnl2FTFSzNBaKKaMV6tsSk0rw9gYw9gs+JFCq/qk2LCZ78KDwyj+Z289TijSkUw==}
 
@@ -17255,7 +17252,7 @@ snapshots:
     optionalDependencies:
       '@azure/identity': 4.13.1
 
-  '@modelcontextprotocol/sdk@1.29.0(zod@3.25.76)':
+  '@modelcontextprotocol/sdk@1.29.0(zod@4.4.2)':
     dependencies:
       '@hono/node-server': 1.19.9(hono@4.11.7)
       ajv: 8.18.0
@@ -17272,8 +17269,8 @@ snapshots:
       json-schema-typed: 8.0.2
       pkce-challenge: 5.0.0
       raw-body: 3.0.1
-      zod: 3.25.76
-      zod-to-json-schema: 3.25.1(zod@3.25.76)
+      zod: 4.4.2
+      zod-to-json-schema: 3.25.1(zod@4.4.2)
     transitivePeerDependencies:
       - supports-color
 
@@ -27864,15 +27861,13 @@ snapshots:
       graphmatch: 1.1.1
     optional: true
 
-  zod-to-json-schema@3.25.1(zod@3.25.76):
+  zod-to-json-schema@3.25.1(zod@4.4.2):
     dependencies:
-      zod: 3.25.76
+      zod: 4.4.2
 
   zod-validation-error@4.0.2(zod@3.25.76):
     dependencies:
       zod: 3.25.76
-
-  zod@3.25.76: {}
 
   zod@4.4.2: {}
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -21999,8 +21999,8 @@ snapshots:
       '@babel/parser': 7.29.2
       eslint: 9.39.4(jiti@2.6.1)
       hermes-parser: 0.25.1
-      zod: 3.25.76
-      zod-validation-error: 4.0.2(zod@3.25.76)
+      zod: 4.4.2
+      zod-validation-error: 4.0.2(zod@4.4.2)
     transitivePeerDependencies:
       - supports-color
 
@@ -27865,9 +27865,9 @@ snapshots:
     dependencies:
       zod: 4.4.2
 
-  zod-validation-error@4.0.2(zod@3.25.76):
+  zod-validation-error@4.0.2(zod@4.4.2):
     dependencies:
-      zod: 3.25.76
+      zod: 4.4.2
 
   zod@4.4.2: {}
 


### PR DESCRIPTION
Migrate `@pagopa/dx-mcpserver` to the workspace catalog Zod v4 so the package stops pinning Zod v3 while the rest of the workspace has already standardized on v4.

This keeps the MCP server behavior unchanged by:
- switching the app dependency to the catalog version
- updating the remaining Zod v3-specific validation and typing code to Zod v4-compatible APIs
- preserving existing validation messages with focused test updates
- adding the required release plan for `@pagopa/dx-mcpserver`
