### PR TITLE
Add GitHub Actions secrets for dx-release-internal

### DIFF
--- a/infra/repository/README.md
+++ b/infra/repository/README.md
@@ -29,6 +29,8 @@
 | [github_actions_secret.e2e_gh_runner_app_installation_id](https://registry.terraform.io/providers/integrations/github/latest/docs/resources/actions_secret) | resource |
 | [github_actions_secret.e2e_gh_runner_app_private_key](https://registry.terraform.io/providers/integrations/github/latest/docs/resources/actions_secret) | resource |
 | [github_actions_secret.e2e_gh_runner_pat](https://registry.terraform.io/providers/integrations/github/latest/docs/resources/actions_secret) | resource |
+| [github_actions_secret.gh_release_app_id](https://registry.terraform.io/providers/integrations/github/latest/docs/resources/actions_secret) | resource |
+| [github_actions_secret.gh_release_app_key](https://registry.terraform.io/providers/integrations/github/latest/docs/resources/actions_secret) | resource |
 | [github_actions_secret.lets_encrypt_private_key](https://registry.terraform.io/providers/integrations/github/latest/docs/resources/actions_secret) | resource |
 | [github_actions_secret.lets_encrypt_registration](https://registry.terraform.io/providers/integrations/github/latest/docs/resources/actions_secret) | resource |
 | [github_actions_secret.slack_webhook_url](https://registry.terraform.io/providers/integrations/github/latest/docs/resources/actions_secret) | resource |

--- a/infra/repository/README.md
+++ b/infra/repository/README.md
@@ -29,8 +29,8 @@
 | [github_actions_secret.e2e_gh_runner_app_installation_id](https://registry.terraform.io/providers/integrations/github/latest/docs/resources/actions_secret) | resource |
 | [github_actions_secret.e2e_gh_runner_app_private_key](https://registry.terraform.io/providers/integrations/github/latest/docs/resources/actions_secret) | resource |
 | [github_actions_secret.e2e_gh_runner_pat](https://registry.terraform.io/providers/integrations/github/latest/docs/resources/actions_secret) | resource |
-| [github_actions_secret.gh_release_app_id](https://registry.terraform.io/providers/integrations/github/latest/docs/resources/actions_secret) | resource |
 | [github_actions_secret.gh_release_app_key](https://registry.terraform.io/providers/integrations/github/latest/docs/resources/actions_secret) | resource |
+| [github_actions_secret.gh_release_client_id](https://registry.terraform.io/providers/integrations/github/latest/docs/resources/actions_secret) | resource |
 | [github_actions_secret.lets_encrypt_private_key](https://registry.terraform.io/providers/integrations/github/latest/docs/resources/actions_secret) | resource |
 | [github_actions_secret.lets_encrypt_registration](https://registry.terraform.io/providers/integrations/github/latest/docs/resources/actions_secret) | resource |
 | [github_actions_secret.slack_webhook_url](https://registry.terraform.io/providers/integrations/github/latest/docs/resources/actions_secret) | resource |

--- a/infra/repository/secrets.tf
+++ b/infra/repository/secrets.tf
@@ -111,9 +111,9 @@ resource "github_actions_secret" "gh_release_app_key" {
   }
 }
 
-resource "github_actions_secret" "gh_release_app_id" {
+resource "github_actions_secret" "gh_release_client_id" {
   repository      = module.github_repository.name
-  secret_name     = "GH_RELEASE_APP_ID"
+  secret_name     = "GH_RELEASE_CLIENT_ID"
   plaintext_value = "placeholder"
 
   lifecycle {

--- a/infra/repository/secrets.tf
+++ b/infra/repository/secrets.tf
@@ -100,3 +100,23 @@ resource "github_actions_environment_secret" "stategraph_token" {
     ignore_changes = [remote_updated_at]
   }
 }
+
+resource "github_actions_secret" "gh_release_app_key" {
+  repository      = module.github_repository.name
+  secret_name     = "GH_RELEASE_APP_KEY"
+  plaintext_value = "placeholder"
+
+  lifecycle {
+    ignore_changes = [remote_updated_at]
+  }
+}
+
+resource "github_actions_secret" "gh_release_app_id" {
+  repository      = module.github_repository.name
+  secret_name     = "GH_RELEASE_APP_ID"
+  plaintext_value = "placeholder"
+
+  lifecycle {
+    ignore_changes = [remote_updated_at]
+  }
+}


### PR DESCRIPTION
Introduce new GitHub Actions secrets to replace the existing PAT for release automation flow.