### PR TITLE
Custom VNet setup for CAEs integration tests

### DIFF
--- a/infra/modules/azure_container_app_environment/tests/integration.tftest.hcl
+++ b/infra/modules/azure_container_app_environment/tests/integration.tftest.hcl
@@ -39,6 +39,7 @@ run "setup" {
 
   variables {
     environment = var.environment
+    tags        = var.tags
     test_kind   = var.test_kind
   }
 }

--- a/infra/modules/azure_container_app_environment/tests/setup/README.md
+++ b/infra/modules/azure_container_app_environment/tests/setup/README.md
@@ -23,7 +23,7 @@ No modules.
 | [azurerm_private_dns_zone_virtual_network_link.container_apps](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/private_dns_zone_virtual_network_link) | resource |
 | [azurerm_subnet.pep](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/subnet) | resource |
 | [azurerm_virtual_network.this](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/virtual_network) | resource |
-| [dx_available_subnet_cidr.pip_subnet](https://registry.terraform.io/providers/pagopa-dx/azure/latest/docs/resources/available_subnet_cidr) | resource |
+| [dx_available_subnet_cidr.pep_subnet](https://registry.terraform.io/providers/pagopa-dx/azure/latest/docs/resources/available_subnet_cidr) | resource |
 | [azurerm_log_analytics_workspace.logs](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/data-sources/log_analytics_workspace) | data source |
 | [azurerm_private_dns_zone.container_apps](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/data-sources/private_dns_zone) | data source |
 | [azurerm_resource_group.network](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/data-sources/resource_group) | data source |

--- a/infra/modules/azure_container_app_environment/tests/setup/README.md
+++ b/infra/modules/azure_container_app_environment/tests/setup/README.md
@@ -20,17 +20,21 @@ No modules.
 
 | Name | Type |
 |------|------|
-| [azurerm_client_config.current](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/data-sources/client_config) | data source |
+| [azurerm_private_dns_zone_virtual_network_link.container_apps](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/private_dns_zone_virtual_network_link) | resource |
+| [azurerm_subnet.pep](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/subnet) | resource |
+| [azurerm_virtual_network.this](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/virtual_network) | resource |
+| [dx_available_subnet_cidr.pip_subnet](https://registry.terraform.io/providers/pagopa-dx/azure/latest/docs/resources/available_subnet_cidr) | resource |
 | [azurerm_log_analytics_workspace.logs](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/data-sources/log_analytics_workspace) | data source |
+| [azurerm_private_dns_zone.container_apps](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/data-sources/private_dns_zone) | data source |
 | [azurerm_resource_group.network](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/data-sources/resource_group) | data source |
 | [azurerm_resource_group.test](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/data-sources/resource_group) | data source |
-| [azurerm_virtual_network.vnet](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/data-sources/virtual_network) | data source |
 
 ## Inputs
 
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
 | <a name="input_environment"></a> [environment](#input\_environment) | n/a | <pre>object({<br/>    prefix          = string<br/>    env_short       = string<br/>    location        = string<br/>    domain          = optional(string)<br/>    app_name        = string<br/>    instance_number = string<br/>  })</pre> | n/a | yes |
+| <a name="input_tags"></a> [tags](#input\_tags) | Tags to apply to setup resources | `map(string)` | n/a | yes |
 | <a name="input_test_kind"></a> [test\_kind](#input\_test\_kind) | Test type: must be 'integration' (setup module is not used by e2e tests) | `string` | n/a | yes |
 
 ## Outputs
@@ -40,6 +44,5 @@ No modules.
 | <a name="output_log_analytics_workspace_id"></a> [log\_analytics\_workspace\_id](#output\_log\_analytics\_workspace\_id) | n/a |
 | <a name="output_network_resource_group_name"></a> [network\_resource\_group\_name](#output\_network\_resource\_group\_name) | n/a |
 | <a name="output_resource_group_name"></a> [resource\_group\_name](#output\_resource\_group\_name) | n/a |
-| <a name="output_subscription_id"></a> [subscription\_id](#output\_subscription\_id) | n/a |
 | <a name="output_vnet_id"></a> [vnet\_id](#output\_vnet\_id) | n/a |
 <!-- END_TF_DOCS -->

--- a/infra/modules/azure_container_app_environment/tests/setup/main.tf
+++ b/infra/modules/azure_container_app_environment/tests/setup/main.tf
@@ -34,7 +34,7 @@ resource "dx_available_subnet_cidr" "pep_subnet" {
 }
 
 resource "azurerm_subnet" "pep" {
-  name                 = provider::dx::resource_name(merge(var.environment, { resource_type = "subnet", app_name = "caem-pep" }))
+  name                 = provider::dx::resource_name(merge(var.environment, { domain = "", resource_type = "subnet", app_name = "pep" }))
   resource_group_name  = data.azurerm_resource_group.test.name
   virtual_network_name = azurerm_virtual_network.this.name
   address_prefixes     = [dx_available_subnet_cidr.pep_subnet.cidr_block]

--- a/infra/modules/azure_container_app_environment/tests/setup/main.tf
+++ b/infra/modules/azure_container_app_environment/tests/setup/main.tf
@@ -30,7 +30,7 @@ resource "azurerm_virtual_network" "this" {
 
 resource "dx_available_subnet_cidr" "pep_subnet" {
   virtual_network_id = azurerm_virtual_network.this.id
-  prefix_length      = "27"
+  prefix_length      = 27
 }
 
 resource "azurerm_subnet" "pep" {

--- a/infra/modules/azure_container_app_environment/tests/setup/main.tf
+++ b/infra/modules/azure_container_app_environment/tests/setup/main.tf
@@ -28,17 +28,16 @@ resource "azurerm_virtual_network" "this" {
   tags = var.tags
 }
 
-resource "dx_available_subnet_cidr" "pip_subnet" {
+resource "dx_available_subnet_cidr" "pep_subnet" {
   virtual_network_id = azurerm_virtual_network.this.id
   prefix_length      = "27"
 }
-
 
 resource "azurerm_subnet" "pep" {
   name                 = provider::dx::resource_name(merge(var.environment, { resource_type = "subnet", app_name = "pep" }))
   resource_group_name  = data.azurerm_resource_group.test.name
   virtual_network_name = azurerm_virtual_network.this.name
-  address_prefixes     = [dx_available_subnet_cidr.pip_subnet.cidr_block]
+  address_prefixes     = [dx_available_subnet_cidr.pep_subnet.cidr_block]
 }
 
 data "azurerm_private_dns_zone" "container_apps" {

--- a/infra/modules/azure_container_app_environment/tests/setup/main.tf
+++ b/infra/modules/azure_container_app_environment/tests/setup/main.tf
@@ -34,7 +34,7 @@ resource "dx_available_subnet_cidr" "pep_subnet" {
 }
 
 resource "azurerm_subnet" "pep" {
-  name                 = provider::dx::resource_name(merge(var.environment, { resource_type = "subnet", app_name = "pep" }))
+  name                 = provider::dx::resource_name(merge(var.environment, { resource_type = "subnet", app_name = "caem-pep" }))
   resource_group_name  = data.azurerm_resource_group.test.name
   virtual_network_name = azurerm_virtual_network.this.name
   address_prefixes     = [dx_available_subnet_cidr.pep_subnet.cidr_block]

--- a/infra/modules/azure_container_app_environment/tests/setup/main.tf
+++ b/infra/modules/azure_container_app_environment/tests/setup/main.tf
@@ -7,9 +7,9 @@ locals {
     name            = var.test_kind
     instance_number = tonumber(var.environment.instance_number)
   }
-}
 
-data "azurerm_client_config" "current" {}
+  vnet_address_space = "10.0.0.0/21"
+}
 
 data "azurerm_resource_group" "test" {
   name = provider::dx::resource_name(merge(local.existing_resources, { resource_type = "resource_group" }))
@@ -19,18 +19,46 @@ data "azurerm_resource_group" "network" {
   name = provider::dx::resource_name(merge(local.existing_resources, { resource_type = "resource_group", name = "network" }))
 }
 
-data "azurerm_virtual_network" "vnet" {
-  name                = provider::dx::resource_name(merge(local.existing_resources, { resource_type = "virtual_network" }))
+resource "azurerm_virtual_network" "this" {
+  name                = provider::dx::resource_name(merge(var.environment, { resource_type = "virtual_network" }))
+  location            = data.azurerm_resource_group.test.location
   resource_group_name = data.azurerm_resource_group.test.name
+  address_space       = [local.vnet_address_space]
+
+  tags = var.tags
+}
+
+resource "dx_available_subnet_cidr" "pip_subnet" {
+  virtual_network_id = azurerm_virtual_network.this.id
+  prefix_length      = "27"
+}
+
+
+resource "azurerm_subnet" "pep" {
+  name                 = provider::dx::resource_name(merge(var.environment, { resource_type = "subnet", app_name = "pep" }))
+  resource_group_name  = data.azurerm_resource_group.test.name
+  virtual_network_name = azurerm_virtual_network.this.name
+  address_prefixes     = [dx_available_subnet_cidr.pip_subnet.cidr_block]
+}
+
+data "azurerm_private_dns_zone" "container_apps" {
+  name                = "privatelink.${var.environment.location}.azurecontainerapps.io"
+  resource_group_name = data.azurerm_resource_group.network.name
+}
+
+resource "azurerm_private_dns_zone_virtual_network_link" "container_apps" {
+  name                  = azurerm_virtual_network.this.name
+  resource_group_name   = data.azurerm_resource_group.network.name
+  private_dns_zone_name = data.azurerm_private_dns_zone.container_apps.name
+  virtual_network_id    = azurerm_virtual_network.this.id
+  registration_enabled  = false
+
+  tags = var.tags
 }
 
 data "azurerm_log_analytics_workspace" "logs" {
   name                = provider::dx::resource_name(merge(local.existing_resources, { resource_type = "log_analytics" }))
   resource_group_name = data.azurerm_resource_group.test.name
-}
-
-output "subscription_id" {
-  value = data.azurerm_client_config.current.subscription_id
 }
 
 output "resource_group_name" {
@@ -42,7 +70,7 @@ output "network_resource_group_name" {
 }
 
 output "vnet_id" {
-  value = data.azurerm_virtual_network.vnet.id
+  value = azurerm_virtual_network.this.id
 }
 
 output "log_analytics_workspace_id" {

--- a/infra/modules/azure_container_app_environment/tests/setup/variables.tf
+++ b/infra/modules/azure_container_app_environment/tests/setup/variables.tf
@@ -9,6 +9,11 @@ variable "environment" {
   })
 }
 
+variable "tags" {
+  type        = map(string)
+  description = "Tags to apply to setup resources"
+}
+
 variable "test_kind" {
   type        = string
   description = "Test type: must be 'integration' (setup module is not used by e2e tests)"

--- a/infra/modules/github_selfhosted_runner_on_container_app_jobs/tests/integration.tftest.hcl
+++ b/infra/modules/github_selfhosted_runner_on_container_app_jobs/tests/integration.tftest.hcl
@@ -10,6 +10,7 @@ variables {
     env_short       = "d"
     location        = "italynorth"
     domain          = "int"
+    app_name        = "ghr"
     instance_number = "01"
   }
 
@@ -57,7 +58,7 @@ run "apply_pat_auth_rbac" {
 
     key_vault = {
       name                = run.setup.key_vault_name
-      resource_group_name = run.setup.key_vault_resource_group_name
+      resource_group_name = run.setup.resource_group_name
       use_rbac            = true
     }
   }
@@ -118,7 +119,7 @@ run "apply_github_app_auth" {
 
     key_vault = {
       name                = run.setup.key_vault_name
-      resource_group_name = run.setup.key_vault_resource_group_name
+      resource_group_name = run.setup.resource_group_name
       use_rbac            = true
     }
 

--- a/infra/modules/github_selfhosted_runner_on_container_app_jobs/tests/setup/README.md
+++ b/infra/modules/github_selfhosted_runner_on_container_app_jobs/tests/setup/README.md
@@ -43,7 +43,7 @@ No modules.
 
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
-| <a name="input_environment"></a> [environment](#input\_environment) | n/a | <pre>object({<br/>    prefix          = string<br/>    env_short       = string<br/>    location        = string<br/>    domain          = optional(string)<br/>    instance_number = string<br/>  })</pre> | n/a | yes |
+| <a name="input_environment"></a> [environment](#input\_environment) | n/a | <pre>object({<br/>    prefix          = string<br/>    env_short       = string<br/>    location        = string<br/>    app_name        = optional(string)<br/>    domain          = optional(string)<br/>    instance_number = string<br/>  })</pre> | n/a | yes |
 | <a name="input_tags"></a> [tags](#input\_tags) | Tags to apply to setup resources | `map(string)` | n/a | yes |
 | <a name="input_test_kind"></a> [test\_kind](#input\_test\_kind) | Test type: must be 'integration' (setup module is not used by e2e tests) | `string` | n/a | yes |
 

--- a/infra/modules/github_selfhosted_runner_on_container_app_jobs/tests/setup/README.md
+++ b/infra/modules/github_selfhosted_runner_on_container_app_jobs/tests/setup/README.md
@@ -1,5 +1,9 @@
 # setup
 
+Setup module for integration tests of `github_selfhosted_runner_on_container_app_jobs`.
+
+Creates a module-scoped VNet inside the existing integration resource group, together with dedicated `pep` and delegated `cae` subnets for the fixture Container App Environment. The setup keeps using the shared integration Log Analytics workspace and intentionally does not create private DNS zone links because the current fixtures do not use private endpoints.
+
 <!-- BEGIN_TF_DOCS -->
 ## Requirements
 
@@ -26,12 +30,13 @@ No modules.
 | [azurerm_resource_group.sut](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/resource_group) | resource |
 | [azurerm_role_assignment.kv_admin](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/role_assignment) | resource |
 | [azurerm_subnet.cae](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/subnet) | resource |
+| [azurerm_subnet.pep](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/subnet) | resource |
+| [azurerm_virtual_network.this](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/virtual_network) | resource |
 | [dx_available_subnet_cidr.cae_subnet](https://registry.terraform.io/providers/pagopa-dx/azure/latest/docs/resources/available_subnet_cidr) | resource |
+| [dx_available_subnet_cidr.pep_subnet](https://registry.terraform.io/providers/pagopa-dx/azure/latest/docs/resources/available_subnet_cidr) | resource |
 | [random_integer.kv_instance](https://registry.terraform.io/providers/hashicorp/random/latest/docs/resources/integer) | resource |
 | [azurerm_client_config.current](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/data-sources/client_config) | data source |
 | [azurerm_log_analytics_workspace.int](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/data-sources/log_analytics_workspace) | data source |
-| [azurerm_resource_group.network](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/data-sources/resource_group) | data source |
-| [azurerm_virtual_network.vnet](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/data-sources/virtual_network) | data source |
 
 ## Inputs
 
@@ -39,7 +44,6 @@ No modules.
 |------|-------------|------|---------|:--------:|
 | <a name="input_environment"></a> [environment](#input\_environment) | n/a | <pre>object({<br/>    prefix          = string<br/>    env_short       = string<br/>    location        = string<br/>    instance_number = string<br/>  })</pre> | n/a | yes |
 | <a name="input_tags"></a> [tags](#input\_tags) | Tags to apply to setup resources | `map(string)` | n/a | yes |
-| <a name="input_test_kind"></a> [test\_kind](#input\_test\_kind) | Test type: must be 'integration' (setup is not used by e2e tests) | `string` | n/a | yes |
 
 ## Outputs
 

--- a/infra/modules/github_selfhosted_runner_on_container_app_jobs/tests/setup/README.md
+++ b/infra/modules/github_selfhosted_runner_on_container_app_jobs/tests/setup/README.md
@@ -2,7 +2,7 @@
 
 Setup module for integration tests of `github_selfhosted_runner_on_container_app_jobs`.
 
-Creates a module-scoped VNet and the fixture resources inside the existing integration resource group, together with dedicated `pep` and delegated `cae` subnets for the fixture Container App Environment. The setup keeps using the shared integration Log Analytics workspace and intentionally does not create private DNS zone links because the current fixtures do not use private endpoints.
+Creates a dedicated resource group for the test setup and places the module-scoped VNet and fixture resources there, together with dedicated `pep` and delegated `cae` subnets for the fixture Container App Environment. The setup keeps using the shared integration Log Analytics workspace and intentionally does not create private DNS zone links because the current fixtures do not use private endpoints.
 
 <!-- BEGIN_TF_DOCS -->
 ## Requirements

--- a/infra/modules/github_selfhosted_runner_on_container_app_jobs/tests/setup/README.md
+++ b/infra/modules/github_selfhosted_runner_on_container_app_jobs/tests/setup/README.md
@@ -2,7 +2,7 @@
 
 Setup module for integration tests of `github_selfhosted_runner_on_container_app_jobs`.
 
-Creates a module-scoped VNet inside the existing integration resource group, together with dedicated `pep` and delegated `cae` subnets for the fixture Container App Environment. The setup keeps using the shared integration Log Analytics workspace and intentionally does not create private DNS zone links because the current fixtures do not use private endpoints.
+Creates a module-scoped VNet and the fixture resources inside the existing integration resource group, together with dedicated `pep` and delegated `cae` subnets for the fixture Container App Environment. The setup keeps using the shared integration Log Analytics workspace and intentionally does not create private DNS zone links because the current fixtures do not use private endpoints.
 
 <!-- BEGIN_TF_DOCS -->
 ## Requirements
@@ -37,13 +37,15 @@ No modules.
 | [random_integer.kv_instance](https://registry.terraform.io/providers/hashicorp/random/latest/docs/resources/integer) | resource |
 | [azurerm_client_config.current](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/data-sources/client_config) | data source |
 | [azurerm_log_analytics_workspace.int](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/data-sources/log_analytics_workspace) | data source |
+| [azurerm_resource_group.test](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/data-sources/resource_group) | data source |
 
 ## Inputs
 
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
-| <a name="input_environment"></a> [environment](#input\_environment) | n/a | <pre>object({<br/>    prefix          = string<br/>    env_short       = string<br/>    location        = string<br/>    instance_number = string<br/>  })</pre> | n/a | yes |
+| <a name="input_environment"></a> [environment](#input\_environment) | n/a | <pre>object({<br/>    prefix          = string<br/>    env_short       = string<br/>    location        = string<br/>    domain          = optional(string)<br/>    instance_number = string<br/>  })</pre> | n/a | yes |
 | <a name="input_tags"></a> [tags](#input\_tags) | Tags to apply to setup resources | `map(string)` | n/a | yes |
+| <a name="input_test_kind"></a> [test\_kind](#input\_test\_kind) | Test type: must be 'integration' (setup module is not used by e2e tests) | `string` | n/a | yes |
 
 ## Outputs
 
@@ -52,6 +54,5 @@ No modules.
 | <a name="output_container_app_environment_id"></a> [container\_app\_environment\_id](#output\_container\_app\_environment\_id) | n/a |
 | <a name="output_container_app_environment_location"></a> [container\_app\_environment\_location](#output\_container\_app\_environment\_location) | n/a |
 | <a name="output_key_vault_name"></a> [key\_vault\_name](#output\_key\_vault\_name) | n/a |
-| <a name="output_key_vault_resource_group_name"></a> [key\_vault\_resource\_group\_name](#output\_key\_vault\_resource\_group\_name) | n/a |
 | <a name="output_resource_group_name"></a> [resource\_group\_name](#output\_resource\_group\_name) | n/a |
 <!-- END_TF_DOCS -->

--- a/infra/modules/github_selfhosted_runner_on_container_app_jobs/tests/setup/main.tf
+++ b/infra/modules/github_selfhosted_runner_on_container_app_jobs/tests/setup/main.tf
@@ -38,12 +38,12 @@ resource "azurerm_virtual_network" "this" {
 
 resource "dx_available_subnet_cidr" "pep_subnet" {
   virtual_network_id = azurerm_virtual_network.this.id
-  prefix_length      = "27"
+  prefix_length      = 27
 }
 
 resource "dx_available_subnet_cidr" "cae_subnet" {
   virtual_network_id = azurerm_virtual_network.this.id
-  prefix_length      = "27"
+  prefix_length      = 27
 
   depends_on = [azurerm_subnet.pep]
 }

--- a/infra/modules/github_selfhosted_runner_on_container_app_jobs/tests/setup/main.tf
+++ b/infra/modules/github_selfhosted_runner_on_container_app_jobs/tests/setup/main.tf
@@ -1,14 +1,37 @@
 locals {
-  vnet_address_space = "10.0.0.0/21"
+  existing_resources = {
+    prefix          = var.environment.prefix
+    environment     = var.environment.env_short
+    location        = var.environment.location
+    domain          = ""
+    name            = var.test_kind
+    instance_number = tonumber(var.environment.instance_number)
+  }
 }
 
 data "azurerm_client_config" "current" {}
+
+data "azurerm_resource_group" "test" {
+  name = provider::dx::resource_name(merge(local.existing_resources, { resource_type = "resource_group" }))
+}
+
+data "azurerm_log_analytics_workspace" "int" {
+  name                = provider::dx::resource_name(merge(local.existing_resources, { resource_type = "log_analytics" }))
+  resource_group_name = data.azurerm_resource_group.test.name
+}
+
+resource "azurerm_resource_group" "sut" {
+  name     = provider::dx::resource_name(merge(var.environment, { resource_type = "resource_group" }))
+  location = var.environment.location
+
+  tags = var.tags
+}
 
 resource "azurerm_virtual_network" "this" {
   name                = provider::dx::resource_name(merge(var.environment, { resource_type = "virtual_network" }))
   location            = azurerm_resource_group.sut.location
   resource_group_name = azurerm_resource_group.sut.name
-  address_space       = [local.vnet_address_space]
+  address_space       = ["10.0.0.0/21"]
 
   tags = var.tags
 }
@@ -21,22 +44,12 @@ resource "dx_available_subnet_cidr" "pep_subnet" {
 resource "dx_available_subnet_cidr" "cae_subnet" {
   virtual_network_id = azurerm_virtual_network.this.id
   prefix_length      = "27"
-}
 
-data "azurerm_log_analytics_workspace" "int" {
-  name                = provider::dx::resource_name(merge(var.environment, { app_name = "integration", domain = "", resource_type = "log_analytics" }))
-  resource_group_name = provider::dx::resource_name(merge(var.environment, { app_name = "integration", domain = "", resource_type = "resource_group" }))
-}
-
-resource "azurerm_resource_group" "sut" {
-  name     = provider::dx::resource_name(merge(var.environment, { resource_type = "resource_group" }))
-  location = var.environment.location
-
-  tags = var.tags
+  depends_on = [azurerm_subnet.pep]
 }
 
 resource "azurerm_subnet" "pep" {
-  name                 = provider::dx::resource_name(merge(var.environment, { resource_type = "subnet", app_name = "pep" }))
+  name                 = provider::dx::resource_name(merge(var.environment, { resource_type = "private_endpoint_subnet" }))
   resource_group_name  = azurerm_resource_group.sut.name
   virtual_network_name = azurerm_virtual_network.this.name
   address_prefixes     = [dx_available_subnet_cidr.pep_subnet.cidr_block]
@@ -60,7 +73,7 @@ resource "azurerm_subnet" "cae" {
 resource "azurerm_container_app_environment" "runner" {
   name                           = provider::dx::resource_name(merge(var.environment, { resource_type = "container_app_environment" }))
   resource_group_name            = azurerm_resource_group.sut.name
-  location                       = var.environment.location
+  location                       = azurerm_resource_group.sut.location
   internal_load_balancer_enabled = false
   infrastructure_subnet_id       = azurerm_subnet.cae.id
   log_analytics_workspace_id     = data.azurerm_log_analytics_workspace.int.id
@@ -94,7 +107,12 @@ resource "random_integer" "kv_instance" {
 #tfsec:ignore:AVD-AZU-0016
 #tfsec:ignore:AVD-AZU-0017
 resource "azurerm_key_vault" "test" {
-  name                          = provider::dx::resource_name(merge(var.environment, { resource_type = "key_vault", instance_number = random_integer.kv_instance.result }))
+  name = provider::dx::resource_name(
+    merge(var.environment,
+      {
+        resource_type = "key_vault", instance_number = random_integer.kv_instance.result
+      }
+  ))
   location                      = azurerm_resource_group.sut.location
   resource_group_name           = azurerm_resource_group.sut.name
   tenant_id                     = data.azurerm_client_config.current.tenant_id
@@ -163,8 +181,4 @@ output "container_app_environment_location" {
 
 output "key_vault_name" {
   value = azurerm_key_vault.test.name
-}
-
-output "key_vault_resource_group_name" {
-  value = azurerm_resource_group.sut.name
 }

--- a/infra/modules/github_selfhosted_runner_on_container_app_jobs/tests/setup/main.tf
+++ b/infra/modules/github_selfhosted_runner_on_container_app_jobs/tests/setup/main.tf
@@ -1,23 +1,26 @@
 locals {
-  existing_resources = {
-    prefix          = var.environment.prefix,
-    environment     = var.environment.env_short,
-    location        = var.environment.location,
-    domain          = ""
-    name            = var.test_kind,
-    instance_number = tonumber(var.environment.instance_number),
-  }
+  vnet_address_space = "10.0.0.0/21"
 }
 
 data "azurerm_client_config" "current" {}
 
-data "azurerm_resource_group" "network" {
-  name = provider::dx::resource_name(merge(local.existing_resources, { resource_type = "resource_group" }))
+resource "azurerm_virtual_network" "this" {
+  name                = provider::dx::resource_name(merge(var.environment, { resource_type = "virtual_network" }))
+  location            = azurerm_resource_group.sut.location
+  resource_group_name = azurerm_resource_group.sut.name
+  address_space       = [local.vnet_address_space]
+
+  tags = var.tags
 }
 
-data "azurerm_virtual_network" "vnet" {
-  name                = provider::dx::resource_name(merge(local.existing_resources, { resource_type = "virtual_network" }))
-  resource_group_name = data.azurerm_resource_group.network.name
+resource "dx_available_subnet_cidr" "pep_subnet" {
+  virtual_network_id = azurerm_virtual_network.this.id
+  prefix_length      = "27"
+}
+
+resource "dx_available_subnet_cidr" "cae_subnet" {
+  virtual_network_id = azurerm_virtual_network.this.id
+  prefix_length      = "27"
 }
 
 data "azurerm_log_analytics_workspace" "int" {
@@ -32,15 +35,17 @@ resource "azurerm_resource_group" "sut" {
   tags = var.tags
 }
 
-resource "dx_available_subnet_cidr" "cae_subnet" {
-  virtual_network_id = data.azurerm_virtual_network.vnet.id
-  prefix_length      = 27
+resource "azurerm_subnet" "pep" {
+  name                 = provider::dx::resource_name(merge(var.environment, { resource_type = "subnet", app_name = "pep" }))
+  resource_group_name  = azurerm_resource_group.sut.name
+  virtual_network_name = azurerm_virtual_network.this.name
+  address_prefixes     = [dx_available_subnet_cidr.pep_subnet.cidr_block]
 }
 
 resource "azurerm_subnet" "cae" {
-  name                 = provider::dx::resource_name(merge(var.environment, { resource_type = "subnet", name = "cae" }))
-  resource_group_name  = data.azurerm_resource_group.network.name
-  virtual_network_name = data.azurerm_virtual_network.vnet.name
+  name                 = provider::dx::resource_name(merge(var.environment, { resource_type = "container_app_subnet" }))
+  resource_group_name  = azurerm_resource_group.sut.name
+  virtual_network_name = azurerm_virtual_network.this.name
   address_prefixes     = [dx_available_subnet_cidr.cae_subnet.cidr_block]
 
   delegation {

--- a/infra/modules/github_selfhosted_runner_on_container_app_jobs/tests/setup/variables.tf
+++ b/infra/modules/github_selfhosted_runner_on_container_app_jobs/tests/setup/variables.tf
@@ -3,6 +3,7 @@ variable "environment" {
     prefix          = string
     env_short       = string
     location        = string
+    domain          = optional(string)
     instance_number = string
   })
 }
@@ -10,4 +11,14 @@ variable "environment" {
 variable "tags" {
   type        = map(string)
   description = "Tags to apply to setup resources"
+}
+
+variable "test_kind" {
+  type        = string
+  description = "Test type: must be 'integration' (setup module is not used by e2e tests)"
+
+  validation {
+    condition     = var.test_kind == "integration"
+    error_message = "test_kind must be 'integration' (setup is not used by e2e tests)"
+  }
 }

--- a/infra/modules/github_selfhosted_runner_on_container_app_jobs/tests/setup/variables.tf
+++ b/infra/modules/github_selfhosted_runner_on_container_app_jobs/tests/setup/variables.tf
@@ -11,8 +11,3 @@ variable "tags" {
   type        = map(string)
   description = "Tags to apply to setup resources"
 }
-
-variable "test_kind" {
-  type        = string
-  description = "Test type: must be 'integration' (setup is not used by e2e tests)"
-}

--- a/infra/modules/github_selfhosted_runner_on_container_app_jobs/tests/setup/variables.tf
+++ b/infra/modules/github_selfhosted_runner_on_container_app_jobs/tests/setup/variables.tf
@@ -3,6 +3,7 @@ variable "environment" {
     prefix          = string
     env_short       = string
     location        = string
+    app_name        = optional(string)
     domain          = optional(string)
     instance_number = string
   })


### PR DESCRIPTION
Introduce a custom virtual network and associated resources for CAEs integration tests, including dedicated subnets for `pep` and `cae`. Update variable definitions to include tags and ensure proper validation for the test kind. Adjust resource references to align with the new setup.

Close CES-2079