### PR TITLE
Fix duplicated keys error in merge roles module

### DIFF
--- a/.nx/version-plans/version-plan-1778226587305.md
+++ b/.nx/version-plans/version-plan-1778226587305.md
@@ -1,0 +1,5 @@
+---
+azure_merge_roles: patch
+---
+
+Fixed case where actions and not actions would contain the same permission causing duplicated keys errors.

--- a/infra/modules/azure_core_infra/custom_roles.tf
+++ b/infra/modules/azure_core_infra/custom_roles.tf
@@ -1,7 +1,6 @@
 module "dx_app_cd_resource_group_deploy" {
-#  source  = "pagopa-dx/azure-merge-roles/azurerm"
-#  version = "~> 0.1"
-   source = "github.com/pagopa/dx//infra/modules/azure_merge_roles?ref=fix-duplicated-keys-in-merge-roles"
+  source  = "pagopa-dx/azure-merge-roles/azurerm"
+  version = "~> 0.1"
 
   scope     = data.azurerm_subscription.current.id
   role_name = "${local.subscription_role_name_prefix} DX App CD Resource Groups"
@@ -16,9 +15,8 @@ module "dx_app_cd_resource_group_deploy" {
 }
 
 module "dx_app_ci_resource_group_reader" {
-#  source  = "pagopa-dx/azure-merge-roles/azurerm"
-#  version = "~> 0.1"
-   source = "github.com/pagopa/dx//infra/modules/azure_merge_roles?ref=fix-duplicated-keys-in-merge-roles"
+  source  = "pagopa-dx/azure-merge-roles/azurerm"
+  version = "~> 0.1"
 
   scope     = data.azurerm_subscription.current.id
   role_name = "${local.subscription_role_name_prefix} DX App CI Resource Groups"
@@ -30,9 +28,8 @@ module "dx_app_ci_resource_group_reader" {
 }
 
 module "dx_infra_cd_private_networking" {
-#  source  = "pagopa-dx/azure-merge-roles/azurerm"
-#  version = "~> 0.1"
-   source = "github.com/pagopa/dx//infra/modules/azure_merge_roles?ref=fix-duplicated-keys-in-merge-roles"
+  source  = "pagopa-dx/azure-merge-roles/azurerm"
+  version = "~> 0.1"
 
   scope     = data.azurerm_subscription.current.id
   role_name = "${local.subscription_role_name_prefix} DX Infra CD Private Networking"
@@ -44,9 +41,8 @@ module "dx_infra_cd_private_networking" {
 }
 
 module "dx_infra_cd_resource_group_deploy" {
-#  source  = "pagopa-dx/azure-merge-roles/azurerm"
-#  version = "~> 0.1"
-   source = "github.com/pagopa/dx//infra/modules/azure_merge_roles?ref=fix-duplicated-keys-in-merge-roles"
+  source  = "pagopa-dx/azure-merge-roles/azurerm"
+  version = "~> 0.1"
 
   scope     = data.azurerm_subscription.current.id
   role_name = "${local.subscription_role_name_prefix} DX Infra CD Resource Groups"
@@ -65,9 +61,8 @@ module "dx_infra_cd_resource_group_deploy" {
 }
 
 module "dx_infra_cd_subscription_admin" {
-#  source  = "pagopa-dx/azure-merge-roles/azurerm"
-#  version = "~> 0.1"
-   source = "github.com/pagopa/dx//infra/modules/azure_merge_roles?ref=fix-duplicated-keys-in-merge-roles"
+  source  = "pagopa-dx/azure-merge-roles/azurerm"
+  version = "~> 0.1"
 
   scope     = data.azurerm_subscription.current.id
   role_name = "${local.subscription_role_name_prefix} DX Infra CD Subscription"
@@ -102,9 +97,8 @@ module "dx_infra_cd_subscription_admin" {
 }
 
 module "dx_infra_ci_resource_group_reader" {
-#  source  = "pagopa-dx/azure-merge-roles/azurerm"
-#  version = "~> 0.1"
-   source = "github.com/pagopa/dx//infra/modules/azure_merge_roles?ref=fix-duplicated-keys-in-merge-roles"
+  source  = "pagopa-dx/azure-merge-roles/azurerm"
+  version = "~> 0.1"
 
   scope     = data.azurerm_subscription.current.id
   role_name = "${local.subscription_role_name_prefix} DX Infra CI Resource Groups"
@@ -123,9 +117,8 @@ module "dx_infra_ci_resource_group_reader" {
 }
 
 module "dx_infra_ci_subscription_reader" {
-#  source  = "pagopa-dx/azure-merge-roles/azurerm"
-#  version = "~> 0.1"
-   source = "github.com/pagopa/dx//infra/modules/azure_merge_roles?ref=fix-duplicated-keys-in-merge-roles"
+  source  = "pagopa-dx/azure-merge-roles/azurerm"
+  version = "~> 0.1"
 
   scope     = data.azurerm_subscription.current.id
   role_name = "${local.subscription_role_name_prefix} DX Infra CI Subscription"
@@ -139,9 +132,8 @@ module "dx_infra_ci_subscription_reader" {
 }
 
 module "dx_function_host_storage" {
-#  source  = "pagopa-dx/azure-merge-roles/azurerm"
-#  version = "~> 0.1"
-   source = "github.com/pagopa/dx//infra/modules/azure_merge_roles?ref=fix-duplicated-keys-in-merge-roles"
+  source  = "pagopa-dx/azure-merge-roles/azurerm"
+  version = "~> 0.1"
 
   scope     = data.azurerm_subscription.current.id
   role_name = "${local.subscription_role_name_prefix} DX Function Host Storage"
@@ -154,9 +146,8 @@ module "dx_function_host_storage" {
 }
 
 module "dx_function_durable_storage" {
-#  source  = "pagopa-dx/azure-merge-roles/azurerm"
-#  version = "~> 0.1"
-   source = "github.com/pagopa/dx//infra/modules/azure_merge_roles?ref=fix-duplicated-keys-in-merge-roles"
+  source  = "pagopa-dx/azure-merge-roles/azurerm"
+  version = "~> 0.1"
 
   scope     = data.azurerm_subscription.current.id
   role_name = "${local.subscription_role_name_prefix} DX Function Durable Storage"

--- a/infra/modules/azure_core_infra/custom_roles.tf
+++ b/infra/modules/azure_core_infra/custom_roles.tf
@@ -1,6 +1,7 @@
 module "dx_app_cd_resource_group_deploy" {
-  source  = "pagopa-dx/azure-merge-roles/azurerm"
-  version = "~> 0.1"
+#  source  = "pagopa-dx/azure-merge-roles/azurerm"
+#  version = "~> 0.1"
+   source = "github.com/pagopa/dx//infra/modules/azure_merge_roles?ref?=fix-duplicated-keys-in-merge-roles"
 
   scope     = data.azurerm_subscription.current.id
   role_name = "${local.subscription_role_name_prefix} DX App CD Resource Groups"
@@ -15,8 +16,9 @@ module "dx_app_cd_resource_group_deploy" {
 }
 
 module "dx_app_ci_resource_group_reader" {
-  source  = "pagopa-dx/azure-merge-roles/azurerm"
-  version = "~> 0.1"
+#  source  = "pagopa-dx/azure-merge-roles/azurerm"
+#  version = "~> 0.1"
+   source = "github.com/pagopa/dx//infra/modules/azure_merge_roles?ref?=fix-duplicated-keys-in-merge-roles"
 
   scope     = data.azurerm_subscription.current.id
   role_name = "${local.subscription_role_name_prefix} DX App CI Resource Groups"
@@ -28,8 +30,9 @@ module "dx_app_ci_resource_group_reader" {
 }
 
 module "dx_infra_cd_private_networking" {
-  source  = "pagopa-dx/azure-merge-roles/azurerm"
-  version = "~> 0.1"
+#  source  = "pagopa-dx/azure-merge-roles/azurerm"
+#  version = "~> 0.1"
+   source = "github.com/pagopa/dx//infra/modules/azure_merge_roles?ref?=fix-duplicated-keys-in-merge-roles"
 
   scope     = data.azurerm_subscription.current.id
   role_name = "${local.subscription_role_name_prefix} DX Infra CD Private Networking"
@@ -41,8 +44,9 @@ module "dx_infra_cd_private_networking" {
 }
 
 module "dx_infra_cd_resource_group_deploy" {
-  source  = "pagopa-dx/azure-merge-roles/azurerm"
-  version = "~> 0.1"
+#  source  = "pagopa-dx/azure-merge-roles/azurerm"
+#  version = "~> 0.1"
+   source = "github.com/pagopa/dx//infra/modules/azure_merge_roles?ref?=fix-duplicated-keys-in-merge-roles"
 
   scope     = data.azurerm_subscription.current.id
   role_name = "${local.subscription_role_name_prefix} DX Infra CD Resource Groups"
@@ -61,8 +65,9 @@ module "dx_infra_cd_resource_group_deploy" {
 }
 
 module "dx_infra_cd_subscription_admin" {
-  source  = "pagopa-dx/azure-merge-roles/azurerm"
-  version = "~> 0.1"
+#  source  = "pagopa-dx/azure-merge-roles/azurerm"
+#  version = "~> 0.1"
+   source = "github.com/pagopa/dx//infra/modules/azure_merge_roles?ref?=fix-duplicated-keys-in-merge-roles"
 
   scope     = data.azurerm_subscription.current.id
   role_name = "${local.subscription_role_name_prefix} DX Infra CD Subscription"
@@ -97,8 +102,9 @@ module "dx_infra_cd_subscription_admin" {
 }
 
 module "dx_infra_ci_resource_group_reader" {
-  source  = "pagopa-dx/azure-merge-roles/azurerm"
-  version = "~> 0.1"
+#  source  = "pagopa-dx/azure-merge-roles/azurerm"
+#  version = "~> 0.1"
+   source = "github.com/pagopa/dx//infra/modules/azure_merge_roles?ref?=fix-duplicated-keys-in-merge-roles"
 
   scope     = data.azurerm_subscription.current.id
   role_name = "${local.subscription_role_name_prefix} DX Infra CI Resource Groups"
@@ -117,8 +123,9 @@ module "dx_infra_ci_resource_group_reader" {
 }
 
 module "dx_infra_ci_subscription_reader" {
-  source  = "pagopa-dx/azure-merge-roles/azurerm"
-  version = "~> 0.1"
+#  source  = "pagopa-dx/azure-merge-roles/azurerm"
+#  version = "~> 0.1"
+   source = "github.com/pagopa/dx//infra/modules/azure_merge_roles?ref?=fix-duplicated-keys-in-merge-roles"
 
   scope     = data.azurerm_subscription.current.id
   role_name = "${local.subscription_role_name_prefix} DX Infra CI Subscription"
@@ -132,8 +139,9 @@ module "dx_infra_ci_subscription_reader" {
 }
 
 module "dx_function_host_storage" {
-  source  = "pagopa-dx/azure-merge-roles/azurerm"
-  version = "~> 0.1"
+#  source  = "pagopa-dx/azure-merge-roles/azurerm"
+#  version = "~> 0.1"
+   source = "github.com/pagopa/dx//infra/modules/azure_merge_roles?ref?=fix-duplicated-keys-in-merge-roles"
 
   scope     = data.azurerm_subscription.current.id
   role_name = "${local.subscription_role_name_prefix} DX Function Host Storage"
@@ -146,8 +154,9 @@ module "dx_function_host_storage" {
 }
 
 module "dx_function_durable_storage" {
-  source  = "pagopa-dx/azure-merge-roles/azurerm"
-  version = "~> 0.1"
+#  source  = "pagopa-dx/azure-merge-roles/azurerm"
+#  version = "~> 0.1"
+   source = "github.com/pagopa/dx//infra/modules/azure_merge_roles?ref?=fix-duplicated-keys-in-merge-roles"
 
   scope     = data.azurerm_subscription.current.id
   role_name = "${local.subscription_role_name_prefix} DX Function Durable Storage"

--- a/infra/modules/azure_core_infra/custom_roles.tf
+++ b/infra/modules/azure_core_infra/custom_roles.tf
@@ -1,7 +1,7 @@
 module "dx_app_cd_resource_group_deploy" {
 #  source  = "pagopa-dx/azure-merge-roles/azurerm"
 #  version = "~> 0.1"
-   source = "github.com/pagopa/dx//infra/modules/azure_merge_roles?ref?=fix-duplicated-keys-in-merge-roles"
+   source = "github.com/pagopa/dx//infra/modules/azure_merge_roles?ref=fix-duplicated-keys-in-merge-roles"
 
   scope     = data.azurerm_subscription.current.id
   role_name = "${local.subscription_role_name_prefix} DX App CD Resource Groups"
@@ -18,7 +18,7 @@ module "dx_app_cd_resource_group_deploy" {
 module "dx_app_ci_resource_group_reader" {
 #  source  = "pagopa-dx/azure-merge-roles/azurerm"
 #  version = "~> 0.1"
-   source = "github.com/pagopa/dx//infra/modules/azure_merge_roles?ref?=fix-duplicated-keys-in-merge-roles"
+   source = "github.com/pagopa/dx//infra/modules/azure_merge_roles?ref=fix-duplicated-keys-in-merge-roles"
 
   scope     = data.azurerm_subscription.current.id
   role_name = "${local.subscription_role_name_prefix} DX App CI Resource Groups"
@@ -32,7 +32,7 @@ module "dx_app_ci_resource_group_reader" {
 module "dx_infra_cd_private_networking" {
 #  source  = "pagopa-dx/azure-merge-roles/azurerm"
 #  version = "~> 0.1"
-   source = "github.com/pagopa/dx//infra/modules/azure_merge_roles?ref?=fix-duplicated-keys-in-merge-roles"
+   source = "github.com/pagopa/dx//infra/modules/azure_merge_roles?ref=fix-duplicated-keys-in-merge-roles"
 
   scope     = data.azurerm_subscription.current.id
   role_name = "${local.subscription_role_name_prefix} DX Infra CD Private Networking"
@@ -46,7 +46,7 @@ module "dx_infra_cd_private_networking" {
 module "dx_infra_cd_resource_group_deploy" {
 #  source  = "pagopa-dx/azure-merge-roles/azurerm"
 #  version = "~> 0.1"
-   source = "github.com/pagopa/dx//infra/modules/azure_merge_roles?ref?=fix-duplicated-keys-in-merge-roles"
+   source = "github.com/pagopa/dx//infra/modules/azure_merge_roles?ref=fix-duplicated-keys-in-merge-roles"
 
   scope     = data.azurerm_subscription.current.id
   role_name = "${local.subscription_role_name_prefix} DX Infra CD Resource Groups"
@@ -67,7 +67,7 @@ module "dx_infra_cd_resource_group_deploy" {
 module "dx_infra_cd_subscription_admin" {
 #  source  = "pagopa-dx/azure-merge-roles/azurerm"
 #  version = "~> 0.1"
-   source = "github.com/pagopa/dx//infra/modules/azure_merge_roles?ref?=fix-duplicated-keys-in-merge-roles"
+   source = "github.com/pagopa/dx//infra/modules/azure_merge_roles?ref=fix-duplicated-keys-in-merge-roles"
 
   scope     = data.azurerm_subscription.current.id
   role_name = "${local.subscription_role_name_prefix} DX Infra CD Subscription"
@@ -104,7 +104,7 @@ module "dx_infra_cd_subscription_admin" {
 module "dx_infra_ci_resource_group_reader" {
 #  source  = "pagopa-dx/azure-merge-roles/azurerm"
 #  version = "~> 0.1"
-   source = "github.com/pagopa/dx//infra/modules/azure_merge_roles?ref?=fix-duplicated-keys-in-merge-roles"
+   source = "github.com/pagopa/dx//infra/modules/azure_merge_roles?ref=fix-duplicated-keys-in-merge-roles"
 
   scope     = data.azurerm_subscription.current.id
   role_name = "${local.subscription_role_name_prefix} DX Infra CI Resource Groups"
@@ -125,7 +125,7 @@ module "dx_infra_ci_resource_group_reader" {
 module "dx_infra_ci_subscription_reader" {
 #  source  = "pagopa-dx/azure-merge-roles/azurerm"
 #  version = "~> 0.1"
-   source = "github.com/pagopa/dx//infra/modules/azure_merge_roles?ref?=fix-duplicated-keys-in-merge-roles"
+   source = "github.com/pagopa/dx//infra/modules/azure_merge_roles?ref=fix-duplicated-keys-in-merge-roles"
 
   scope     = data.azurerm_subscription.current.id
   role_name = "${local.subscription_role_name_prefix} DX Infra CI Subscription"
@@ -141,7 +141,7 @@ module "dx_infra_ci_subscription_reader" {
 module "dx_function_host_storage" {
 #  source  = "pagopa-dx/azure-merge-roles/azurerm"
 #  version = "~> 0.1"
-   source = "github.com/pagopa/dx//infra/modules/azure_merge_roles?ref?=fix-duplicated-keys-in-merge-roles"
+   source = "github.com/pagopa/dx//infra/modules/azure_merge_roles?ref=fix-duplicated-keys-in-merge-roles"
 
   scope     = data.azurerm_subscription.current.id
   role_name = "${local.subscription_role_name_prefix} DX Function Host Storage"
@@ -156,7 +156,7 @@ module "dx_function_host_storage" {
 module "dx_function_durable_storage" {
 #  source  = "pagopa-dx/azure-merge-roles/azurerm"
 #  version = "~> 0.1"
-   source = "github.com/pagopa/dx//infra/modules/azure_merge_roles?ref?=fix-duplicated-keys-in-merge-roles"
+   source = "github.com/pagopa/dx//infra/modules/azure_merge_roles?ref=fix-duplicated-keys-in-merge-roles"
 
   scope     = data.azurerm_subscription.current.id
   role_name = "${local.subscription_role_name_prefix} DX Function Durable Storage"

--- a/infra/modules/azure_merge_roles/locals.tf
+++ b/infra/modules/azure_merge_roles/locals.tf
@@ -30,95 +30,20 @@ locals {
     for action in var.additional_data_actions : trimspace(action)
   ]))
 
-  permission_sets = {
-    control = {
-      allowed_attr = "actions"
-      denied_attr  = "not_actions"
-      additional   = local.normalized_additional_actions
-    }
-    data = {
-      allowed_attr = "data_actions"
-      denied_attr  = "not_data_actions"
-      additional   = local.normalized_additional_data_actions
-    }
-  }
-
-  source_allowed_actions_by_type = {
-    for permission_type, config in local.permission_sets : permission_type => sort(distinct(flatten([
-      for permission in local.normalized_source_permissions : permission[config.allowed_attr]
-    ])))
-  }
-
-  additional_allowed_actions_by_type = {
-    for permission_type, config in local.permission_sets : permission_type => config.additional
-  }
-
-  effective_allowed_actions_by_type = {
-    for permission_type, config in local.permission_sets : permission_type => sort(distinct(concat(
-      local.source_allowed_actions_by_type[permission_type],
-      local.additional_allowed_actions_by_type[permission_type],
-    )))
-  }
-
-  excluded_actions_by_type = {
-    for permission_type, config in local.permission_sets : permission_type => sort(distinct(flatten([
-      for permission in local.normalized_source_permissions : permission[config.denied_attr]
-    ])))
-  }
-
-  all_allowed_actions  = sort(distinct(flatten(values(local.effective_allowed_actions_by_type))))
-  all_excluded_actions = sort(distinct(flatten(values(local.excluded_actions_by_type))))
-
-  action_regex_patterns = {
-    for action in distinct(concat(local.all_allowed_actions, local.all_excluded_actions)) : lower(action) => "^${replace(replace(lower(action), ".", "[.]"), "*", ".*")}$"
-  }
-
-  action_overlap_by_pair = {
-    for pair in flatten([
-      for excluded_action in local.all_excluded_actions : [
-        for allowed_action in local.all_allowed_actions : {
-          key = "${lower(excluded_action)}|||${lower(allowed_action)}"
-          overlaps = (
-            length(regexall(local.action_regex_patterns[lower(allowed_action)], lower(excluded_action))) > 0 ||
-            length(regexall(local.action_regex_patterns[lower(excluded_action)], lower(allowed_action))) > 0 ||
-            (
-              length(regexall("\\*", allowed_action)) > 0 &&
-              length(regexall("\\*", excluded_action)) > 0 &&
-              (
-                startswith(lower(allowed_action), element(split("*", lower(excluded_action)), 0)) ||
-                startswith(lower(excluded_action), element(split("*", lower(allowed_action)), 0))
-              )
-            )
-          )
-        }
-      ]
-    ]) : pair.key => pair.overlaps
-  }
-
-  source_exclusion_overlap_by_type = {
-    for permission_type, config in local.permission_sets : permission_type => {
-      for excluded_action in local.excluded_actions_by_type[permission_type] : excluded_action => anytrue([
-        for permission in local.normalized_source_permissions : (
-          !contains([for denied_action in permission[config.denied_attr] : lower(denied_action)], lower(excluded_action)) &&
-          anytrue([
-            for allowed_action in permission[config.allowed_attr] : local.action_overlap_by_pair["${lower(excluded_action)}|||${lower(allowed_action)}"]
-          ])
-        )
-      ])
-    }
-  }
-
-  additional_exclusion_overlap_by_type = {
-    for permission_type, config in local.permission_sets : permission_type => {
-      for excluded_action in local.excluded_actions_by_type[permission_type] : excluded_action => anytrue([
-        for allowed_action in local.additional_allowed_actions_by_type[permission_type] : local.action_overlap_by_pair["${lower(excluded_action)}|||${lower(allowed_action)}"]
-      ])
-    }
-  }
-
   merged_permissions = {
-    actions      = local.effective_allowed_actions_by_type.control
-    data_actions = local.effective_allowed_actions_by_type.data
+    actions = sort(distinct(concat(
+      flatten([
+        for permission in local.normalized_source_permissions : permission.actions
+      ]),
+      local.normalized_additional_actions,
+    )))
+
+    data_actions = sort(distinct(concat(
+      flatten([
+        for permission in local.normalized_source_permissions : permission.data_actions
+      ]),
+      local.normalized_additional_data_actions,
+    )))
 
     # Azure custom roles accept a single permissions object. Preserve an
     # exclusion only when no other permission block overlaps it strongly enough
@@ -129,19 +54,85 @@ locals {
     # prefix as enough evidence that the exclusion should be dropped. A block
     # cannot cancel the exact same exclusion it declares itself.
     not_actions = sort([
-      for excluded_action in local.excluded_actions_by_type.control : excluded_action
+      for excluded_action in distinct(flatten([
+        for permission in local.normalized_source_permissions : permission.not_actions
+      ])) : excluded_action
       if !(
-        local.source_exclusion_overlap_by_type.control[excluded_action] ||
-        local.additional_exclusion_overlap_by_type.control[excluded_action]
+        anytrue([
+          for permission in local.normalized_source_permissions : (
+            !contains([for denied_action in permission.not_actions : lower(denied_action)], lower(excluded_action)) &&
+            anytrue([
+              for allowed_action in permission.actions : (
+                length(regexall("^${replace(replace(lower(allowed_action), ".", "[.]"), "*", ".*")}$", lower(excluded_action))) > 0 ||
+                length(regexall("^${replace(replace(lower(excluded_action), ".", "[.]"), "*", ".*")}$", lower(allowed_action))) > 0 ||
+                (
+                  length(regexall("\\*", allowed_action)) > 0 &&
+                  length(regexall("\\*", excluded_action)) > 0 &&
+                  (
+                    startswith(lower(allowed_action), element(split("*", lower(excluded_action)), 0)) ||
+                    startswith(lower(excluded_action), element(split("*", lower(allowed_action)), 0))
+                  )
+                )
+              )
+            ])
+          )
+        ]) ||
+        anytrue([
+          for allowed_action in local.normalized_additional_actions : (
+            length(regexall("^${replace(replace(lower(allowed_action), ".", "[.]"), "*", ".*")}$", lower(excluded_action))) > 0 ||
+            length(regexall("^${replace(replace(lower(excluded_action), ".", "[.]"), "*", ".*")}$", lower(allowed_action))) > 0 ||
+            (
+              length(regexall("\\*", allowed_action)) > 0 &&
+              length(regexall("\\*", excluded_action)) > 0 &&
+              (
+                startswith(lower(allowed_action), element(split("*", lower(excluded_action)), 0)) ||
+                startswith(lower(excluded_action), element(split("*", lower(allowed_action)), 0))
+              )
+            )
+          )
+        ])
       )
     ])
 
     # Apply the same permissive overlap policy to data-plane permissions.
     not_data_actions = sort([
-      for excluded_action in local.excluded_actions_by_type.data : excluded_action
+      for excluded_action in distinct(flatten([
+        for permission in local.normalized_source_permissions : permission.not_data_actions
+      ])) : excluded_action
       if !(
-        local.source_exclusion_overlap_by_type.data[excluded_action] ||
-        local.additional_exclusion_overlap_by_type.data[excluded_action]
+        anytrue([
+          for permission in local.normalized_source_permissions : (
+            !contains([for denied_action in permission.not_data_actions : lower(denied_action)], lower(excluded_action)) &&
+            anytrue([
+              for allowed_action in permission.data_actions : (
+                length(regexall("^${replace(replace(lower(allowed_action), ".", "[.]"), "*", ".*")}$", lower(excluded_action))) > 0 ||
+                length(regexall("^${replace(replace(lower(excluded_action), ".", "[.]"), "*", ".*")}$", lower(allowed_action))) > 0 ||
+                (
+                  length(regexall("\\*", allowed_action)) > 0 &&
+                  length(regexall("\\*", excluded_action)) > 0 &&
+                  (
+                    startswith(lower(allowed_action), element(split("*", lower(excluded_action)), 0)) ||
+                    startswith(lower(excluded_action), element(split("*", lower(allowed_action)), 0))
+                  )
+                )
+              )
+            ])
+          )
+        ]) ||
+        anytrue([
+          for allowed_action in local.normalized_additional_data_actions : (
+            length(regexall("^${replace(replace(lower(allowed_action), ".", "[.]"), "*", ".*")}$", lower(excluded_action))) > 0 ||
+            length(regexall("^${replace(replace(lower(excluded_action), ".", "[.]"), "*", ".*")}$", lower(allowed_action))) > 0 ||
+            (
+              length(regexall("\\*", allowed_action)) > 0 &&
+              length(regexall("\\*", excluded_action)) > 0 &&
+              (
+                startswith(lower(allowed_action), element(split("*", lower(excluded_action)), 0)) ||
+                startswith(lower(excluded_action), element(split("*", lower(allowed_action)), 0))
+              )
+            )
+          )
+        ])
       )
     ])
   }

--- a/infra/modules/azure_merge_roles/tests/unit.tftest.hcl
+++ b/infra/modules/azure_merge_roles/tests/unit.tftest.hcl
@@ -97,6 +97,52 @@ run "merge_roles_appends_additional_actions_to_control_plane_permissions" {
   }
 }
 
+run "merge_roles_handles_case_insensitive_overlap_with_additional_actions" {
+  command = plan
+
+  variables {
+    additional_actions = ["microsoft.app/managedenvironments/*/read"]
+  }
+
+  override_data {
+    target = data.azurerm_role_definition.source["0"]
+    values = {
+      permissions = [
+        {
+          actions          = ["Microsoft.Authorization/*"]
+          data_actions     = []
+          not_actions      = ["Microsoft.App/managedEnvironments/*/read"]
+          not_data_actions = []
+        },
+      ]
+    }
+  }
+
+  override_data {
+    target = data.azurerm_role_definition.source["1"]
+    values = {
+      permissions = [
+        {
+          actions          = ["Microsoft.Insights/*/read"]
+          data_actions     = []
+          not_actions      = []
+          not_data_actions = []
+        },
+      ]
+    }
+  }
+
+  assert {
+    condition     = jsonencode(local.merged_permissions.not_actions) == jsonencode([])
+    error_message = "merged_permissions.not_actions must treat additional_actions case-insensitively when checking overlap"
+  }
+
+  assert {
+    condition     = contains(local.merged_permissions.actions, "microsoft.app/managedenvironments/*/read")
+    error_message = "merged_permissions.actions must retain the caller-provided additional action when source exclusions use a different casing"
+  }
+}
+
 run "merge_roles_appends_additional_data_actions_to_data_plane_permissions" {
   command = plan
 


### PR DESCRIPTION
Resolve an issue with duplicated keys in the merge roles module by ensuring case-insensitive handling of overlaps with additional actions. This change improves the merging logic for permissions and enhances the overall functionality.