### PR TITLE
Reduce Drift Detection slack messages

### DIFF
--- a/.github/workflows/_cron-terraform-drift-detection.yaml
+++ b/.github/workflows/_cron-terraform-drift-detection.yaml
@@ -3,25 +3,9 @@ name: Drift Detection
 on:
   workflow_dispatch:
   schedule:
-    - cron: "00 08 * * *" # Run at 08:00 every day
+    - cron: "00 08 * * 1-5" # Run at 08:00 Monday through Friday
 
 jobs:
-  drift_detection_dev:
-    uses: ./.github/workflows/infra_drift_detection.yml
-    name: Drift Detection - DEV
-    permissions:
-      contents: read
-      actions: read
-      id-token: write
-    secrets: inherit
-    with:
-      environment: "dev"
-      override_github_environment: "infra-dev"
-      base_path: "infra/resources"
-      use_private_agent: true
-      use_labels: true
-      override_labels: "dev"
-
   drift_detection_prod:
     uses: ./.github/workflows/infra_drift_detection.yml
     name: Drift Detection - PROD


### PR DESCRIPTION
In this PR, the drift detection cron job has been updated to run only from Monday to Friday, and the check in DEV has been removed.
This will help reduce the overall volume of Slack notifications.

Resolves: CES-2056