### PR TITLE
Upgrade Slack GitHub Action version

### DIFF
--- a/.github/actions/slack-notification/action.yaml
+++ b/.github/actions/slack-notification/action.yaml
@@ -35,9 +35,8 @@ runs:
 
         echo "title=$title" >> "$GITHUB_OUTPUT"
 
-    # Reference: https://github.com/slackapi/slack-github-action
     - name: Slack Notification
-      uses: slackapi/slack-github-action@91efab103c0de0a537f72a35f6b8cda0ee76bf0a # v2.1.1
+      uses: slackapi/slack-github-action@45a88b9581bfab2566dc881e2cd66d334e621e2c # v3.0.3
       with:
         webhook: ${{ inputs.slack_webhook_url }}
         webhook-type: incoming-webhook


### PR DESCRIPTION
Update the Slack GitHub Action to the latest version.

Close CES-2057