### PR TITLE
Add custom Trivy rule to prevent Key Vault data source usage

### DIFF
--- a/.github/workflows/static_analysis.yaml
+++ b/.github/workflows/static_analysis.yaml
@@ -126,9 +126,11 @@ jobs:
             --config-check .dx-security/.trivy/checks/terraform \
             --check-namespaces user \
             --severity MEDIUM,HIGH,CRITICAL \
-            --exit-code 0 > /tmp/trivy-output.log 2>&1 || true
+            --format json \
+            --skip-version-check \
+            --exit-code 0 > /tmp/trivy-output.json || true
 
-          cat /tmp/trivy-output.log
+          cat /tmp/trivy-output.json
 
       - name: Run pre-commit on specific folders
         if: ${{ inputs.folder != '' }}
@@ -342,22 +344,26 @@ jobs:
           fi
 
           # Trivy custom policies output
-          if [ -f "/tmp/trivy-output.log" ] && grep -q "Failures:" /tmp/trivy-output.log; then
+          if [ -f "/tmp/trivy-output.json" ] && jq -e '[.Results[]? | .Misconfigurations[]?] | length > 0' /tmp/trivy-output.json > /dev/null 2>&1; then
             add_markdown \
               '> [!WARNING]' \
               '> ### ⚠️ Trivy detected forbidden Terraform patterns' \
               '>' \
               '> The following findings must be resolved before this check becomes enforced.' \
               ''
-            add_markdown \
-              '<details>' \
-              '<summary>🔍 Trivy Findings</summary>' \
-              '' \
-              '```'
-            TRIVY_CLEAN=$(sed 's/\x1b\[[0-9;]*m//g' /tmp/trivy-output.log)
-            echo "$TRIVY_CLEAN" >> "$GITHUB_STEP_SUMMARY"
-            echo "$TRIVY_CLEAN" >> "$SUMMARY_FILE"
-            add_markdown '```' '</details>' ''
+
+            TRIVY_TABLE=$(jq -r '
+              ["| Severity | ID | File | Line | Title |",
+               "|----------|----|------|------|-------|"] +
+              [.Results[] |
+                .Target as $target |
+                .Misconfigurations[]? |
+                "| " + .Severity + " | " + .AVDID + " | `" + $target + "` | L" + (.CauseMetadata.StartLine | tostring) + " | " + .Title + " |"
+              ] | .[]' /tmp/trivy-output.json)
+
+            echo "$TRIVY_TABLE" >> "$GITHUB_STEP_SUMMARY"
+            echo "$TRIVY_TABLE" >> "$SUMMARY_FILE"
+            add_to_summary ''
           fi
 
           # Pre-commit output

--- a/.github/workflows/static_analysis.yaml
+++ b/.github/workflows/static_analysis.yaml
@@ -126,7 +126,9 @@ jobs:
             --config-check .dx-security/.trivy/checks/terraform \
             --check-namespaces user \
             --severity MEDIUM,HIGH,CRITICAL \
-            --exit-code 0 2>&1 | tee /tmp/trivy-output.log
+            --exit-code 0 > /tmp/trivy-output.log 2>&1 || true
+
+          cat /tmp/trivy-output.log
 
       - name: Run pre-commit on specific folders
         if: ${{ inputs.folder != '' }}
@@ -315,11 +317,16 @@ jobs:
                 "|--------|--------|---------|------|"
 
               # Add module details or show error
-              jq -r '.results[] | "| " + .module + " | " + .status + " | " + .version + " | " + (.path // "N/A") + " |"' lock_output.json >> "$GITHUB_STEP_SUMMARY" >> "$SUMMARY_FILE" || {
+              JQ_OUT=$(jq -r '.results[] | "| " + .module + " | " + .status + " | " + .version + " | " + (.path // "N/A") + " |"' lock_output.json) && {
+                echo "$JQ_OUT" >> "$GITHUB_STEP_SUMMARY"
+                echo "$JQ_OUT" >> "$SUMMARY_FILE"
+              } || {
                 add_markdown \
                   "Error processing JSON file. Raw content:" \
                   "\`\`\`json"
-                cat lock_output.json >> "$GITHUB_STEP_SUMMARY" >> "$SUMMARY_FILE"
+                CAT_OUT=$(cat lock_output.json)
+                echo "$CAT_OUT" >> "$GITHUB_STEP_SUMMARY"
+                echo "$CAT_OUT" >> "$SUMMARY_FILE"
                 add_to_summary "\`\`\`"
               }
               add_to_summary "</details>"
@@ -335,7 +342,7 @@ jobs:
           fi
 
           # Trivy custom policies output
-          if [ -f "/tmp/trivy-output.log" ]; then
+          if [ -f "/tmp/trivy-output.log" ] && grep -q "Failures:" /tmp/trivy-output.log; then
             add_markdown \
               '> [!WARNING]' \
               '> ### ⚠️ Trivy detected forbidden Terraform patterns' \
@@ -347,7 +354,9 @@ jobs:
               '<summary>🔍 Trivy Findings</summary>' \
               '' \
               '```'
-            sed 's/\x1b\[[0-9;]*m//g' /tmp/trivy-output.log >> "$GITHUB_STEP_SUMMARY" >> "$SUMMARY_FILE"
+            TRIVY_CLEAN=$(sed 's/\x1b\[[0-9;]*m//g' /tmp/trivy-output.log)
+            echo "$TRIVY_CLEAN" >> "$GITHUB_STEP_SUMMARY"
+            echo "$TRIVY_CLEAN" >> "$SUMMARY_FILE"
             add_markdown '```' '</details>' ''
           fi
 
@@ -359,7 +368,9 @@ jobs:
               '<summary>📋 Pre-commit Output Log</summary>' \
               '' \
               '```'
-            sed 's/\x1b\[[0-9;]*m//g' /tmp/pre-commit-output.log >> "$GITHUB_STEP_SUMMARY" >> "$SUMMARY_FILE"
+            PRECOMMIT_CLEAN=$(sed 's/\x1b\[[0-9;]*m//g' /tmp/pre-commit-output.log)
+            echo "$PRECOMMIT_CLEAN" >> "$GITHUB_STEP_SUMMARY"
+            echo "$PRECOMMIT_CLEAN" >> "$SUMMARY_FILE"
             add_markdown '```' '</details>'
           else
             add_to_summary "⚠️ No pre-commit output found. Check if pre-commit was executed."

--- a/.github/workflows/static_analysis.yaml
+++ b/.github/workflows/static_analysis.yaml
@@ -116,10 +116,6 @@ jobs:
         run: |
           set -eu
 
-          pwd
-
-          ls
-
           trivy config "./" \
             --misconfig-scanners terraform \
             --raw-config-scanners terraform \

--- a/.github/workflows/static_analysis.yaml
+++ b/.github/workflows/static_analysis.yaml
@@ -117,6 +117,10 @@ jobs:
         run: |
           set -eu
 
+          pwd
+
+          ls
+
           trivy config "./" \
             --misconfig-scanners terraform \
             --raw-config-scanners terraform \

--- a/.github/workflows/static_analysis.yaml
+++ b/.github/workflows/static_analysis.yaml
@@ -73,7 +73,6 @@ jobs:
     name: Terraform Validation
     runs-on: ubuntu-latest
     needs: [get-versions]
-    # Ensures execution even if get-versions is skipped
     if: ${{ always() }}
     env:
       TERRAFORM_VERSION: ${{ inputs.terraform_version || needs.get-versions.outputs.terraform_version }}
@@ -117,6 +116,7 @@ jobs:
           set -eu
 
           trivy config "./" \
+            --disable-telemetry \
             --misconfig-scanners terraform \
             --raw-config-scanners terraform \
             --skip-dirs "**/.terraform" \
@@ -125,8 +125,8 @@ jobs:
             --tf-exclude-downloaded-modules \
             --config-check .dx-security/.trivy/checks/terraform \
             --check-namespaces user \
-            --severity HIGH \
-            --exit-code 1
+            --severity MEDIUM,HIGH,CRITICAL \
+            --exit-code 0 2>&1 | tee /tmp/trivy-output.log
 
       - name: Run pre-commit on specific folders
         if: ${{ inputs.folder != '' }}
@@ -332,6 +332,23 @@ jobs:
                 ""
             fi
             add_to_summary ""
+          fi
+
+          # Trivy custom policies output
+          if [ -f "/tmp/trivy-output.log" ]; then
+            add_markdown \
+              '> [!WARNING]' \
+              '> ### ⚠️ Trivy detected forbidden Terraform patterns' \
+              '>' \
+              '> The following findings must be resolved before this check becomes enforced.' \
+              ''
+            add_markdown \
+              '<details>' \
+              '<summary>🔍 Trivy Findings</summary>' \
+              '' \
+              '```'
+            sed 's/\x1b\[[0-9;]*m//g' /tmp/trivy-output.log >> "$GITHUB_STEP_SUMMARY" >> "$SUMMARY_FILE"
+            add_markdown '```' '</details>' ''
           fi
 
           # Pre-commit output

--- a/.github/workflows/static_analysis.yaml
+++ b/.github/workflows/static_analysis.yaml
@@ -92,11 +92,10 @@ jobs:
 
       - name: Checkout DX Trivy policies
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-        if: ${{ github.repository != 'pagopa/dx' }}
         with:
           repository: pagopa/dx
-          ref: ${{ inputs.dx_policies_ref }}
-          path: ./
+          ref: ${{ github.repository == 'pagopa/dx' && github.sha || inputs.dx_policies_ref }}
+          path: .dx-security
           sparse-checkout: |
             .trivy/checks/terraform
           sparse-checkout-cone-mode: false
@@ -128,7 +127,7 @@ jobs:
             --skip-dirs "**/tests/**" \
             --ignorefile .trivyignore \
             --tf-exclude-downloaded-modules \
-            --config-check ./.trivy/checks/terraform \
+            --config-check .dx-security/.trivy/checks/terraform \
             --check-namespaces user \
             --severity HIGH \
             --exit-code 1

--- a/.github/workflows/static_analysis.yaml
+++ b/.github/workflows/static_analysis.yaml
@@ -27,6 +27,11 @@ on:
         description: If set, it runs the pre-commit on a single folder. Otherwise, it is run on all files.
         type: string
         required: false
+      dx_policies_ref:
+        description: Git ref used to fetch centralized DX Trivy custom policies.
+        type: string
+        required: false
+        default: main
       verbose:
         description: If enabled, it prints the verbose logging of pre-commit checks
         type: boolean
@@ -85,6 +90,17 @@ jobs:
           fetch-depth: 0
           ref: ${{ github.sha }}
 
+      - name: Checkout DX Trivy policies
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        if: ${{ github.repository != 'pagopa/dx' }}
+        with:
+          repository: pagopa/dx
+          ref: ${{ inputs.dx_policies_ref }}
+          path: ./
+          sparse-checkout: |
+            .trivy/checks/terraform
+          sparse-checkout-cone-mode: false
+
       - name: Git config
         run: |
           set -eu
@@ -96,6 +112,23 @@ jobs:
         run: |
           apk --no-cache add tar
           python -m pip freeze --local
+
+      - name: Run Trivy custom policies
+        working-directory: ${{ inputs.folder }}
+        run: |
+          set -eu
+
+          trivy config "./" \
+            --misconfig-scanners terraform \
+            --raw-config-scanners terraform \
+            --skip-dirs "**/.terraform" \
+            --skip-dirs "**/tests/**" \
+            --ignorefile .trivyignore \
+            --tf-exclude-downloaded-modules \
+            --config-check ./.trivy/checks/terraform \
+            --check-namespaces user \
+            --severity HIGH \
+            --exit-code 1
 
       - name: Run pre-commit on specific folders
         if: ${{ inputs.folder != '' }}

--- a/.github/workflows/static_analysis.yaml
+++ b/.github/workflows/static_analysis.yaml
@@ -114,7 +114,6 @@ jobs:
           python -m pip freeze --local
 
       - name: Run Trivy custom policies
-        working-directory: ${{ inputs.folder }}
         run: |
           set -eu
 

--- a/.github/workflows/static_analysis.yaml
+++ b/.github/workflows/static_analysis.yaml
@@ -27,11 +27,6 @@ on:
         description: If set, it runs the pre-commit on a single folder. Otherwise, it is run on all files.
         type: string
         required: false
-      dx_policies_ref:
-        description: Git ref used to fetch centralized DX Trivy custom policies.
-        type: string
-        required: false
-        default: main
       verbose:
         description: If enabled, it prints the verbose logging of pre-commit checks
         type: boolean
@@ -93,7 +88,7 @@ jobs:
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           repository: pagopa/dx
-          ref: ${{ github.repository == 'pagopa/dx' && github.sha || inputs.dx_policies_ref }}
+          ref: main
           path: .dx-security
           sparse-checkout: |
             .trivy/checks/terraform

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -54,5 +54,8 @@ repos:
           - --args=--skip-dirs="**/.terraform"
           - --args=--skip-dirs="**/tests/apps/network_access"
           - --args=--ignorefile=__GIT_WORKING_DIR__/.trivyignore
+          - --args=--config-check=__GIT_WORKING_DIR__/.trivy/checks/terraform
+          - --args=--check-namespaces=user
+          - --args=--raw-config-scanners=terraform
           - --args=--tf-exclude-downloaded-modules
           - --hook-config=--parallelism-limit=1


### PR DESCRIPTION
Implement a custom Trivy rule that denies the use of Key Vault secrets via data sources in Terraform configurations. Update the workflow to include this new rule and ensure proper execution of Trivy checks.

Depends on #1780
Close CES-2004