### PR TITLE
Deploy dx-metrics web image

### DIFF
--- a/.github/workflows/_release-docker-dx-metrics-v1.yaml
+++ b/.github/workflows/_release-docker-dx-metrics-v1.yaml
@@ -7,6 +7,8 @@ on:
       - main
     paths:
       - "apps/dx-metrics/package.json"
+      - ".github/workflows/_release-docker-dx-metrics-v1.yaml"
+      - ".github/workflows/release-azure-containerapp-v1.yaml"
 
 permissions:
   contents: read
@@ -26,6 +28,7 @@ jobs:
     with:
       dockerfile_path: ./apps/dx-metrics/Dockerfile
       dockerfile_context: .
+      build_target: runner
       docker_image_name: pagopa/dx-metrics
       docker_image_description: "DX Metrics is a monitoring and analytics service for the PagoPA Developer Experience (DX) team, providing insights into development experience."
       container_app: dx-p-itn-metrics-portal-ca-01

--- a/.github/workflows/release-azure-containerapp-v1.yaml
+++ b/.github/workflows/release-azure-containerapp-v1.yaml
@@ -25,8 +25,13 @@ on:
         required: false
         default: PagoPA
         description: Authors names to use as image label
+      build_target:
+        type: string
+        required: false
+        description: Optional Docker build target for multi-stage Dockerfiles
       build_args:
-        description: List of build arguments to use for Dockerfile build, given in
+        description:
+          List of build arguments to use for Dockerfile build, given in
           env=value format.
         type: string
         required: false
@@ -80,6 +85,7 @@ jobs:
           docker_image_name: ${{ env.IMAGE_NAME }}
           docker_image_description: "${{ inputs.docker_image_description }}"
           docker_image_authors: ${{ inputs.docker_image_authors }}
+          build_target: ${{ inputs.build_target }}
           build_args: ${{ inputs.build_args }}
           build_platforms: ${{ inputs.build_platforms }}
           push_to_registry: true
@@ -263,7 +269,8 @@ jobs:
             --revision "$CURRENT_REVISION_NAME"
 
       - name: Deactivate New Revision
-        if: ${{ failure() && steps.get_revision_mode.outputs.revision_mode == 'Multiple'
+        if:
+          ${{ failure() && steps.get_revision_mode.outputs.revision_mode == 'Multiple'
           }}
         env:
           CURRENT_REVISION_NAME: ${{ steps.get_current_revision.outputs.current_revision_name }}


### PR DESCRIPTION
## Why
The DX Metrics Container App was building the last stage from a multi-stage Dockerfile. Because the final stage is `import-runner`, the deployed revision started `dist/import.mjs` instead of the Next.js server and failed on GitHub authentication.

## What changed
- add an optional `build_target` input to the reusable Container App release workflow
- make the DX Metrics deploy workflow build the `runner` stage explicitly
- trigger the DX Metrics deploy workflow when the relevant workflow files change