### PR TITLE
Move custom roles to a submodule of azure-core-infra

### DIFF
--- a/.nx/version-plans/version-plan-1778491373248.md
+++ b/.nx/version-plans/version-plan-1778491373248.md
@@ -1,0 +1,5 @@
+---
+azure_core_infra: patch
+---
+
+Relocate custom roles to a dedicated submodule for better accessibility from repositories that don't need the entire azure-core-infra resources.

--- a/infra/modules/azure_core_infra/README.md
+++ b/infra/modules/azure_core_infra/README.md
@@ -48,16 +48,8 @@ For detailed usage examples, refer to the [examples folder](https://github.com/p
 |------|--------|---------|
 | <a name="module_application_insights"></a> [application\_insights](#module\_application\_insights) | ./_modules/application_insights | n/a |
 | <a name="module_common_log_analytics"></a> [common\_log\_analytics](#module\_common\_log\_analytics) | ./_modules/log_analytics | n/a |
+| <a name="module_custom_roles"></a> [custom\_roles](#module\_custom\_roles) | ./modules/custom_roles | n/a |
 | <a name="module_dns"></a> [dns](#module\_dns) | ./_modules/dns | n/a |
-| <a name="module_dx_app_cd_resource_group_deploy"></a> [dx\_app\_cd\_resource\_group\_deploy](#module\_dx\_app\_cd\_resource\_group\_deploy) | pagopa-dx/azure-merge-roles/azurerm | ~> 0.1 |
-| <a name="module_dx_app_ci_resource_group_reader"></a> [dx\_app\_ci\_resource\_group\_reader](#module\_dx\_app\_ci\_resource\_group\_reader) | pagopa-dx/azure-merge-roles/azurerm | ~> 0.1 |
-| <a name="module_dx_function_durable_storage"></a> [dx\_function\_durable\_storage](#module\_dx\_function\_durable\_storage) | pagopa-dx/azure-merge-roles/azurerm | ~> 0.1 |
-| <a name="module_dx_function_host_storage"></a> [dx\_function\_host\_storage](#module\_dx\_function\_host\_storage) | pagopa-dx/azure-merge-roles/azurerm | ~> 0.1 |
-| <a name="module_dx_infra_cd_private_networking"></a> [dx\_infra\_cd\_private\_networking](#module\_dx\_infra\_cd\_private\_networking) | pagopa-dx/azure-merge-roles/azurerm | ~> 0.1 |
-| <a name="module_dx_infra_cd_resource_group_deploy"></a> [dx\_infra\_cd\_resource\_group\_deploy](#module\_dx\_infra\_cd\_resource\_group\_deploy) | pagopa-dx/azure-merge-roles/azurerm | ~> 0.1 |
-| <a name="module_dx_infra_cd_subscription_admin"></a> [dx\_infra\_cd\_subscription\_admin](#module\_dx\_infra\_cd\_subscription\_admin) | pagopa-dx/azure-merge-roles/azurerm | ~> 0.1 |
-| <a name="module_dx_infra_ci_resource_group_reader"></a> [dx\_infra\_ci\_resource\_group\_reader](#module\_dx\_infra\_ci\_resource\_group\_reader) | pagopa-dx/azure-merge-roles/azurerm | ~> 0.1 |
-| <a name="module_dx_infra_ci_subscription_reader"></a> [dx\_infra\_ci\_subscription\_reader](#module\_dx\_infra\_ci\_subscription\_reader) | pagopa-dx/azure-merge-roles/azurerm | ~> 0.1 |
 | <a name="module_github_runner"></a> [github\_runner](#module\_github\_runner) | ./_modules/github_runner | n/a |
 | <a name="module_key_vault"></a> [key\_vault](#module\_key\_vault) | ./_modules/key_vault | n/a |
 | <a name="module_nat_gateway"></a> [nat\_gateway](#module\_nat\_gateway) | ./_modules/nat_gateway | n/a |

--- a/infra/modules/azure_core_infra/locals.tf
+++ b/infra/modules/azure_core_infra/locals.tf
@@ -4,7 +4,6 @@ locals {
     "italynorth" = "itn",
     "westeurope" = "weu"
   })[var.environment.location]
-  subscription_role_name_prefix = trimspace(data.azurerm_subscription.current.display_name)
 
   project = "${var.environment.prefix}-${var.environment.env_short}-${local.location_short}"
   naming_config = {

--- a/infra/modules/azure_core_infra/main.tf
+++ b/infra/modules/azure_core_infra/main.tf
@@ -230,3 +230,14 @@ module "github_runner" {
 
   tags = local.tags
 }
+
+#----------------#
+#  CUSTOM ROLES  #
+#----------------#
+
+module "custom_roles" {
+  source = "./modules/custom_roles"
+
+  subscription_id   = data.azurerm_subscription.current.id
+  subscription_name = data.azurerm_subscription.current.display_name
+}

--- a/infra/modules/azure_core_infra/modules/custom_roles/README.md
+++ b/infra/modules/azure_core_infra/modules/custom_roles/README.md
@@ -34,5 +34,11 @@ No requirements.
 
 ## Outputs
 
-No outputs.
+| Name | Description |
+|------|-------------|
+| <a name="output_dx_app_ci_resource_group_reader"></a> [dx\_app\_ci\_resource\_group\_reader](#output\_dx\_app\_ci\_resource\_group\_reader) | The merged custom role name for the App CI resource group reader role. |
+| <a name="output_dx_function_durable_storage"></a> [dx\_function\_durable\_storage](#output\_dx\_function\_durable\_storage) | The merged custom role name for the Function App durable storage role. |
+| <a name="output_dx_function_host_storage"></a> [dx\_function\_host\_storage](#output\_dx\_function\_host\_storage) | The merged custom role name for the Function App host storage role. |
+| <a name="output_dx_infra_cd_subscription_admin"></a> [dx\_infra\_cd\_subscription\_admin](#output\_dx\_infra\_cd\_subscription\_admin) | The merged custom role name for the Infra CD subscription admin role. |
+| <a name="output_dx_infra_ci_subscription_reader"></a> [dx\_infra\_ci\_subscription\_reader](#output\_dx\_infra\_ci\_subscription\_reader) | The merged custom role name for the Infra CI subscription reader role. |
 <!-- END_TF_DOCS -->

--- a/infra/modules/azure_core_infra/modules/custom_roles/README.md
+++ b/infra/modules/azure_core_infra/modules/custom_roles/README.md
@@ -1,44 +1,48 @@
 # custom_roles
 
 <!-- BEGIN_TF_DOCS -->
+
 ## Requirements
 
-No requirements.
+| Name                                                               | Version |
+| ------------------------------------------------------------------ | ------- |
+| <a name="requirement_azurerm"></a> [azurerm](#requirement_azurerm) | ~> 4.62 |
 
 ## Modules
 
-| Name | Source | Version |
-|------|--------|---------|
-| <a name="module_dx_app_cd_resource_group_deploy"></a> [dx\_app\_cd\_resource\_group\_deploy](#module\_dx\_app\_cd\_resource\_group\_deploy) | pagopa-dx/azure-merge-roles/azurerm | ~> 0.1 |
-| <a name="module_dx_app_ci_resource_group_reader"></a> [dx\_app\_ci\_resource\_group\_reader](#module\_dx\_app\_ci\_resource\_group\_reader) | pagopa-dx/azure-merge-roles/azurerm | ~> 0.1 |
-| <a name="module_dx_function_durable_storage"></a> [dx\_function\_durable\_storage](#module\_dx\_function\_durable\_storage) | pagopa-dx/azure-merge-roles/azurerm | ~> 0.1 |
-| <a name="module_dx_function_host_storage"></a> [dx\_function\_host\_storage](#module\_dx\_function\_host\_storage) | pagopa-dx/azure-merge-roles/azurerm | ~> 0.1 |
-| <a name="module_dx_infra_cd_private_networking"></a> [dx\_infra\_cd\_private\_networking](#module\_dx\_infra\_cd\_private\_networking) | pagopa-dx/azure-merge-roles/azurerm | ~> 0.1 |
-| <a name="module_dx_infra_cd_resource_group_deploy"></a> [dx\_infra\_cd\_resource\_group\_deploy](#module\_dx\_infra\_cd\_resource\_group\_deploy) | pagopa-dx/azure-merge-roles/azurerm | ~> 0.1 |
-| <a name="module_dx_infra_cd_subscription_admin"></a> [dx\_infra\_cd\_subscription\_admin](#module\_dx\_infra\_cd\_subscription\_admin) | pagopa-dx/azure-merge-roles/azurerm | ~> 0.1 |
-| <a name="module_dx_infra_ci_resource_group_reader"></a> [dx\_infra\_ci\_resource\_group\_reader](#module\_dx\_infra\_ci\_resource\_group\_reader) | pagopa-dx/azure-merge-roles/azurerm | ~> 0.1 |
-| <a name="module_dx_infra_ci_subscription_reader"></a> [dx\_infra\_ci\_subscription\_reader](#module\_dx\_infra\_ci\_subscription\_reader) | pagopa-dx/azure-merge-roles/azurerm | ~> 0.1 |
+| Name                                                                                                                                   | Source                              | Version |
+| -------------------------------------------------------------------------------------------------------------------------------------- | ----------------------------------- | ------- |
+| <a name="module_dx_app_cd_resource_group_deploy"></a> [dx_app_cd_resource_group_deploy](#module_dx_app_cd_resource_group_deploy)       | pagopa-dx/azure-merge-roles/azurerm | ~> 0.1  |
+| <a name="module_dx_app_ci_resource_group_reader"></a> [dx_app_ci_resource_group_reader](#module_dx_app_ci_resource_group_reader)       | pagopa-dx/azure-merge-roles/azurerm | ~> 0.1  |
+| <a name="module_dx_function_durable_storage"></a> [dx_function_durable_storage](#module_dx_function_durable_storage)                   | pagopa-dx/azure-merge-roles/azurerm | ~> 0.1  |
+| <a name="module_dx_function_host_storage"></a> [dx_function_host_storage](#module_dx_function_host_storage)                            | pagopa-dx/azure-merge-roles/azurerm | ~> 0.1  |
+| <a name="module_dx_infra_cd_private_networking"></a> [dx_infra_cd_private_networking](#module_dx_infra_cd_private_networking)          | pagopa-dx/azure-merge-roles/azurerm | ~> 0.1  |
+| <a name="module_dx_infra_cd_resource_group_deploy"></a> [dx_infra_cd_resource_group_deploy](#module_dx_infra_cd_resource_group_deploy) | pagopa-dx/azure-merge-roles/azurerm | ~> 0.1  |
+| <a name="module_dx_infra_cd_subscription_admin"></a> [dx_infra_cd_subscription_admin](#module_dx_infra_cd_subscription_admin)          | pagopa-dx/azure-merge-roles/azurerm | ~> 0.1  |
+| <a name="module_dx_infra_ci_resource_group_reader"></a> [dx_infra_ci_resource_group_reader](#module_dx_infra_ci_resource_group_reader) | pagopa-dx/azure-merge-roles/azurerm | ~> 0.1  |
+| <a name="module_dx_infra_ci_subscription_reader"></a> [dx_infra_ci_subscription_reader](#module_dx_infra_ci_subscription_reader)       | pagopa-dx/azure-merge-roles/azurerm | ~> 0.1  |
 
 ## Resources
 
-| Name | Type |
-|------|------|
+| Name                                                                                                                            | Type        |
+| ------------------------------------------------------------------------------------------------------------------------------- | ----------- |
 | [azurerm_subscription.current](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/data-sources/subscription) | data source |
 
 ## Inputs
 
-| Name | Description | Type | Default | Required |
-|------|-------------|------|---------|:--------:|
-| <a name="input_subscription_id"></a> [subscription\_id](#input\_subscription\_id) | The ID of the subscription where the custom roles will be created. | `string` | `null` | no |
-| <a name="input_subscription_name"></a> [subscription\_name](#input\_subscription\_name) | The display name of the subscription where the custom roles will be created. | `string` | `null` | no |
+| Name                                                                                 | Description                                                                  | Type     | Default | Required |
+| ------------------------------------------------------------------------------------ | ---------------------------------------------------------------------------- | -------- | ------- | :------: |
+| <a name="input_subscription_id"></a> [subscription_id](#input_subscription_id)       | The ID of the subscription where the custom roles will be created.           | `string` | `null`  |    no    |
+| <a name="input_subscription_name"></a> [subscription_name](#input_subscription_name) | The display name of the subscription where the custom roles will be created. | `string` | `null`  |    no    |
 
 ## Outputs
 
-| Name | Description |
-|------|-------------|
-| <a name="output_dx_app_ci_resource_group_reader"></a> [dx\_app\_ci\_resource\_group\_reader](#output\_dx\_app\_ci\_resource\_group\_reader) | The merged custom role name for the App CI resource group reader role. |
-| <a name="output_dx_function_durable_storage"></a> [dx\_function\_durable\_storage](#output\_dx\_function\_durable\_storage) | The merged custom role name for the Function App durable storage role. |
-| <a name="output_dx_function_host_storage"></a> [dx\_function\_host\_storage](#output\_dx\_function\_host\_storage) | The merged custom role name for the Function App host storage role. |
-| <a name="output_dx_infra_cd_subscription_admin"></a> [dx\_infra\_cd\_subscription\_admin](#output\_dx\_infra\_cd\_subscription\_admin) | The merged custom role name for the Infra CD subscription admin role. |
-| <a name="output_dx_infra_ci_subscription_reader"></a> [dx\_infra\_ci\_subscription\_reader](#output\_dx\_infra\_ci\_subscription\_reader) | The merged custom role name for the Infra CI subscription reader role. |
+| Name                                                                                                                             | Description                                                            |
+| -------------------------------------------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------- |
+| <a name="output_dx_app_ci_resource_group_reader"></a> [dx_app_ci_resource_group_reader](#output_dx_app_ci_resource_group_reader) | The merged custom role name for the App CI resource group reader role. |
+| <a name="output_dx_function_durable_storage"></a> [dx_function_durable_storage](#output_dx_function_durable_storage)             | The merged custom role name for the Function App durable storage role. |
+| <a name="output_dx_function_host_storage"></a> [dx_function_host_storage](#output_dx_function_host_storage)                      | The merged custom role name for the Function App host storage role.    |
+| <a name="output_dx_infra_cd_subscription_admin"></a> [dx_infra_cd_subscription_admin](#output_dx_infra_cd_subscription_admin)    | The merged custom role name for the Infra CD subscription admin role.  |
+| <a name="output_dx_infra_ci_subscription_reader"></a> [dx_infra_ci_subscription_reader](#output_dx_infra_ci_subscription_reader) | The merged custom role name for the Infra CI subscription reader role. |
+
 <!-- END_TF_DOCS -->

--- a/infra/modules/azure_core_infra/modules/custom_roles/README.md
+++ b/infra/modules/azure_core_infra/modules/custom_roles/README.md
@@ -1,46 +1,48 @@
 # custom_roles
 
 <!-- BEGIN_TF_DOCS -->
+
 ## Requirements
 
-| Name | Version |
-|------|---------|
-| <a name="requirement_azurerm"></a> [azurerm](#requirement\_azurerm) | ~> 4.62 |
+| Name                                                               | Version |
+| ------------------------------------------------------------------ | ------- |
+| <a name="requirement_azurerm"></a> [azurerm](#requirement_azurerm) | ~> 4.62 |
 
 ## Modules
 
-| Name | Source | Version |
-|------|--------|---------|
-| <a name="module_dx_app_cd_resource_group_deploy"></a> [dx\_app\_cd\_resource\_group\_deploy](#module\_dx\_app\_cd\_resource\_group\_deploy) | pagopa-dx/azure-merge-roles/azurerm | ~> 0.1 |
-| <a name="module_dx_app_ci_resource_group_reader"></a> [dx\_app\_ci\_resource\_group\_reader](#module\_dx\_app\_ci\_resource\_group\_reader) | pagopa-dx/azure-merge-roles/azurerm | ~> 0.1 |
-| <a name="module_dx_function_durable_storage"></a> [dx\_function\_durable\_storage](#module\_dx\_function\_durable\_storage) | pagopa-dx/azure-merge-roles/azurerm | ~> 0.1 |
-| <a name="module_dx_function_host_storage"></a> [dx\_function\_host\_storage](#module\_dx\_function\_host\_storage) | pagopa-dx/azure-merge-roles/azurerm | ~> 0.1 |
-| <a name="module_dx_infra_cd_private_networking"></a> [dx\_infra\_cd\_private\_networking](#module\_dx\_infra\_cd\_private\_networking) | pagopa-dx/azure-merge-roles/azurerm | ~> 0.1 |
-| <a name="module_dx_infra_cd_resource_group_deploy"></a> [dx\_infra\_cd\_resource\_group\_deploy](#module\_dx\_infra\_cd\_resource\_group\_deploy) | pagopa-dx/azure-merge-roles/azurerm | ~> 0.1 |
-| <a name="module_dx_infra_cd_subscription_admin"></a> [dx\_infra\_cd\_subscription\_admin](#module\_dx\_infra\_cd\_subscription\_admin) | pagopa-dx/azure-merge-roles/azurerm | ~> 0.1 |
-| <a name="module_dx_infra_ci_resource_group_reader"></a> [dx\_infra\_ci\_resource\_group\_reader](#module\_dx\_infra\_ci\_resource\_group\_reader) | pagopa-dx/azure-merge-roles/azurerm | ~> 0.1 |
-| <a name="module_dx_infra_ci_subscription_reader"></a> [dx\_infra\_ci\_subscription\_reader](#module\_dx\_infra\_ci\_subscription\_reader) | pagopa-dx/azure-merge-roles/azurerm | ~> 0.1 |
+| Name                                                                                                                                   | Source                              | Version |
+| -------------------------------------------------------------------------------------------------------------------------------------- | ----------------------------------- | ------- |
+| <a name="module_dx_app_cd_resource_group_deploy"></a> [dx_app_cd_resource_group_deploy](#module_dx_app_cd_resource_group_deploy)       | pagopa-dx/azure-merge-roles/azurerm | ~> 0.1  |
+| <a name="module_dx_app_ci_resource_group_reader"></a> [dx_app_ci_resource_group_reader](#module_dx_app_ci_resource_group_reader)       | pagopa-dx/azure-merge-roles/azurerm | ~> 0.1  |
+| <a name="module_dx_function_durable_storage"></a> [dx_function_durable_storage](#module_dx_function_durable_storage)                   | pagopa-dx/azure-merge-roles/azurerm | ~> 0.1  |
+| <a name="module_dx_function_host_storage"></a> [dx_function_host_storage](#module_dx_function_host_storage)                            | pagopa-dx/azure-merge-roles/azurerm | ~> 0.1  |
+| <a name="module_dx_infra_cd_private_networking"></a> [dx_infra_cd_private_networking](#module_dx_infra_cd_private_networking)          | pagopa-dx/azure-merge-roles/azurerm | ~> 0.1  |
+| <a name="module_dx_infra_cd_resource_group_deploy"></a> [dx_infra_cd_resource_group_deploy](#module_dx_infra_cd_resource_group_deploy) | pagopa-dx/azure-merge-roles/azurerm | ~> 0.1  |
+| <a name="module_dx_infra_cd_subscription_admin"></a> [dx_infra_cd_subscription_admin](#module_dx_infra_cd_subscription_admin)          | pagopa-dx/azure-merge-roles/azurerm | ~> 0.1  |
+| <a name="module_dx_infra_ci_resource_group_reader"></a> [dx_infra_ci_resource_group_reader](#module_dx_infra_ci_resource_group_reader) | pagopa-dx/azure-merge-roles/azurerm | ~> 0.1  |
+| <a name="module_dx_infra_ci_subscription_reader"></a> [dx_infra_ci_subscription_reader](#module_dx_infra_ci_subscription_reader)       | pagopa-dx/azure-merge-roles/azurerm | ~> 0.1  |
 
 ## Resources
 
-| Name | Type |
-|------|------|
+| Name                                                                                                                            | Type        |
+| ------------------------------------------------------------------------------------------------------------------------------- | ----------- |
 | [azurerm_subscription.current](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/data-sources/subscription) | data source |
 
 ## Inputs
 
-| Name | Description | Type | Default | Required |
-|------|-------------|------|---------|:--------:|
-| <a name="input_subscription_id"></a> [subscription\_id](#input\_subscription\_id) | The ID of the subscription where the custom roles will be created. | `string` | `null` | no |
-| <a name="input_subscription_name"></a> [subscription\_name](#input\_subscription\_name) | The display name of the subscription where the custom roles will be created. | `string` | `null` | no |
+| Name                                                                                 | Description                                                                                                                                                        | Type     | Default | Required |
+| ------------------------------------------------------------------------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------ | -------- | ------- | :------: |
+| <a name="input_subscription_id"></a> [subscription_id](#input_subscription_id)       | The ID of the subscription where the custom roles will be created. Omit it together with subscription_name to use the current provider subscription automatically. | `string` | `null`  |    no    |
+| <a name="input_subscription_name"></a> [subscription_name](#input_subscription_name) | The display name of the subscription where the custom roles will be created. Omit it to auto-discover the display name for the selected subscription.              | `string` | `null`  |    no    |
 
 ## Outputs
 
-| Name | Description |
-|------|-------------|
-| <a name="output_dx_app_ci_resource_group_reader"></a> [dx\_app\_ci\_resource\_group\_reader](#output\_dx\_app\_ci\_resource\_group\_reader) | The merged custom role name for the App CI resource group reader role. |
-| <a name="output_dx_function_durable_storage"></a> [dx\_function\_durable\_storage](#output\_dx\_function\_durable\_storage) | The merged custom role name for the Function App durable storage role. |
-| <a name="output_dx_function_host_storage"></a> [dx\_function\_host\_storage](#output\_dx\_function\_host\_storage) | The merged custom role name for the Function App host storage role. |
-| <a name="output_dx_infra_cd_subscription_admin"></a> [dx\_infra\_cd\_subscription\_admin](#output\_dx\_infra\_cd\_subscription\_admin) | The merged custom role name for the Infra CD subscription admin role. |
-| <a name="output_dx_infra_ci_subscription_reader"></a> [dx\_infra\_ci\_subscription\_reader](#output\_dx\_infra\_ci\_subscription\_reader) | The merged custom role name for the Infra CI subscription reader role. |
+| Name                                                                                                                             | Description                                                            |
+| -------------------------------------------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------- |
+| <a name="output_dx_app_ci_resource_group_reader"></a> [dx_app_ci_resource_group_reader](#output_dx_app_ci_resource_group_reader) | The merged custom role name for the App CI resource group reader role. |
+| <a name="output_dx_function_durable_storage"></a> [dx_function_durable_storage](#output_dx_function_durable_storage)             | The merged custom role name for the Function App durable storage role. |
+| <a name="output_dx_function_host_storage"></a> [dx_function_host_storage](#output_dx_function_host_storage)                      | The merged custom role name for the Function App host storage role.    |
+| <a name="output_dx_infra_cd_subscription_admin"></a> [dx_infra_cd_subscription_admin](#output_dx_infra_cd_subscription_admin)    | The merged custom role name for the Infra CD subscription admin role.  |
+| <a name="output_dx_infra_ci_subscription_reader"></a> [dx_infra_ci_subscription_reader](#output_dx_infra_ci_subscription_reader) | The merged custom role name for the Infra CI subscription reader role. |
+
 <!-- END_TF_DOCS -->

--- a/infra/modules/azure_core_infra/modules/custom_roles/README.md
+++ b/infra/modules/azure_core_infra/modules/custom_roles/README.md
@@ -1,0 +1,38 @@
+# custom_roles
+
+<!-- BEGIN_TF_DOCS -->
+## Requirements
+
+No requirements.
+
+## Modules
+
+| Name | Source | Version |
+|------|--------|---------|
+| <a name="module_dx_app_cd_resource_group_deploy"></a> [dx\_app\_cd\_resource\_group\_deploy](#module\_dx\_app\_cd\_resource\_group\_deploy) | pagopa-dx/azure-merge-roles/azurerm | ~> 0.1 |
+| <a name="module_dx_app_ci_resource_group_reader"></a> [dx\_app\_ci\_resource\_group\_reader](#module\_dx\_app\_ci\_resource\_group\_reader) | pagopa-dx/azure-merge-roles/azurerm | ~> 0.1 |
+| <a name="module_dx_function_durable_storage"></a> [dx\_function\_durable\_storage](#module\_dx\_function\_durable\_storage) | pagopa-dx/azure-merge-roles/azurerm | ~> 0.1 |
+| <a name="module_dx_function_host_storage"></a> [dx\_function\_host\_storage](#module\_dx\_function\_host\_storage) | pagopa-dx/azure-merge-roles/azurerm | ~> 0.1 |
+| <a name="module_dx_infra_cd_private_networking"></a> [dx\_infra\_cd\_private\_networking](#module\_dx\_infra\_cd\_private\_networking) | pagopa-dx/azure-merge-roles/azurerm | ~> 0.1 |
+| <a name="module_dx_infra_cd_resource_group_deploy"></a> [dx\_infra\_cd\_resource\_group\_deploy](#module\_dx\_infra\_cd\_resource\_group\_deploy) | pagopa-dx/azure-merge-roles/azurerm | ~> 0.1 |
+| <a name="module_dx_infra_cd_subscription_admin"></a> [dx\_infra\_cd\_subscription\_admin](#module\_dx\_infra\_cd\_subscription\_admin) | pagopa-dx/azure-merge-roles/azurerm | ~> 0.1 |
+| <a name="module_dx_infra_ci_resource_group_reader"></a> [dx\_infra\_ci\_resource\_group\_reader](#module\_dx\_infra\_ci\_resource\_group\_reader) | pagopa-dx/azure-merge-roles/azurerm | ~> 0.1 |
+| <a name="module_dx_infra_ci_subscription_reader"></a> [dx\_infra\_ci\_subscription\_reader](#module\_dx\_infra\_ci\_subscription\_reader) | pagopa-dx/azure-merge-roles/azurerm | ~> 0.1 |
+
+## Resources
+
+| Name | Type |
+|------|------|
+| [azurerm_subscription.current](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/data-sources/subscription) | data source |
+
+## Inputs
+
+| Name | Description | Type | Default | Required |
+|------|-------------|------|---------|:--------:|
+| <a name="input_subscription_id"></a> [subscription\_id](#input\_subscription\_id) | The ID of the subscription where the custom roles will be created. | `string` | `null` | no |
+| <a name="input_subscription_name"></a> [subscription\_name](#input\_subscription\_name) | The display name of the subscription where the custom roles will be created. | `string` | `null` | no |
+
+## Outputs
+
+No outputs.
+<!-- END_TF_DOCS -->

--- a/infra/modules/azure_core_infra/modules/custom_roles/README.md
+++ b/infra/modules/azure_core_infra/modules/custom_roles/README.md
@@ -1,48 +1,46 @@
 # custom_roles
 
 <!-- BEGIN_TF_DOCS -->
-
 ## Requirements
 
-| Name                                                               | Version |
-| ------------------------------------------------------------------ | ------- |
-| <a name="requirement_azurerm"></a> [azurerm](#requirement_azurerm) | ~> 4.62 |
+| Name | Version |
+|------|---------|
+| <a name="requirement_azurerm"></a> [azurerm](#requirement\_azurerm) | ~> 4.62 |
 
 ## Modules
 
-| Name                                                                                                                                   | Source                              | Version |
-| -------------------------------------------------------------------------------------------------------------------------------------- | ----------------------------------- | ------- |
-| <a name="module_dx_app_cd_resource_group_deploy"></a> [dx_app_cd_resource_group_deploy](#module_dx_app_cd_resource_group_deploy)       | pagopa-dx/azure-merge-roles/azurerm | ~> 0.1  |
-| <a name="module_dx_app_ci_resource_group_reader"></a> [dx_app_ci_resource_group_reader](#module_dx_app_ci_resource_group_reader)       | pagopa-dx/azure-merge-roles/azurerm | ~> 0.1  |
-| <a name="module_dx_function_durable_storage"></a> [dx_function_durable_storage](#module_dx_function_durable_storage)                   | pagopa-dx/azure-merge-roles/azurerm | ~> 0.1  |
-| <a name="module_dx_function_host_storage"></a> [dx_function_host_storage](#module_dx_function_host_storage)                            | pagopa-dx/azure-merge-roles/azurerm | ~> 0.1  |
-| <a name="module_dx_infra_cd_private_networking"></a> [dx_infra_cd_private_networking](#module_dx_infra_cd_private_networking)          | pagopa-dx/azure-merge-roles/azurerm | ~> 0.1  |
-| <a name="module_dx_infra_cd_resource_group_deploy"></a> [dx_infra_cd_resource_group_deploy](#module_dx_infra_cd_resource_group_deploy) | pagopa-dx/azure-merge-roles/azurerm | ~> 0.1  |
-| <a name="module_dx_infra_cd_subscription_admin"></a> [dx_infra_cd_subscription_admin](#module_dx_infra_cd_subscription_admin)          | pagopa-dx/azure-merge-roles/azurerm | ~> 0.1  |
-| <a name="module_dx_infra_ci_resource_group_reader"></a> [dx_infra_ci_resource_group_reader](#module_dx_infra_ci_resource_group_reader) | pagopa-dx/azure-merge-roles/azurerm | ~> 0.1  |
-| <a name="module_dx_infra_ci_subscription_reader"></a> [dx_infra_ci_subscription_reader](#module_dx_infra_ci_subscription_reader)       | pagopa-dx/azure-merge-roles/azurerm | ~> 0.1  |
+| Name | Source | Version |
+|------|--------|---------|
+| <a name="module_dx_app_cd_resource_group_deploy"></a> [dx\_app\_cd\_resource\_group\_deploy](#module\_dx\_app\_cd\_resource\_group\_deploy) | pagopa-dx/azure-merge-roles/azurerm | ~> 0.1 |
+| <a name="module_dx_app_ci_resource_group_reader"></a> [dx\_app\_ci\_resource\_group\_reader](#module\_dx\_app\_ci\_resource\_group\_reader) | pagopa-dx/azure-merge-roles/azurerm | ~> 0.1 |
+| <a name="module_dx_function_durable_storage"></a> [dx\_function\_durable\_storage](#module\_dx\_function\_durable\_storage) | pagopa-dx/azure-merge-roles/azurerm | ~> 0.1 |
+| <a name="module_dx_function_host_storage"></a> [dx\_function\_host\_storage](#module\_dx\_function\_host\_storage) | pagopa-dx/azure-merge-roles/azurerm | ~> 0.1 |
+| <a name="module_dx_infra_cd_private_networking"></a> [dx\_infra\_cd\_private\_networking](#module\_dx\_infra\_cd\_private\_networking) | pagopa-dx/azure-merge-roles/azurerm | ~> 0.1 |
+| <a name="module_dx_infra_cd_resource_group_deploy"></a> [dx\_infra\_cd\_resource\_group\_deploy](#module\_dx\_infra\_cd\_resource\_group\_deploy) | pagopa-dx/azure-merge-roles/azurerm | ~> 0.1 |
+| <a name="module_dx_infra_cd_subscription_admin"></a> [dx\_infra\_cd\_subscription\_admin](#module\_dx\_infra\_cd\_subscription\_admin) | pagopa-dx/azure-merge-roles/azurerm | ~> 0.1 |
+| <a name="module_dx_infra_ci_resource_group_reader"></a> [dx\_infra\_ci\_resource\_group\_reader](#module\_dx\_infra\_ci\_resource\_group\_reader) | pagopa-dx/azure-merge-roles/azurerm | ~> 0.1 |
+| <a name="module_dx_infra_ci_subscription_reader"></a> [dx\_infra\_ci\_subscription\_reader](#module\_dx\_infra\_ci\_subscription\_reader) | pagopa-dx/azure-merge-roles/azurerm | ~> 0.1 |
 
 ## Resources
 
-| Name                                                                                                                            | Type        |
-| ------------------------------------------------------------------------------------------------------------------------------- | ----------- |
+| Name | Type |
+|------|------|
 | [azurerm_subscription.current](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/data-sources/subscription) | data source |
 
 ## Inputs
 
-| Name                                                                                 | Description                                                                  | Type     | Default | Required |
-| ------------------------------------------------------------------------------------ | ---------------------------------------------------------------------------- | -------- | ------- | :------: |
-| <a name="input_subscription_id"></a> [subscription_id](#input_subscription_id)       | The ID of the subscription where the custom roles will be created.           | `string` | `null`  |    no    |
-| <a name="input_subscription_name"></a> [subscription_name](#input_subscription_name) | The display name of the subscription where the custom roles will be created. | `string` | `null`  |    no    |
+| Name | Description | Type | Default | Required |
+|------|-------------|------|---------|:--------:|
+| <a name="input_subscription_id"></a> [subscription\_id](#input\_subscription\_id) | The ID of the subscription where the custom roles will be created. | `string` | `null` | no |
+| <a name="input_subscription_name"></a> [subscription\_name](#input\_subscription\_name) | The display name of the subscription where the custom roles will be created. | `string` | `null` | no |
 
 ## Outputs
 
-| Name                                                                                                                             | Description                                                            |
-| -------------------------------------------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------- |
-| <a name="output_dx_app_ci_resource_group_reader"></a> [dx_app_ci_resource_group_reader](#output_dx_app_ci_resource_group_reader) | The merged custom role name for the App CI resource group reader role. |
-| <a name="output_dx_function_durable_storage"></a> [dx_function_durable_storage](#output_dx_function_durable_storage)             | The merged custom role name for the Function App durable storage role. |
-| <a name="output_dx_function_host_storage"></a> [dx_function_host_storage](#output_dx_function_host_storage)                      | The merged custom role name for the Function App host storage role.    |
-| <a name="output_dx_infra_cd_subscription_admin"></a> [dx_infra_cd_subscription_admin](#output_dx_infra_cd_subscription_admin)    | The merged custom role name for the Infra CD subscription admin role.  |
-| <a name="output_dx_infra_ci_subscription_reader"></a> [dx_infra_ci_subscription_reader](#output_dx_infra_ci_subscription_reader) | The merged custom role name for the Infra CI subscription reader role. |
-
+| Name | Description |
+|------|-------------|
+| <a name="output_dx_app_ci_resource_group_reader"></a> [dx\_app\_ci\_resource\_group\_reader](#output\_dx\_app\_ci\_resource\_group\_reader) | The merged custom role name for the App CI resource group reader role. |
+| <a name="output_dx_function_durable_storage"></a> [dx\_function\_durable\_storage](#output\_dx\_function\_durable\_storage) | The merged custom role name for the Function App durable storage role. |
+| <a name="output_dx_function_host_storage"></a> [dx\_function\_host\_storage](#output\_dx\_function\_host\_storage) | The merged custom role name for the Function App host storage role. |
+| <a name="output_dx_infra_cd_subscription_admin"></a> [dx\_infra\_cd\_subscription\_admin](#output\_dx\_infra\_cd\_subscription\_admin) | The merged custom role name for the Infra CD subscription admin role. |
+| <a name="output_dx_infra_ci_subscription_reader"></a> [dx\_infra\_ci\_subscription\_reader](#output\_dx\_infra\_ci\_subscription\_reader) | The merged custom role name for the Infra CI subscription reader role. |
 <!-- END_TF_DOCS -->

--- a/infra/modules/azure_core_infra/modules/custom_roles/README.md
+++ b/infra/modules/azure_core_infra/modules/custom_roles/README.md
@@ -1,48 +1,46 @@
 # custom_roles
 
 <!-- BEGIN_TF_DOCS -->
-
 ## Requirements
 
-| Name                                                               | Version |
-| ------------------------------------------------------------------ | ------- |
-| <a name="requirement_azurerm"></a> [azurerm](#requirement_azurerm) | ~> 4.62 |
+| Name | Version |
+|------|---------|
+| <a name="requirement_azurerm"></a> [azurerm](#requirement\_azurerm) | ~> 4.62 |
 
 ## Modules
 
-| Name                                                                                                                                   | Source                              | Version |
-| -------------------------------------------------------------------------------------------------------------------------------------- | ----------------------------------- | ------- |
-| <a name="module_dx_app_cd_resource_group_deploy"></a> [dx_app_cd_resource_group_deploy](#module_dx_app_cd_resource_group_deploy)       | pagopa-dx/azure-merge-roles/azurerm | ~> 0.1  |
-| <a name="module_dx_app_ci_resource_group_reader"></a> [dx_app_ci_resource_group_reader](#module_dx_app_ci_resource_group_reader)       | pagopa-dx/azure-merge-roles/azurerm | ~> 0.1  |
-| <a name="module_dx_function_durable_storage"></a> [dx_function_durable_storage](#module_dx_function_durable_storage)                   | pagopa-dx/azure-merge-roles/azurerm | ~> 0.1  |
-| <a name="module_dx_function_host_storage"></a> [dx_function_host_storage](#module_dx_function_host_storage)                            | pagopa-dx/azure-merge-roles/azurerm | ~> 0.1  |
-| <a name="module_dx_infra_cd_private_networking"></a> [dx_infra_cd_private_networking](#module_dx_infra_cd_private_networking)          | pagopa-dx/azure-merge-roles/azurerm | ~> 0.1  |
-| <a name="module_dx_infra_cd_resource_group_deploy"></a> [dx_infra_cd_resource_group_deploy](#module_dx_infra_cd_resource_group_deploy) | pagopa-dx/azure-merge-roles/azurerm | ~> 0.1  |
-| <a name="module_dx_infra_cd_subscription_admin"></a> [dx_infra_cd_subscription_admin](#module_dx_infra_cd_subscription_admin)          | pagopa-dx/azure-merge-roles/azurerm | ~> 0.1  |
-| <a name="module_dx_infra_ci_resource_group_reader"></a> [dx_infra_ci_resource_group_reader](#module_dx_infra_ci_resource_group_reader) | pagopa-dx/azure-merge-roles/azurerm | ~> 0.1  |
-| <a name="module_dx_infra_ci_subscription_reader"></a> [dx_infra_ci_subscription_reader](#module_dx_infra_ci_subscription_reader)       | pagopa-dx/azure-merge-roles/azurerm | ~> 0.1  |
+| Name | Source | Version |
+|------|--------|---------|
+| <a name="module_dx_app_cd_resource_group_deploy"></a> [dx\_app\_cd\_resource\_group\_deploy](#module\_dx\_app\_cd\_resource\_group\_deploy) | pagopa-dx/azure-merge-roles/azurerm | ~> 0.1 |
+| <a name="module_dx_app_ci_resource_group_reader"></a> [dx\_app\_ci\_resource\_group\_reader](#module\_dx\_app\_ci\_resource\_group\_reader) | pagopa-dx/azure-merge-roles/azurerm | ~> 0.1 |
+| <a name="module_dx_function_durable_storage"></a> [dx\_function\_durable\_storage](#module\_dx\_function\_durable\_storage) | pagopa-dx/azure-merge-roles/azurerm | ~> 0.1 |
+| <a name="module_dx_function_host_storage"></a> [dx\_function\_host\_storage](#module\_dx\_function\_host\_storage) | pagopa-dx/azure-merge-roles/azurerm | ~> 0.1 |
+| <a name="module_dx_infra_cd_private_networking"></a> [dx\_infra\_cd\_private\_networking](#module\_dx\_infra\_cd\_private\_networking) | pagopa-dx/azure-merge-roles/azurerm | ~> 0.1 |
+| <a name="module_dx_infra_cd_resource_group_deploy"></a> [dx\_infra\_cd\_resource\_group\_deploy](#module\_dx\_infra\_cd\_resource\_group\_deploy) | pagopa-dx/azure-merge-roles/azurerm | ~> 0.1 |
+| <a name="module_dx_infra_cd_subscription_admin"></a> [dx\_infra\_cd\_subscription\_admin](#module\_dx\_infra\_cd\_subscription\_admin) | pagopa-dx/azure-merge-roles/azurerm | ~> 0.1 |
+| <a name="module_dx_infra_ci_resource_group_reader"></a> [dx\_infra\_ci\_resource\_group\_reader](#module\_dx\_infra\_ci\_resource\_group\_reader) | pagopa-dx/azure-merge-roles/azurerm | ~> 0.1 |
+| <a name="module_dx_infra_ci_subscription_reader"></a> [dx\_infra\_ci\_subscription\_reader](#module\_dx\_infra\_ci\_subscription\_reader) | pagopa-dx/azure-merge-roles/azurerm | ~> 0.1 |
 
 ## Resources
 
-| Name                                                                                                                            | Type        |
-| ------------------------------------------------------------------------------------------------------------------------------- | ----------- |
+| Name | Type |
+|------|------|
 | [azurerm_subscription.current](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/data-sources/subscription) | data source |
 
 ## Inputs
 
-| Name                                                                                 | Description                                                                                                                                                        | Type     | Default | Required |
-| ------------------------------------------------------------------------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------ | -------- | ------- | :------: |
-| <a name="input_subscription_id"></a> [subscription_id](#input_subscription_id)       | The ID of the subscription where the custom roles will be created. Omit it together with subscription_name to use the current provider subscription automatically. | `string` | `null`  |    no    |
-| <a name="input_subscription_name"></a> [subscription_name](#input_subscription_name) | The display name of the subscription where the custom roles will be created. Omit it to auto-discover the display name for the selected subscription.              | `string` | `null`  |    no    |
+| Name | Description | Type | Default | Required |
+|------|-------------|------|---------|:--------:|
+| <a name="input_subscription_id"></a> [subscription\_id](#input\_subscription\_id) | The ID of the subscription where the custom roles will be created. Omit it together with subscription\_name to use the current provider subscription automatically. | `string` | `null` | no |
+| <a name="input_subscription_name"></a> [subscription\_name](#input\_subscription\_name) | The display name of the subscription where the custom roles will be created. Omit it to auto-discover the display name for the selected subscription. | `string` | `null` | no |
 
 ## Outputs
 
-| Name                                                                                                                             | Description                                                            |
-| -------------------------------------------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------- |
-| <a name="output_dx_app_ci_resource_group_reader"></a> [dx_app_ci_resource_group_reader](#output_dx_app_ci_resource_group_reader) | The merged custom role name for the App CI resource group reader role. |
-| <a name="output_dx_function_durable_storage"></a> [dx_function_durable_storage](#output_dx_function_durable_storage)             | The merged custom role name for the Function App durable storage role. |
-| <a name="output_dx_function_host_storage"></a> [dx_function_host_storage](#output_dx_function_host_storage)                      | The merged custom role name for the Function App host storage role.    |
-| <a name="output_dx_infra_cd_subscription_admin"></a> [dx_infra_cd_subscription_admin](#output_dx_infra_cd_subscription_admin)    | The merged custom role name for the Infra CD subscription admin role.  |
-| <a name="output_dx_infra_ci_subscription_reader"></a> [dx_infra_ci_subscription_reader](#output_dx_infra_ci_subscription_reader) | The merged custom role name for the Infra CI subscription reader role. |
-
+| Name | Description |
+|------|-------------|
+| <a name="output_dx_app_ci_resource_group_reader"></a> [dx\_app\_ci\_resource\_group\_reader](#output\_dx\_app\_ci\_resource\_group\_reader) | The merged custom role name for the App CI resource group reader role. |
+| <a name="output_dx_function_durable_storage"></a> [dx\_function\_durable\_storage](#output\_dx\_function\_durable\_storage) | The merged custom role name for the Function App durable storage role. |
+| <a name="output_dx_function_host_storage"></a> [dx\_function\_host\_storage](#output\_dx\_function\_host\_storage) | The merged custom role name for the Function App host storage role. |
+| <a name="output_dx_infra_cd_subscription_admin"></a> [dx\_infra\_cd\_subscription\_admin](#output\_dx\_infra\_cd\_subscription\_admin) | The merged custom role name for the Infra CD subscription admin role. |
+| <a name="output_dx_infra_ci_subscription_reader"></a> [dx\_infra\_ci\_subscription\_reader](#output\_dx\_infra\_ci\_subscription\_reader) | The merged custom role name for the Infra CI subscription reader role. |
 <!-- END_TF_DOCS -->

--- a/infra/modules/azure_core_infra/modules/custom_roles/custom_roles.tf
+++ b/infra/modules/azure_core_infra/modules/custom_roles/custom_roles.tf
@@ -2,7 +2,7 @@ module "dx_app_cd_resource_group_deploy" {
   source  = "pagopa-dx/azure-merge-roles/azurerm"
   version = "~> 0.1"
 
-  scope     = data.azurerm_subscription.current.id
+  scope     = local.subscription_id
   role_name = "${local.subscription_role_name_prefix} DX App CD Resource Groups"
   reason    = "Merged role for DX App CD identities at resource group scope"
   source_roles = [
@@ -18,7 +18,7 @@ module "dx_app_ci_resource_group_reader" {
   source  = "pagopa-dx/azure-merge-roles/azurerm"
   version = "~> 0.1"
 
-  scope     = data.azurerm_subscription.current.id
+  scope     = local.subscription_id
   role_name = "${local.subscription_role_name_prefix} DX App CI Resource Groups"
   reason    = "Merged role for DX App CI identities at resource group scope"
   source_roles = [
@@ -31,7 +31,7 @@ module "dx_infra_cd_private_networking" {
   source  = "pagopa-dx/azure-merge-roles/azurerm"
   version = "~> 0.1"
 
-  scope     = data.azurerm_subscription.current.id
+  scope     = local.subscription_id
   role_name = "${local.subscription_role_name_prefix} DX Infra CD Private Networking"
   reason    = "Merged role for DX Infra CD identities managing private DNS networking"
   source_roles = [
@@ -44,7 +44,7 @@ module "dx_infra_cd_resource_group_deploy" {
   source  = "pagopa-dx/azure-merge-roles/azurerm"
   version = "~> 0.1"
 
-  scope     = data.azurerm_subscription.current.id
+  scope     = local.subscription_id
   role_name = "${local.subscription_role_name_prefix} DX Infra CD Resource Groups"
   reason    = "Merged role for DX Infra CD identities at resource group scope"
   source_roles = [
@@ -64,7 +64,7 @@ module "dx_infra_cd_subscription_admin" {
   source  = "pagopa-dx/azure-merge-roles/azurerm"
   version = "~> 0.1"
 
-  scope     = data.azurerm_subscription.current.id
+  scope     = local.subscription_id
   role_name = "${local.subscription_role_name_prefix} DX Infra CD Subscription"
   reason    = "Merged role for DX Infra CD identities at subscription scope"
   source_roles = [
@@ -100,7 +100,7 @@ module "dx_infra_ci_resource_group_reader" {
   source  = "pagopa-dx/azure-merge-roles/azurerm"
   version = "~> 0.1"
 
-  scope     = data.azurerm_subscription.current.id
+  scope     = local.subscription_id
   role_name = "${local.subscription_role_name_prefix} DX Infra CI Resource Groups"
   reason    = "Merged role for DX Infra CI identities at resource group scope"
   source_roles = [
@@ -120,7 +120,7 @@ module "dx_infra_ci_subscription_reader" {
   source  = "pagopa-dx/azure-merge-roles/azurerm"
   version = "~> 0.1"
 
-  scope     = data.azurerm_subscription.current.id
+  scope     = local.subscription_id
   role_name = "${local.subscription_role_name_prefix} DX Infra CI Subscription"
   reason    = "Merged role for DX Infra CI identities at subscription scope"
   source_roles = [
@@ -135,7 +135,7 @@ module "dx_function_host_storage" {
   source  = "pagopa-dx/azure-merge-roles/azurerm"
   version = "~> 0.1"
 
-  scope     = data.azurerm_subscription.current.id
+  scope     = local.subscription_id
   role_name = "${local.subscription_role_name_prefix} DX Function Host Storage"
   reason    = "Merged role for Function App host storage access"
   source_roles = [
@@ -149,7 +149,7 @@ module "dx_function_durable_storage" {
   source  = "pagopa-dx/azure-merge-roles/azurerm"
   version = "~> 0.1"
 
-  scope     = data.azurerm_subscription.current.id
+  scope     = local.subscription_id
   role_name = "${local.subscription_role_name_prefix} DX Function Durable Storage"
   reason    = "Merged role for Function App durable storage access"
   source_roles = [

--- a/infra/modules/azure_core_infra/modules/custom_roles/data.tf
+++ b/infra/modules/azure_core_infra/modules/custom_roles/data.tf
@@ -1,0 +1,3 @@
+data "azurerm_subscription" "current" {
+  count = var.subscription_id == null ? 0 : 1
+}

--- a/infra/modules/azure_core_infra/modules/custom_roles/data.tf
+++ b/infra/modules/azure_core_infra/modules/custom_roles/data.tf
@@ -1,3 +1,3 @@
 data "azurerm_subscription" "current" {
-  count = var.subscription_id == null ? 0 : 1
+  count = var.subscription_id == null ? 1 : 0
 }

--- a/infra/modules/azure_core_infra/modules/custom_roles/data.tf
+++ b/infra/modules/azure_core_infra/modules/custom_roles/data.tf
@@ -1,3 +1,4 @@
 data "azurerm_subscription" "current" {
-  count = var.subscription_id == null ? 1 : 0
+  count           = var.subscription_id == null || var.subscription_name == null ? 1 : 0
+  subscription_id = var.subscription_id == null ? null : trimspace(var.subscription_id)
 }

--- a/infra/modules/azure_core_infra/modules/custom_roles/locals.tf
+++ b/infra/modules/azure_core_infra/modules/custom_roles/locals.tf
@@ -1,6 +1,6 @@
 locals {
-  subscription_id   = var.subscription_id != null ? var.subscription_id : data.azurerm_subscription.current[0].id
-  subscription_name = var.subscription_name != null ? var.subscription_name : data.azurerm_subscription.current[0].display_name
+  subscription_id   = var.subscription_id != null ? trimspace(var.subscription_id) : data.azurerm_subscription.current[0].id
+  subscription_name = var.subscription_name != null ? trimspace(var.subscription_name) : data.azurerm_subscription.current[0].display_name
 
-  subscription_role_name_prefix = trimspace(local.subscription_name)
+  subscription_role_name_prefix = local.subscription_name
 }

--- a/infra/modules/azure_core_infra/modules/custom_roles/locals.tf
+++ b/infra/modules/azure_core_infra/modules/custom_roles/locals.tf
@@ -1,0 +1,6 @@
+locals {
+  subscription_id   = var.subscription_id != null ? var.subscription_id : data.azurerm_subscription.current[0].subscription_id
+  subscription_name = var.subscription_name != null ? var.subscription_name : data.azurerm_subscription.current[0].display_name
+
+  subscription_role_name_prefix = trimspace(local.subscription_name)
+}

--- a/infra/modules/azure_core_infra/modules/custom_roles/locals.tf
+++ b/infra/modules/azure_core_infra/modules/custom_roles/locals.tf
@@ -1,5 +1,5 @@
 locals {
-  subscription_id   = var.subscription_id != null ? var.subscription_id : data.azurerm_subscription.current[0].subscription_id
+  subscription_id   = var.subscription_id != null ? var.subscription_id : data.azurerm_subscription.current[0].id
   subscription_name = var.subscription_name != null ? var.subscription_name : data.azurerm_subscription.current[0].display_name
 
   subscription_role_name_prefix = trimspace(local.subscription_name)

--- a/infra/modules/azure_core_infra/modules/custom_roles/outputs.tf
+++ b/infra/modules/azure_core_infra/modules/custom_roles/outputs.tf
@@ -1,0 +1,24 @@
+output "dx_app_ci_resource_group_reader" {
+  description = "The merged custom role name for the App CI resource group reader role."
+  value       = module.dx_app_ci_resource_group_reader.custom_role_name
+}
+
+output "dx_infra_ci_subscription_reader" {
+  description = "The merged custom role name for the Infra CI subscription reader role."
+  value       = module.dx_infra_ci_subscription_reader.custom_role_name
+}
+
+output "dx_infra_cd_subscription_admin" {
+  description = "The merged custom role name for the Infra CD subscription admin role."
+  value       = module.dx_infra_cd_subscription_admin.custom_role_name
+}
+
+output "dx_function_host_storage" {
+  description = "The merged custom role name for the Function App host storage role."
+  value       = module.dx_function_host_storage.custom_role_name
+}
+
+output "dx_function_durable_storage" {
+  description = "The merged custom role name for the Function App durable storage role."
+  value       = module.dx_function_durable_storage.custom_role_name
+}

--- a/infra/modules/azure_core_infra/modules/custom_roles/providers.tf
+++ b/infra/modules/azure_core_infra/modules/custom_roles/providers.tf
@@ -1,0 +1,8 @@
+terraform {
+  required_providers {
+    azurerm = {
+      source  = "hashicorp/azurerm"
+      version = "~> 4.62"
+    }
+  }
+}

--- a/infra/modules/azure_core_infra/modules/custom_roles/tests/contract.tftest.hcl
+++ b/infra/modules/azure_core_infra/modules/custom_roles/tests/contract.tftest.hcl
@@ -1,0 +1,92 @@
+mock_provider "azurerm" {}
+
+override_data {
+  target = data.azurerm_subscription.current
+  values = {
+    id              = "/subscriptions/00000000-0000-0000-0000-000000000000"
+    subscription_id = "00000000-0000-0000-0000-000000000000"
+    display_name    = "DX Current"
+  }
+}
+
+run "uses_current_provider_subscription_when_inputs_are_omitted" {
+  command = plan
+
+  assert {
+    condition     = local.subscription_id == "/subscriptions/00000000-0000-0000-0000-000000000000"
+    error_message = "The module must default to the current provider subscription ID when subscription_id is omitted."
+  }
+
+  assert {
+    condition     = local.subscription_name == "DX Current"
+    error_message = "The module must default to the current provider subscription display name when subscription_name is omitted."
+  }
+
+  assert {
+    condition     = output.dx_app_ci_resource_group_reader == "DX Current DX App CI Resource Groups"
+    error_message = "The generated role names must use the current provider subscription display name as prefix when no explicit inputs are provided."
+  }
+}
+
+run "uses_provided_subscription_id_and_discovers_name_when_name_is_omitted" {
+  command = plan
+
+  variables {
+    subscription_id = "/subscriptions/11111111-1111-1111-1111-111111111111"
+  }
+
+  override_data {
+    target = data.azurerm_subscription.current
+    values = {
+      id              = "/subscriptions/11111111-1111-1111-1111-111111111111"
+      subscription_id = "11111111-1111-1111-1111-111111111111"
+      display_name    = "DX Standalone"
+    }
+  }
+
+  assert {
+    condition     = local.subscription_id == "/subscriptions/11111111-1111-1111-1111-111111111111"
+    error_message = "The module must preserve the provided subscription_id when resolving a missing subscription_name."
+  }
+
+  assert {
+    condition     = local.subscription_name == "DX Standalone"
+    error_message = "The module must resolve the subscription display name for a provided subscription_id when subscription_name is omitted."
+  }
+
+  assert {
+    condition     = output.dx_function_host_storage == "DX Standalone DX Function Host Storage"
+    error_message = "The generated role names must use the discovered display name when only subscription_id is provided."
+  }
+}
+
+run "subscription_name_requires_subscription_id" {
+  command = plan
+
+  variables {
+    subscription_name = "DX Standalone"
+  }
+
+  expect_failures = [var.subscription_name]
+}
+
+run "subscription_id_must_not_be_blank" {
+  command = plan
+
+  variables {
+    subscription_id = "   "
+  }
+
+  expect_failures = [var.subscription_id]
+}
+
+run "subscription_name_must_not_be_blank" {
+  command = plan
+
+  variables {
+    subscription_id   = "/subscriptions/22222222-2222-2222-2222-222222222222"
+    subscription_name = "   "
+  }
+
+  expect_failures = [var.subscription_name]
+}

--- a/infra/modules/azure_core_infra/modules/custom_roles/variables.tf
+++ b/infra/modules/azure_core_infra/modules/custom_roles/variables.tf
@@ -1,11 +1,26 @@
 variable "subscription_id" {
-  description = "The ID of the subscription where the custom roles will be created."
+  description = "The ID of the subscription where the custom roles will be created. Omit it together with subscription_name to use the current provider subscription automatically."
   type        = string
   default     = null
+
+  validation {
+    condition     = var.subscription_id == null ? true : trimspace(var.subscription_id) != ""
+    error_message = "subscription_id must be null or a non-empty string."
+  }
 }
 
 variable "subscription_name" {
-  description = "The display name of the subscription where the custom roles will be created."
+  description = "The display name of the subscription where the custom roles will be created. Omit it to auto-discover the display name for the selected subscription."
   type        = string
   default     = null
+
+  validation {
+    condition     = var.subscription_name == null ? true : trimspace(var.subscription_name) != ""
+    error_message = "subscription_name must be null or a non-empty string."
+  }
+
+  validation {
+    condition     = var.subscription_name == null ? true : var.subscription_id != null && trimspace(var.subscription_id) != ""
+    error_message = "subscription_name requires subscription_id. Omit both values to use the current provider subscription automatically."
+  }
 }

--- a/infra/modules/azure_core_infra/modules/custom_roles/variables.tf
+++ b/infra/modules/azure_core_infra/modules/custom_roles/variables.tf
@@ -1,0 +1,11 @@
+variable "subscription_id" {
+  description = "The ID of the subscription where the custom roles will be created."
+  type        = string
+  default     = null
+}
+
+variable "subscription_name" {
+  description = "The display name of the subscription where the custom roles will be created."
+  type        = string
+  default     = null
+}

--- a/infra/modules/azure_core_infra/moved.tf
+++ b/infra/modules/azure_core_infra/moved.tf
@@ -1,0 +1,44 @@
+moved {
+  from = module.dx_app_cd_resource_group_deploy
+  to   = module.custom_roles.module.dx_app_cd_resource_group_deploy
+}
+
+moved {
+  from = module.dx_app_ci_resource_group_reader
+  to   = module.custom_roles.module.dx_app_ci_resource_group_reader
+}
+
+moved {
+  from = module.dx_infra_cd_private_networking
+  to   = module.custom_roles.module.dx_infra_cd_private_networking
+}
+
+moved {
+  from = module.dx_infra_cd_resource_group_deploy
+  to   = module.custom_roles.module.dx_infra_cd_resource_group_deploy
+}
+
+moved {
+  from = module.dx_infra_cd_subscription_admin
+  to   = module.custom_roles.module.dx_infra_cd_subscription_admin
+}
+
+moved {
+  from = module.dx_infra_ci_resource_group_reader
+  to   = module.custom_roles.module.dx_infra_ci_resource_group_reader
+}
+
+moved {
+  from = module.dx_infra_ci_subscription_reader
+  to   = module.custom_roles.module.dx_infra_ci_subscription_reader
+}
+
+moved {
+  from = module.dx_function_host_storage
+  to   = module.custom_roles.module.dx_function_host_storage
+}
+
+moved {
+  from = module.dx_function_durable_storage
+  to   = module.custom_roles.module.dx_function_durable_storage
+}

--- a/infra/modules/azure_core_infra/tests/common.tftest.hcl
+++ b/infra/modules/azure_core_infra/tests/common.tftest.hcl
@@ -71,27 +71,27 @@ run "core_is_correct_plan" {
   }
 
   assert {
-    condition     = module.dx_app_ci_resource_group_reader.custom_role_name == "${data.azurerm_subscription.current.display_name} DX App CI Resource Groups"
+    condition     = module.custom_roles.dx_app_ci_resource_group_reader == "${data.azurerm_subscription.current.display_name} DX App CI Resource Groups"
     error_message = "The App CI merged custom role must include the subscription display name as prefix"
   }
 
   assert {
-    condition     = module.dx_infra_ci_subscription_reader.custom_role_name == "${data.azurerm_subscription.current.display_name} DX Infra CI Subscription"
+    condition     = module.custom_roles.dx_infra_ci_subscription_reader == "${data.azurerm_subscription.current.display_name} DX Infra CI Subscription"
     error_message = "The Infra CI merged custom role must include the subscription display name as prefix"
   }
 
   assert {
-    condition     = module.dx_infra_cd_subscription_admin.custom_role_name == "${data.azurerm_subscription.current.display_name} DX Infra CD Subscription"
+    condition     = module.custom_roles.dx_infra_cd_subscription_admin == "${data.azurerm_subscription.current.display_name} DX Infra CD Subscription"
     error_message = "The Infra CD merged custom role must include the subscription display name as prefix"
   }
 
   assert {
-    condition     = module.dx_function_host_storage.custom_role_name == "${data.azurerm_subscription.current.display_name} DX Function Host Storage"
+    condition     = module.custom_roles.dx_function_host_storage == "${data.azurerm_subscription.current.display_name} DX Function Host Storage"
     error_message = "The Function App host storage merged custom role must include the subscription display name as prefix"
   }
 
   assert {
-    condition     = module.dx_function_durable_storage.custom_role_name == "${data.azurerm_subscription.current.display_name} DX Function Durable Storage"
+    condition     = module.custom_roles.dx_function_durable_storage == "${data.azurerm_subscription.current.display_name} DX Function Durable Storage"
     error_message = "The Function App durable storage merged custom role must include the subscription display name as prefix"
   }
 }


### PR DESCRIPTION
Relocate custom roles to a dedicated submodule for better accessibility from repositories that don't need the entire azure-core-infra resources

Resolves CES-2021