### PR TITLE
Update configure-aws-credentials to Node 24

### DIFF
--- a/.nx/version-plans/version-plan-1778748859367.md
+++ b/.nx/version-plans/version-plan-1778748859367.md
@@ -1,0 +1,5 @@
+---
+csp-login: patch
+---
+
+Update configure-aws-credentials from v4.0.2 to v6.1.1 (Node 24)

--- a/actions/csp-login/action.yaml
+++ b/actions/csp-login/action.yaml
@@ -23,7 +23,7 @@ runs:
 
     - name: AWS Login
       if: env.ROLE_ARN
-      uses: aws-actions/configure-aws-credentials@e3dd6a429d7300a6a4c196c26e071d42e0343502 # v4.0.2
+      uses: aws-actions/configure-aws-credentials@d979d5b3a71173a29b74b5b88418bfda9437d885 # v6.1.1
       with:
         role-to-assume: ${{ env.ROLE_ARN }}
         aws-region: ${{ env.AWS_REGION && env.AWS_REGION || 'eu-south-1' }}


### PR DESCRIPTION
## Summary

Bump `aws-actions/configure-aws-credentials` from `v4.0.2` to `v6.1.1` in the `csp-login` composite action.

The v6.0.0 release migrated the action runtime from Node 20 to Node 24. No input API changes affect the `csp-login` action's current usage (`role-to-assume` and `aws-region`).

Resolves CES-2018