### PR TITLE
Replace deprecated property in Container App module

### DIFF
--- a/.nx/version-plans/version-plan-1778228218161.md
+++ b/.nx/version-plans/version-plan-1778228218161.md
@@ -1,0 +1,5 @@
+---
+azure_container_app: patch
+---
+
+Replace `metric` with `enabled_metric` as per deprecation notice in `azurerm_monitor_diagnostic_setting` resource

--- a/infra/modules/azure_container_app/monitoring.tf
+++ b/infra/modules/azure_container_app/monitoring.tf
@@ -13,7 +13,7 @@ resource "azurerm_monitor_diagnostic_setting" "container_app" {
     category_group = "allLogs"
   }
 
-  metric {
+  enabled_metric {
     category = "AllMetrics"
   }
 }


### PR DESCRIPTION
Replace `metric` with `enabled_metric` as per deprecation notice in `azurerm_monitor_diagnostic_setting` resource