### PR TITLE
Handle first-time push to empty subrepos

### DIFF
--- a/.github/actions/push-to-subrepo/action.yaml
+++ b/.github/actions/push-to-subrepo/action.yaml
@@ -105,7 +105,7 @@ runs:
         git subtree split --prefix="$PREFIX_PATH" -b "$BRANCH_NAME"
 
         # Check if the main branch exists on the remote
-        if git ls-remote --heads "$REMOTE_NAME" main | grep -q main; then
+        if git ls-remote --exit-code --heads "$REMOTE_NAME" refs/heads/main >/dev/null; then
           git fetch "$REMOTE_NAME" main --tags
 
           # Merge the changes without overwriting the history
@@ -114,7 +114,6 @@ runs:
           git merge --allow-unrelated-histories -s ours --no-edit temp-branch
         else
           echo "Remote main branch does not exist yet. First-time push."
-          git fetch "$REMOTE_NAME" --tags 2>/dev/null || true
           git checkout "$BRANCH_NAME"
         fi
 

--- a/.github/actions/push-to-subrepo/action.yaml
+++ b/.github/actions/push-to-subrepo/action.yaml
@@ -105,12 +105,18 @@ runs:
         git subtree split --prefix="$PREFIX_PATH" -b "$BRANCH_NAME"
 
         # Check if the main branch exists on the remote
-        git fetch "$REMOTE_NAME" main --tags
+        if git ls-remote --heads "$REMOTE_NAME" main | grep -q main; then
+          git fetch "$REMOTE_NAME" main --tags
 
-        # Merge the changes without overwriting the history
-        git branch temp-branch "$REMOTE_NAME/main"
-        git checkout "$BRANCH_NAME"
-        git merge --allow-unrelated-histories -s ours --no-edit temp-branch
+          # Merge the changes without overwriting the history
+          git branch temp-branch "$REMOTE_NAME/main"
+          git checkout "$BRANCH_NAME"
+          git merge --allow-unrelated-histories -s ours --no-edit temp-branch
+        else
+          echo "Remote main branch does not exist yet. First-time push."
+          git fetch "$REMOTE_NAME" --tags 2>/dev/null || true
+          git checkout "$BRANCH_NAME"
+        fi
 
         # Define the tag name
         if [[ "$REPO_TYPE" == "provider" ]]; then


### PR DESCRIPTION
The `push-to-subrepo` action unconditionally runs `git fetch $REMOTE main`, which fails with `fatal: couldn't find remote ref main` when the target subrepo is empty (no branches yet). This happens for newly created modules whose subrepo was created by `add-module.sh` but never received an initial commit.

This change checks whether `main` exists on the remote via `git ls-remote --heads` before attempting to fetch and merge. When the branch is absent (first-time publish), the merge step is skipped and the subtree branch is pushed directly as `main`.

Resolves CES-1996