### PR TITLE
Upgrade Container App module version constraints

### DIFF
--- a/.nx/version-plans/version-plan-1778685649326.md
+++ b/.nx/version-plans/version-plan-1778685649326.md
@@ -1,0 +1,5 @@
+---
+azure_container_app: major
+---
+
+Bump minor version constraints

--- a/infra/modules/azure_container_app/README.md
+++ b/infra/modules/azure_container_app/README.md
@@ -132,10 +132,10 @@ A complete usage example can be found in the [example/complete](https://github.c
 
 | Name | Version |
 |------|---------|
-| <a name="requirement_azapi"></a> [azapi](#requirement\_azapi) | >= 2.0 |
-| <a name="requirement_azurerm"></a> [azurerm](#requirement\_azurerm) | >= 4.16.0, < 5.0 |
-| <a name="requirement_dx"></a> [dx](#requirement\_dx) | >= 0.0.6, < 1.0.0 |
-| <a name="requirement_time"></a> [time](#requirement\_time) | >= 0.9 |
+| <a name="requirement_azapi"></a> [azapi](#requirement\_azapi) | ~> 2.9 |
+| <a name="requirement_azurerm"></a> [azurerm](#requirement\_azurerm) | ~> 4.70 |
+| <a name="requirement_dx"></a> [dx](#requirement\_dx) | ~> 0.10 |
+| <a name="requirement_time"></a> [time](#requirement\_time) | ~> 0.14 |
 
 ## Modules
 

--- a/infra/modules/azure_container_app/README.md
+++ b/infra/modules/azure_container_app/README.md
@@ -132,6 +132,7 @@ A complete usage example can be found in the [example/complete](https://github.c
 
 | Name | Version |
 |------|---------|
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.14.0 |
 | <a name="requirement_azapi"></a> [azapi](#requirement\_azapi) | ~> 2.9 |
 | <a name="requirement_azurerm"></a> [azurerm](#requirement\_azurerm) | ~> 4.70 |
 | <a name="requirement_dx"></a> [dx](#requirement\_dx) | ~> 0.10 |

--- a/infra/modules/azure_container_app/examples/complete/README.md
+++ b/infra/modules/azure_container_app/examples/complete/README.md
@@ -6,7 +6,7 @@
 | Name | Version |
 |------|---------|
 | <a name="requirement_azurerm"></a> [azurerm](#requirement\_azurerm) | ~> 4.0 |
-| <a name="requirement_dx"></a> [dx](#requirement\_dx) | >= 0.0.6, < 1.0.0 |
+| <a name="requirement_dx"></a> [dx](#requirement\_dx) | ~> 0.10 |
 
 ## Modules
 

--- a/infra/modules/azure_container_app/examples/complete/versions.tf
+++ b/infra/modules/azure_container_app/examples/complete/versions.tf
@@ -14,7 +14,7 @@ terraform {
     }
     dx = {
       source  = "pagopa-dx/azure"
-      version = ">= 0.0.6, < 1.0.0"
+      version = "~> 0.10"
     }
   }
 }

--- a/infra/modules/azure_container_app/providers.tf
+++ b/infra/modules/azure_container_app/providers.tf
@@ -1,4 +1,5 @@
 terraform {
+  required_version = ">= 1.14.0"
   required_providers {
     azurerm = {
       source  = "hashicorp/azurerm"

--- a/infra/modules/azure_container_app/providers.tf
+++ b/infra/modules/azure_container_app/providers.tf
@@ -2,19 +2,19 @@ terraform {
   required_providers {
     azurerm = {
       source  = "hashicorp/azurerm"
-      version = ">= 4.16.0, < 5.0"
+      version = "~> 4.70"
     }
     azapi = {
       source  = "azure/azapi"
-      version = ">= 2.0"
+      version = "~> 2.9"
     }
     dx = {
       source  = "pagopa-dx/azure"
-      version = ">= 0.0.6, < 1.0.0"
+      version = "~> 0.10"
     }
     time = {
       source  = "hashicorp/time"
-      version = ">= 0.9"
+      version = "~> 0.14"
     }
   }
 }

--- a/infra/modules/azure_container_app/tests/setup/README.md
+++ b/infra/modules/azure_container_app/tests/setup/README.md
@@ -5,9 +5,9 @@
 
 | Name | Version |
 |------|---------|
-| <a name="requirement_azurerm"></a> [azurerm](#requirement\_azurerm) | >= 4.16.0, < 5.0 |
-| <a name="requirement_dx"></a> [dx](#requirement\_dx) | >= 0.0.6, < 1.0.0 |
-| <a name="requirement_random"></a> [random](#requirement\_random) | >= 3.7 |
+| <a name="requirement_azurerm"></a> [azurerm](#requirement\_azurerm) | ~> 4.70 |
+| <a name="requirement_dx"></a> [dx](#requirement\_dx) | ~> 0.10 |
+| <a name="requirement_random"></a> [random](#requirement\_random) | >= 3.9 |
 
 ## Modules
 

--- a/infra/modules/azure_container_app/tests/setup/providers.tf
+++ b/infra/modules/azure_container_app/tests/setup/providers.tf
@@ -2,15 +2,15 @@ terraform {
   required_providers {
     azurerm = {
       source  = "hashicorp/azurerm"
-      version = ">= 4.16.0, < 5.0"
+      version = "~> 4.70"
     }
     dx = {
       source  = "pagopa-dx/azure"
-      version = ">= 0.0.6, < 1.0.0"
+      version = "~> 0.10"
     }
     random = {
       source  = "hashicorp/random"
-      version = ">= 3.7"
+      version = ">= 3.9"
     }
   }
 }


### PR DESCRIPTION
This pull request updates the version constraints for several Terraform providers used in the `azure_container_app` module and its examples/tests.
**Provider version constraint updates:**

* Updated `azurerm` provider to require version `~> 4.70` across the main module, examples, and tests, replacing previous broader constraints.
* Updated `azapi` provider to require version `~> 2.9` in the main module.
* Updated `dx` provider to require version `~> 0.10` throughout the module, examples, and tests.
* Updated `time` provider to require version `~> 0.14` in the main module.
* Updated `random` provider to require version `>= 3.9` in the test setup.

Close CES-2049
