### PR TITLE
Enhance GitHub App token handling for terrawiz

### DIFF
--- a/.nx/version-plans/version-plan-1778501891042.md
+++ b/.nx/version-plans/version-plan-1778501891042.md
@@ -1,0 +1,5 @@
+---
+dx-metrics: patch
+---
+
+Add GitHub App support to run Terrawiz import without a separate GITHUB_TOKEN

--- a/apps/dx-metrics/README.md
+++ b/apps/dx-metrics/README.md
@@ -38,7 +38,7 @@ DATABASE_URL=postgresql://postgresql:postgresql@172.18.0.1:5432/postgresql npx d
 3. **Import data (incremental):**
 
 ```bash
-export GITHUB_APP_ID=123456
+export GITHUB_CLIENT_ID=Iv1.0123456789abcdef
 export GITHUB_APP_INSTALLATION_ID=7890123
 # Convert PEM file to a single line with \n escapes
 export GITHUB_APP_PRIVATE_KEY="$(awk '{printf "%s\\n", $0}' /path/to/github-app-private-key.pem)"
@@ -127,16 +127,21 @@ structure and values.
 
 The import script authenticates to GitHub with this precedence:
 
-1. GitHub App installation auth, when all GitHub App variables are configured
+1. GitHub App installation auth with `GITHUB_CLIENT_ID`, when `GITHUB_CLIENT_ID`,
+   `GITHUB_APP_INSTALLATION_ID`, and `GITHUB_APP_PRIVATE_KEY` are configured
    - `dx-metrics` uses the App credentials directly for Octokit and mints a
      temporary installation token for `terrawiz`
-2. `GITHUB_TOKEN`, when GitHub App credentials are absent
+2. GitHub App installation auth with `GITHUB_APP_ID`, when `GITHUB_CLIENT_ID` is
+   absent and `GITHUB_APP_ID`, `GITHUB_APP_INSTALLATION_ID`, and
+   `GITHUB_APP_PRIVATE_KEY` are configured
+3. `GITHUB_TOKEN`, when GitHub App credentials are absent
 
 GitHub App variables:
 
 | Variable                     | Description                                |
 | ---------------------------- | ------------------------------------------ |
-| `GITHUB_APP_ID`              | Numeric GitHub App ID                      |
+| `GITHUB_CLIENT_ID`           | Preferred GitHub App client ID             |
+| `GITHUB_APP_ID`              | Fallback numeric GitHub App ID             |
 | `GITHUB_APP_INSTALLATION_ID` | Numeric installation ID for the target org |
 | `GITHUB_APP_PRIVATE_KEY`     | GitHub App private key in PEM format       |
 

--- a/apps/dx-metrics/README.md
+++ b/apps/dx-metrics/README.md
@@ -50,8 +50,12 @@ If your secret store exposes the private key with escaped newlines (`\n`),
 `dx-metrics` normalizes it automatically before creating the GitHub App
 installation client.
 
+When GitHub App credentials are configured, `dx-metrics` also generates a
+short-lived installation access token right before invoking `terrawiz`, so the
+Terraform module import does not require a separate `GITHUB_TOKEN`.
+
 If GitHub App credentials are not configured, the import script falls back to
-`GITHUB_TOKEN`.
+`GITHUB_TOKEN` for both Octokit and `terrawiz`.
 
 4. **Access dashboards** at http://localhost:3000 (anonymous access; no GitHub login required)
 
@@ -124,6 +128,8 @@ structure and values.
 The import script authenticates to GitHub with this precedence:
 
 1. GitHub App installation auth, when all GitHub App variables are configured
+   - `dx-metrics` uses the App credentials directly for Octokit and mints a
+     temporary installation token for `terrawiz`
 2. `GITHUB_TOKEN`, when GitHub App credentials are absent
 
 GitHub App variables:

--- a/apps/dx-metrics/scripts/import.ts
+++ b/apps/dx-metrics/scripts/import.ts
@@ -49,6 +49,10 @@ const readEnvironmentOverrides = () => ({
   GITHUB_TOKEN: process.env.GITHUB_TOKEN,
 });
 
+const readRuntimeEnvironment = (): NodeJS.ProcessEnv => ({
+  ...process.env,
+});
+
 const handleCliError = (error: unknown): never => {
   if (error instanceof HelpRequestedError) {
     console.log(getHelpText());
@@ -76,7 +80,7 @@ async function main(): Promise<void> {
     fileConfig,
     readEnvironmentOverrides(),
   );
-  const context = await createImportContext(settings);
+  const context = await createImportContext(settings, readRuntimeEnvironment());
   const stats = { skipped: 0 };
 
   try {

--- a/apps/dx-metrics/scripts/import.ts
+++ b/apps/dx-metrics/scripts/import.ts
@@ -46,6 +46,7 @@ const readEnvironmentOverrides = () => ({
   GITHUB_APP_ID: process.env.GITHUB_APP_ID,
   GITHUB_APP_INSTALLATION_ID: process.env.GITHUB_APP_INSTALLATION_ID,
   GITHUB_APP_PRIVATE_KEY: process.env.GITHUB_APP_PRIVATE_KEY,
+  GITHUB_CLIENT_ID: process.env.GITHUB_CLIENT_ID,
   GITHUB_TOKEN: process.env.GITHUB_TOKEN,
 });
 

--- a/apps/dx-metrics/scripts/lib/__tests__/config.test.ts
+++ b/apps/dx-metrics/scripts/lib/__tests__/config.test.ts
@@ -10,7 +10,7 @@ describe("resolveImportSettings", () => {
     const settings = resolveImportSettings(
       { dxTeamSlug: "engineering-team-devex" },
       {
-        GITHUB_APP_ID: "123",
+        GITHUB_CLIENT_ID: "Iv1.client-id",
         GITHUB_APP_INSTALLATION_ID: "456",
         GITHUB_APP_PRIVATE_KEY:
           "-----BEGIN PRIVATE KEY-----\\nprivate-key\\n-----END PRIVATE KEY-----",
@@ -24,7 +24,7 @@ describe("resolveImportSettings", () => {
     const settings = resolveImportSettings(
       { dxTeamSlug: "engineering-team-devex" },
       {
-        GITHUB_APP_ID: "123",
+        GITHUB_CLIENT_ID: "Iv1.client-id",
         GITHUB_APP_INSTALLATION_ID: "456",
         GITHUB_APP_PRIVATE_KEY:
           "-----BEGIN PRIVATE KEY-----\\nprivate-key\\n-----END PRIVATE KEY-----",
@@ -33,7 +33,7 @@ describe("resolveImportSettings", () => {
 
     expect(settings.dxRepo).toBe("dx");
     expect(settings.githubAuth).toEqual({
-      appId: 123,
+      appId: "Iv1.client-id",
       installationId: 456,
       privateKey:
         "-----BEGIN PRIVATE KEY-----\nprivate-key\n-----END PRIVATE KEY-----",
@@ -55,21 +55,7 @@ describe("resolveImportSettings", () => {
     });
   });
 
-  it("throws when GitHub App credentials are incomplete", () => {
-    expect(() =>
-      resolveImportSettings(
-        { dxTeamSlug: "engineering-team-devex" },
-        {
-          GITHUB_APP_ID: "123",
-          GITHUB_APP_PRIVATE_KEY: "-----BEGIN PRIVATE KEY-----",
-        },
-      ),
-    ).toThrow(
-      "Incomplete GitHub App credentials. Set GITHUB_APP_ID, GITHUB_APP_INSTALLATION_ID, and GITHUB_APP_PRIVATE_KEY.",
-    );
-  });
-
-  it("prefers GitHub App credentials over the PAT when both are configured", () => {
+  it("falls back to GITHUB_APP_ID when GITHUB_CLIENT_ID is not configured", () => {
     const settings = resolveImportSettings(
       { dxTeamSlug: "engineering-team-devex" },
       {
@@ -77,7 +63,6 @@ describe("resolveImportSettings", () => {
         GITHUB_APP_INSTALLATION_ID: "456",
         GITHUB_APP_PRIVATE_KEY:
           "-----BEGIN PRIVATE KEY-----\\nprivate-key\\n-----END PRIVATE KEY-----",
-        GITHUB_TOKEN: "ghp_legacy_token",
       },
     );
 
@@ -90,11 +75,60 @@ describe("resolveImportSettings", () => {
     });
   });
 
+  it("throws when GitHub App credentials are incomplete", () => {
+    expect(() =>
+      resolveImportSettings(
+        { dxTeamSlug: "engineering-team-devex" },
+        {
+          GITHUB_CLIENT_ID: "Iv1.client-id",
+          GITHUB_APP_PRIVATE_KEY: "-----BEGIN PRIVATE KEY-----",
+        },
+      ),
+    ).toThrow(
+      "Incomplete GitHub App credentials. Set GITHUB_CLIENT_ID or GITHUB_APP_ID, GITHUB_APP_INSTALLATION_ID, and GITHUB_APP_PRIVATE_KEY.",
+    );
+  });
+
+  it("prefers GITHUB_CLIENT_ID over GITHUB_APP_ID and GITHUB_TOKEN", () => {
+    const settings = resolveImportSettings(
+      { dxTeamSlug: "engineering-team-devex" },
+      {
+        GITHUB_CLIENT_ID: "Iv1.client-id",
+        GITHUB_APP_ID: "123",
+        GITHUB_APP_INSTALLATION_ID: "456",
+        GITHUB_APP_PRIVATE_KEY:
+          "-----BEGIN PRIVATE KEY-----\\nprivate-key\\n-----END PRIVATE KEY-----",
+        GITHUB_TOKEN: "ghp_legacy_token",
+      },
+    );
+
+    expect(settings.githubAuth).toEqual({
+      appId: "Iv1.client-id",
+      installationId: 456,
+      privateKey:
+        "-----BEGIN PRIVATE KEY-----\nprivate-key\n-----END PRIVATE KEY-----",
+      type: "app",
+    });
+  });
+
+  it("rejects a non-numeric GITHUB_APP_ID when GITHUB_CLIENT_ID is absent", () => {
+    expect(() =>
+      resolveImportSettings(
+        { dxTeamSlug: "engineering-team-devex" },
+        {
+          GITHUB_APP_ID: "not-a-number",
+          GITHUB_APP_INSTALLATION_ID: "456",
+          GITHUB_APP_PRIVATE_KEY: "-----BEGIN PRIVATE KEY-----",
+        },
+      ),
+    ).toThrow("Invalid GitHub App credentials:");
+  });
+
   it("throws when neither GitHub App credentials nor the PAT are configured", () => {
     expect(() =>
       resolveImportSettings({ dxTeamSlug: "engineering-team-devex" }, {}),
     ).toThrow(
-      "GitHub authentication is required. Configure either GITHUB_APP_ID, GITHUB_APP_INSTALLATION_ID, and GITHUB_APP_PRIVATE_KEY, or GITHUB_TOKEN.",
+      "GitHub authentication is required. Configure either GITHUB_CLIENT_ID or GITHUB_APP_ID, plus GITHUB_APP_INSTALLATION_ID and GITHUB_APP_PRIVATE_KEY, or GITHUB_TOKEN.",
     );
   });
 });

--- a/apps/dx-metrics/scripts/lib/__tests__/import-context.test.ts
+++ b/apps/dx-metrics/scripts/lib/__tests__/import-context.test.ts
@@ -74,6 +74,20 @@ describe("buildGitHubAppOctokitAuthOptions", () => {
       privateKey: "-----BEGIN PRIVATE KEY-----\nprivate-key",
     });
   });
+
+  it("preserves a client ID string when building Octokit auth options", () => {
+    expect(
+      buildGitHubAppOctokitAuthOptions({
+        appId: "Iv1.client-id",
+        installationId: 456,
+        privateKey: "-----BEGIN PRIVATE KEY-----\nprivate-key",
+      }),
+    ).toEqual({
+      appId: "Iv1.client-id",
+      installationId: 456,
+      privateKey: "-----BEGIN PRIVATE KEY-----\nprivate-key",
+    });
+  });
 });
 
 describe("createOctokitClient", () => {

--- a/apps/dx-metrics/scripts/lib/__tests__/import-context.test.ts
+++ b/apps/dx-metrics/scripts/lib/__tests__/import-context.test.ts
@@ -1,7 +1,9 @@
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 
+import type { GitHubAppAuthSettings } from "../config.js";
 import {
   buildGitHubAppOctokitAuthOptions,
+  createTerrawizGitHubTokenResolver,
   createOctokitClient,
   resolveDxTeamMembers,
   type TeamMembersClient,
@@ -93,5 +95,53 @@ describe("createOctokitClient", () => {
     });
 
     expect(octokit).toBeInstanceOf(Object);
+  });
+});
+
+describe("createTerrawizGitHubTokenResolver", () => {
+  it("returns the configured PAT when PAT auth is used", async () => {
+    const createInstallationTokenResolver = vi.fn(
+      (_githubApp: GitHubAppAuthSettings) => async () =>
+        "ghs_installation_token",
+    );
+
+    const resolveTerrawizGitHubToken = createTerrawizGitHubTokenResolver(
+      {
+        token: "ghp_legacy_token",
+        type: "token",
+      },
+      createInstallationTokenResolver,
+    );
+
+    await expect(resolveTerrawizGitHubToken()).resolves.toBe(
+      "ghp_legacy_token",
+    );
+    expect(createInstallationTokenResolver).not.toHaveBeenCalled();
+  });
+
+  it("creates an installation token resolver when GitHub App auth is used", async () => {
+    const createInstallationTokenResolver = vi.fn(
+      (githubApp: GitHubAppAuthSettings) => async () =>
+        `ghs_${githubApp.installationId}`,
+    );
+
+    const resolveTerrawizGitHubToken = createTerrawizGitHubTokenResolver(
+      {
+        appId: 123,
+        installationId: 456,
+        privateKey: "-----BEGIN PRIVATE KEY-----\nprivate-key",
+        type: "app",
+      },
+      createInstallationTokenResolver,
+    );
+
+    expect(createInstallationTokenResolver).toHaveBeenCalledWith(
+      expect.objectContaining({
+        appId: 123,
+        installationId: 456,
+        privateKey: "-----BEGIN PRIVATE KEY-----\nprivate-key",
+      }),
+    );
+    await expect(resolveTerrawizGitHubToken()).resolves.toBe("ghs_456");
   });
 });

--- a/apps/dx-metrics/scripts/lib/config.ts
+++ b/apps/dx-metrics/scripts/lib/config.ts
@@ -15,11 +15,12 @@ export interface EnvironmentOverrides {
   GITHUB_APP_ID?: string;
   GITHUB_APP_INSTALLATION_ID?: string;
   GITHUB_APP_PRIVATE_KEY?: string;
+  GITHUB_CLIENT_ID?: string;
   GITHUB_TOKEN?: string;
 }
 
 export interface GitHubAppAuthSettings {
-  appId: number;
+  appId: number | string;
   installationId: number;
   privateKey: string;
 }
@@ -48,13 +49,40 @@ export function normalizeGitHubAppPrivateKey(privateKey: string): string {
 }
 
 const GitHubAppAuthSchema = z.object({
-  appId: z.coerce.number().int().positive(),
   installationId: z.coerce.number().int().positive(),
   privateKey: z.string().min(1).transform(normalizeGitHubAppPrivateKey),
 });
 
+const GitHubAppIdSchema = z.coerce.number().int().positive();
+
 const readOptionalEnvironmentString = (value?: string): string | undefined =>
   value && value.trim().length > 0 ? value : undefined;
+
+const resolveGitHubAppIdentifier = (
+  environment: Pick<EnvironmentOverrides, "GITHUB_APP_ID" | "GITHUB_CLIENT_ID">,
+): number | string | undefined => {
+  const clientId = readOptionalEnvironmentString(environment.GITHUB_CLIENT_ID);
+
+  if (clientId) {
+    return clientId;
+  }
+
+  const appId = readOptionalEnvironmentString(environment.GITHUB_APP_ID);
+
+  if (!appId) {
+    return undefined;
+  }
+
+  const result = GitHubAppIdSchema.safeParse(appId);
+
+  if (!result.success) {
+    throw new Error(
+      `Invalid GitHub App credentials: ${z.prettifyError(result.error)}`,
+    );
+  }
+
+  return result.data;
+};
 
 export function loadImportConfig(filePath: string): ImportFileConfig {
   try {
@@ -73,8 +101,8 @@ export function loadImportConfig(filePath: string): ImportFileConfig {
 export function resolveGitHubAppAuth(
   environment: EnvironmentOverrides,
 ): GitHubAppAuthSettings | undefined {
+  const appId = resolveGitHubAppIdentifier(environment);
   const rawGitHubAppAuth = {
-    appId: readOptionalEnvironmentString(environment.GITHUB_APP_ID),
     installationId: readOptionalEnvironmentString(
       environment.GITHUB_APP_INSTALLATION_ID,
     ),
@@ -82,17 +110,20 @@ export function resolveGitHubAppAuth(
       environment.GITHUB_APP_PRIVATE_KEY,
     ),
   };
-  const hasAnyGitHubAppCredential = Object.values(rawGitHubAppAuth).some(
-    (value) => value !== undefined,
-  );
+  const hasAnyGitHubAppCredential =
+    appId !== undefined ||
+    Object.values(rawGitHubAppAuth).some((value) => value !== undefined);
 
   if (!hasAnyGitHubAppCredential) {
     return undefined;
   }
 
-  if (Object.values(rawGitHubAppAuth).some((value) => value === undefined)) {
+  if (
+    appId === undefined ||
+    Object.values(rawGitHubAppAuth).some((value) => value === undefined)
+  ) {
     throw new Error(
-      "Incomplete GitHub App credentials. Set GITHUB_APP_ID, GITHUB_APP_INSTALLATION_ID, and GITHUB_APP_PRIVATE_KEY.",
+      "Incomplete GitHub App credentials. Set GITHUB_CLIENT_ID or GITHUB_APP_ID, GITHUB_APP_INSTALLATION_ID, and GITHUB_APP_PRIVATE_KEY.",
     );
   }
 
@@ -104,7 +135,10 @@ export function resolveGitHubAppAuth(
     );
   }
 
-  return result.data;
+  return {
+    appId,
+    ...result.data,
+  };
 }
 
 export function resolveGitHubAuth(
@@ -129,7 +163,7 @@ export function resolveGitHubAuth(
   }
 
   throw new Error(
-    "GitHub authentication is required. Configure either GITHUB_APP_ID, GITHUB_APP_INSTALLATION_ID, and GITHUB_APP_PRIVATE_KEY, or GITHUB_TOKEN.",
+    "GitHub authentication is required. Configure either GITHUB_CLIENT_ID or GITHUB_APP_ID, plus GITHUB_APP_INSTALLATION_ID and GITHUB_APP_PRIVATE_KEY, or GITHUB_TOKEN.",
   );
 }
 

--- a/apps/dx-metrics/scripts/lib/import-context.ts
+++ b/apps/dx-metrics/scripts/lib/import-context.ts
@@ -31,11 +31,14 @@ export interface ImportContext {
   octokit: Octokit;
   organization: string;
   pool: ImportPool;
+  resolveTerrawizGitHubToken: ResolveTerrawizGitHubToken;
   repositories: string[];
+  runtimeEnvironment: NodeJS.ProcessEnv;
 }
 
 export type ImportDatabase = DatabaseConnection["db"];
 export type ImportPool = DatabaseConnection["pool"];
+export type ResolveTerrawizGitHubToken = () => Promise<string>;
 
 export interface TeamMembersClient {
   paginate: (
@@ -60,7 +63,7 @@ const toSortedUniqueMembers = (members: readonly string[]): string[] =>
 
 export const buildGitHubAppOctokitAuthOptions = (
   githubApp: GitHubAppAuthSettings,
-): GitHubAppAuthSettings => ({
+): Parameters<typeof createAppAuth>[0] => ({
   appId: githubApp.appId,
   installationId: githubApp.installationId,
   privateKey: githubApp.privateKey,
@@ -73,6 +76,27 @@ export const createOctokitClient = (githubAuth: GitHubAuthSettings): Octokit =>
         authStrategy: createAppAuth,
       })
     : new Octokit({ auth: githubAuth.token });
+
+const createGitHubAppInstallationTokenResolver = (
+  githubApp: GitHubAppAuthSettings,
+): ResolveTerrawizGitHubToken => {
+  const auth = createAppAuth(buildGitHubAppOctokitAuthOptions(githubApp));
+
+  return async () => {
+    const authentication = await auth({ type: "installation" });
+    return authentication.token;
+  };
+};
+
+export const createTerrawizGitHubTokenResolver = (
+  githubAuth: GitHubAuthSettings,
+  createInstallationTokenResolver: (
+    githubApp: GitHubAppAuthSettings,
+  ) => ResolveTerrawizGitHubToken = createGitHubAppInstallationTokenResolver,
+): ResolveTerrawizGitHubToken =>
+  githubAuth.type === "app"
+    ? createInstallationTokenResolver(githubAuth)
+    : async () => githubAuth.token;
 
 /** Resolves DX team members from the configured GitHub team slug. */
 export const resolveDxTeamMembers = async (
@@ -100,11 +124,14 @@ export async function closeImportContext(
 
 export async function createImportContext(
   settings: ImportSettings,
+  runtimeEnvironment: NodeJS.ProcessEnv,
 ): Promise<ImportContext> {
   const { databaseUrl, githubAuth, ...config } = settings;
   const { db, pool } = createDatabaseConnection(databaseUrl);
   const octokit = createOctokitClient(githubAuth);
   const dxTeamMembers = await resolveDxTeamMembers(octokit, config);
+  const resolveTerrawizGitHubToken =
+    createTerrawizGitHubTokenResolver(githubAuth);
 
   const ensureRepo = async (name: string): Promise<number> => {
     const fullName = `${config.organization}/${name}`;
@@ -145,7 +172,9 @@ export async function createImportContext(
     octokit,
     organization: config.organization,
     pool,
+    resolveTerrawizGitHubToken,
     repositories: config.repositories,
+    runtimeEnvironment,
   };
 }
 

--- a/apps/dx-metrics/scripts/lib/importers/__tests__/terraform.test.ts
+++ b/apps/dx-metrics/scripts/lib/importers/__tests__/terraform.test.ts
@@ -1,0 +1,37 @@
+/** This module verifies terrawiz process environment resolution for Terraform imports. */
+
+import { describe, expect, it } from "vitest";
+
+import { createTerrawizEnvironment } from "../terraform.js";
+
+describe("createTerrawizEnvironment", () => {
+  it("adds the resolved token to the terrawiz child-process environment", async () => {
+    const environment = await createTerrawizEnvironment({
+      resolveTerrawizGitHubToken: async () => "ghs_installation_token",
+      runtimeEnvironment: {
+        NODE_ENV: "production",
+        PATH: "/usr/bin",
+      },
+    });
+
+    expect(environment).toEqual({
+      GITHUB_TOKEN: "ghs_installation_token",
+      NODE_ENV: "production",
+      PATH: "/usr/bin",
+    });
+  });
+
+  it("overrides an inherited GitHub token with the terrawiz token", async () => {
+    const environment = await createTerrawizEnvironment({
+      resolveTerrawizGitHubToken: async () => "ghs_installation_token",
+      runtimeEnvironment: {
+        GITHUB_TOKEN: "ghp_legacy_token",
+        NODE_ENV: "production",
+        PATH: "/usr/bin",
+      },
+    });
+
+    expect(environment.GITHUB_TOKEN).toBe("ghs_installation_token");
+    expect(environment.PATH).toBe("/usr/bin");
+  });
+});

--- a/apps/dx-metrics/scripts/lib/importers/terraform.ts
+++ b/apps/dx-metrics/scripts/lib/importers/terraform.ts
@@ -1,15 +1,18 @@
 /** This module imports Terraform module usage and registry release metrics. */
 
-import { execSync } from "child_process";
+import { execFile } from "node:child_process";
+import * as fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { promisify } from "node:util";
 import { sql } from "drizzle-orm";
-import fs from "fs";
-import os from "os";
-import path from "path";
 
 import type { ImportContext } from "../import-context";
 
 import * as schema from "../../../src/db/schema";
 import { sleep } from "../importer-helpers";
+
+const execFileAsync = promisify(execFile);
 
 interface TerraformRegistryModule {
   name: string;
@@ -139,6 +142,18 @@ const sortVersions = (versions: string[]): string[] =>
     );
   });
 
+// terrawiz only supports GITHUB_TOKEN, so GitHub App auth must be translated
+// into a short-lived installation token at the child-process boundary.
+export const createTerrawizEnvironment = async (
+  context: Pick<
+    ImportContext,
+    "resolveTerrawizGitHubToken" | "runtimeEnvironment"
+  >,
+): Promise<NodeJS.ProcessEnv> => ({
+  ...context.runtimeEnvironment,
+  GITHUB_TOKEN: await context.resolveTerrawizGitHubToken(),
+});
+
 export async function importTerraformModules(
   context: ImportContext,
   repoName: string,
@@ -153,27 +168,45 @@ export async function importTerraformModules(
   );
 
   try {
-    execSync(
-      `npx --yes terrawiz scan github:${fullName} -f json -e ${temporaryFilePath}`,
+    await execFileAsync(
+      "npx",
+      [
+        "--yes",
+        "terrawiz",
+        "scan",
+        `github:${fullName}`,
+        "-f",
+        "json",
+        "-e",
+        temporaryFilePath,
+      ],
       {
-        env: { ...process.env },
+        env: await createTerrawizEnvironment(context),
         maxBuffer: 50 * 1024 * 1024,
-        stdio: "pipe",
         timeout: 5 * 60 * 1000,
       },
     );
 
     output = parseTerrawizOutput(
-      JSON.parse(fs.readFileSync(temporaryFilePath, "utf-8")),
+      JSON.parse(await fs.readFile(temporaryFilePath, "utf-8")),
     );
   } catch (error) {
     console.log(`    ⚠ terrawiz failed for ${fullName}: ${error}`);
     return;
   } finally {
     try {
-      fs.unlinkSync(temporaryFilePath);
-    } catch {
-      // Preserve cleanup best-effort behavior for the temporary terrawiz snapshot.
+      await fs.unlink(temporaryFilePath);
+    } catch (error) {
+      if (
+        typeof error !== "object" ||
+        error === null ||
+        !("code" in error) ||
+        error.code !== "ENOENT"
+      ) {
+        console.warn(
+          `    ⚠ Failed to remove temporary terrawiz snapshot ${temporaryFilePath}: ${String(error)}`,
+        );
+      }
     }
   }
 


### PR DESCRIPTION
Improve the handling of GitHub App tokens by generating a short-lived installation access token for terrawiz, eliminating the need for a separate GITHUB_TOKEN. Add tests to ensure proper environment resolution for terrawiz imports.