### PR TITLE
Exclude deprecated permissions from merged roles and add release plan

### DIFF
--- a/.nx/version-plans/version-plan-1778231836224.md
+++ b/.nx/version-plans/version-plan-1778231836224.md
@@ -1,0 +1,5 @@
+---
+azure_merge_roles: patch
+---
+
+Exclude known deprecated permissions from the merged roles such as `Microsoft.Classic`

--- a/infra/modules/azure_merge_roles/README.md
+++ b/infra/modules/azure_merge_roles/README.md
@@ -15,6 +15,7 @@ It is designed for the RBAC reduction strategy: define a smaller set of reusable
 - Deduplicates merged permissions so the generated role definition remains stable.
 - Supports caller-provided `additional_actions` when the merged role must grant extra control-plane permissions beyond the permissions granted by the sum of the source roles.
 - Supports caller-provided `additional_data_actions` when the merged role must grant extra data-plane permissions beyond the data permissions granted by the sum of the source roles.
+- Drops legacy `Microsoft.Classic*` provider operations copied from built-in roles because Azure custom roles reject them with `InvalidActionOrNotAction`.
 - Requires an explicit `scope` and always uses that same scope as the role's only assignable scope.
 - Supports role definitions created at management group scope as well as subscription scope.
 
@@ -47,6 +48,8 @@ When multiple exclusions overlap the same re-granted action, the current policy 
 The current implementation preserves the permission fields exposed by `azurerm_role_definition`, including `actions`, `not_actions`, `data_actions`, and `not_data_actions`, but it must compact them into one effective permissions object because Azure rejects custom roles with multiple permission objects.
 
 Source roles are resolved at the same `scope` used to create the merged role definition. This allows the module to merge built-in roles together with custom roles already defined at that scope.
+
+Some built-in roles still expose legacy `Microsoft.Classic*` operations. Azure Resource Manager does not accept those operations inside custom role definitions, so this module removes them from merged source permissions and rejects them in `additional_actions` and `additional_data_actions`.
 
 The AzureRM provider does not expose role definition `condition` and `condition_version`, so conditional built-in roles cannot currently be reproduced bit-for-bit through this module. If that scenario becomes relevant, the module should move from `azurerm_role_definition` to an ARM-level implementation such as `azapi_resource` or a dedicated provider.
 

--- a/infra/modules/azure_merge_roles/locals.tf
+++ b/infra/modules/azure_merge_roles/locals.tf
@@ -5,6 +5,10 @@ locals {
     for index, role_name in var.source_roles : tostring(index) => role_name
   }
 
+  # Azure custom roles reject legacy Microsoft.Classic* provider operations
+  # even when they still appear inside some built-in role definitions.
+  unsupported_action_provider_prefixes = ["microsoft.classic"]
+
   merged_description = "Reason: ${trimspace(var.reason)} | Source roles: ${join(", ", sort(var.source_roles))}"
 
   # Azure role definitions expose permissions as a list of permission objects,
@@ -13,15 +17,39 @@ locals {
     for role_definition in values(data.azurerm_role_definition.source) : role_definition.permissions
   ])
 
+  # Normalize every source permission list once so the merge logic can work on
+  # deduplicated values and does not need to repeat legacy-provider filtering.
   normalized_source_permissions = [
     for permission in local.source_permissions : {
-      actions          = sort(distinct(tolist(try(permission.actions, []))))
-      data_actions     = sort(distinct(tolist(try(permission.data_actions, []))))
-      not_actions      = sort(distinct(tolist(try(permission.not_actions, []))))
-      not_data_actions = sort(distinct(tolist(try(permission.not_data_actions, []))))
+      actions = sort(distinct([
+        for action in tolist(try(permission.actions, [])) : action
+        if !anytrue([
+          for prefix in local.unsupported_action_provider_prefixes : startswith(lower(action), prefix)
+        ])
+      ]))
+      data_actions = sort(distinct([
+        for action in tolist(try(permission.data_actions, [])) : action
+        if !anytrue([
+          for prefix in local.unsupported_action_provider_prefixes : startswith(lower(action), prefix)
+        ])
+      ]))
+      not_actions = sort(distinct([
+        for action in tolist(try(permission.not_actions, [])) : action
+        if !anytrue([
+          for prefix in local.unsupported_action_provider_prefixes : startswith(lower(action), prefix)
+        ])
+      ]))
+      not_data_actions = sort(distinct([
+        for action in tolist(try(permission.not_data_actions, [])) : action
+        if !anytrue([
+          for prefix in local.unsupported_action_provider_prefixes : startswith(lower(action), prefix)
+        ])
+      ]))
     }
   ]
 
+  # Additional grants follow the same normalization path as source permissions
+  # so overlap checks compare trimmed, stable values.
   normalized_additional_actions = sort(distinct([
     for action in var.additional_actions : trimspace(action)
   ]))
@@ -31,6 +59,8 @@ locals {
   ]))
 
   merged_permissions = {
+    # The final allowed permission sets are the union of all source roles plus
+    # any caller-provided additions.
     actions = sort(distinct(concat(
       flatten([
         for permission in local.normalized_source_permissions : permission.actions
@@ -77,6 +107,9 @@ locals {
             ])
           )
         ]) ||
+        # Additional actions must also participate in overlap detection,
+        # otherwise an explicit extra grant could remain blocked by a kept
+        # exclusion from a source role.
         anytrue([
           for allowed_action in local.normalized_additional_actions : (
             length(regexall("^${replace(replace(lower(allowed_action), ".", "[.]"), "*", ".*")}$", lower(excluded_action))) > 0 ||
@@ -119,6 +152,8 @@ locals {
             ])
           )
         ]) ||
+        # Apply the same rule to additional data-plane grants so explicit blob,
+        # queue, or table permissions can override overlapping exclusions.
         anytrue([
           for allowed_action in local.normalized_additional_data_actions : (
             length(regexall("^${replace(replace(lower(allowed_action), ".", "[.]"), "*", ".*")}$", lower(excluded_action))) > 0 ||

--- a/infra/modules/azure_merge_roles/tests/contract.tftest.hcl
+++ b/infra/modules/azure_merge_roles/tests/contract.tftest.hcl
@@ -126,6 +126,16 @@ run "additional_actions_must_reject_unsupported_regex_characters" {
   expect_failures = [var.additional_actions]
 }
 
+run "additional_actions_must_reject_legacy_classic_provider_operations" {
+  command = plan
+
+  variables {
+    additional_actions = ["Microsoft.ClassicCompute/virtualMachines/extensions/*"]
+  }
+
+  expect_failures = [var.additional_actions]
+}
+
 run "additional_data_actions_must_not_contain_blank_values" {
   command = plan
 
@@ -141,6 +151,16 @@ run "additional_data_actions_must_reject_unsupported_regex_characters" {
 
   variables {
     additional_data_actions = ["Microsoft.Storage/storageAccounts/blobServices/containers/blobs[write]"]
+  }
+
+  expect_failures = [var.additional_data_actions]
+}
+
+run "additional_data_actions_must_reject_legacy_classic_provider_operations" {
+  command = plan
+
+  variables {
+    additional_data_actions = ["Microsoft.ClassicStorage/storageAccounts/read"]
   }
 
   expect_failures = [var.additional_data_actions]

--- a/infra/modules/azure_merge_roles/tests/unit.tftest.hcl
+++ b/infra/modules/azure_merge_roles/tests/unit.tftest.hcl
@@ -97,6 +97,53 @@ run "merge_roles_appends_additional_actions_to_control_plane_permissions" {
   }
 }
 
+run "merge_roles_filters_legacy_classic_provider_operations_from_source_roles" {
+  command = plan
+
+  override_data {
+    target = data.azurerm_role_definition.source["0"]
+    values = {
+      permissions = [
+        {
+          actions = [
+            "Microsoft.Authorization/*",
+            "Microsoft.ClassicCompute/virtualMachines/extensions/*",
+          ]
+          data_actions = []
+          not_actions = [
+            "Microsoft.ClassicNetwork/virtualNetworks/read",
+          ]
+          not_data_actions = []
+        },
+      ]
+    }
+  }
+
+  override_data {
+    target = data.azurerm_role_definition.source["1"]
+    values = {
+      permissions = [
+        {
+          actions          = ["Microsoft.Insights/*/read"]
+          data_actions     = []
+          not_actions      = []
+          not_data_actions = []
+        },
+      ]
+    }
+  }
+
+  assert {
+    condition     = !contains(local.merged_permissions.actions, "Microsoft.ClassicCompute/virtualMachines/extensions/*")
+    error_message = "merged_permissions.actions must drop Microsoft.Classic* provider operations that Azure custom roles reject"
+  }
+
+  assert {
+    condition     = !contains(local.merged_permissions.not_actions, "Microsoft.ClassicNetwork/virtualNetworks/read")
+    error_message = "merged_permissions.not_actions must also drop Microsoft.Classic* provider operations that Azure custom roles reject"
+  }
+}
+
 run "merge_roles_handles_case_insensitive_overlap_with_additional_actions" {
   command = plan
 

--- a/infra/modules/azure_merge_roles/variables.tf
+++ b/infra/modules/azure_merge_roles/variables.tf
@@ -50,6 +50,11 @@ variable "additional_actions" {
     condition     = alltrue([for action in var.additional_actions : can(regex("^[0-9A-Za-z./*]+$", trimspace(action)))])
     error_message = "additional_actions entries may contain only Azure RBAC action characters: letters, digits, '/', '.', and '*'."
   }
+
+  validation {
+    condition     = alltrue([for action in var.additional_actions : !startswith(lower(trimspace(action)), "microsoft.classic")])
+    error_message = "additional_actions must not contain legacy Microsoft.Classic* provider operations because Azure custom roles reject them."
+  }
 }
 
 variable "additional_data_actions" {
@@ -65,6 +70,11 @@ variable "additional_data_actions" {
   validation {
     condition     = alltrue([for action in var.additional_data_actions : can(regex("^[0-9A-Za-z./*]+$", trimspace(action)))])
     error_message = "additional_data_actions entries may contain only Azure RBAC action characters: letters, digits, '/', '.', and '*'."
+  }
+
+  validation {
+    condition     = alltrue([for action in var.additional_data_actions : !startswith(lower(trimspace(action)), "microsoft.classic")])
+    error_message = "additional_data_actions must not contain legacy Microsoft.Classic* provider operations because Azure custom roles reject them."
   }
 }
 


### PR DESCRIPTION
The changes exclude known deprecated permissions, specifically `Microsoft.Classic*`, from merged roles to ensure compatibility with Azure custom roles. A release plan has also been added to outline the deployment strategy.