### PR TITLE
Upgrade cache action to v5

### DIFF
--- a/.github/workflows/validate-v1.yaml
+++ b/.github/workflows/validate-v1.yaml
@@ -68,7 +68,7 @@ jobs:
         run: pnpm install
 
       - name: Cache Nx
-        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
+        uses: actions/cache@668228422ae6a00e4ad889ee87cd7109ec5666a7 # v5.0.4
         with:
           path: .nx
           key: ${{ runner.os }}-nx-cache-${{ hashFiles('**/pnpm-lock.yaml') }}


### PR DESCRIPTION
Upgrade actions/cache action to v5 due to deprecated node20 version