### PR TITLE
Add managed_redis_private_endpoint resource type

### DIFF
--- a/.nx/version-plans/version-plan-1779187106543.md
+++ b/.nx/version-plans/version-plan-1779187106543.md
@@ -1,0 +1,5 @@
+---
+provider-azure: minor
+---
+
+Add managed_redis_private_endpoint resource type

--- a/providers/azure/README.md
+++ b/providers/azure/README.md
@@ -234,6 +234,7 @@ The following table lists the resource types and their abbreviations used in the
 | log_analytics                             |       log        |
 | managed_identity                          |        id        |
 | managed_redis                             |       amr        |
+| managed_redis_private_endpoint            |     amr-pep      |
 | nat_gateway                               |        ng        |
 | network_security_group                    |       nsg        |
 | postgre_endpoint                          |     psql-ep      |

--- a/providers/azure/docs/functions/resource_name.md
+++ b/providers/azure/docs/functions/resource_name.md
@@ -115,6 +115,7 @@ The following table lists the resource types and their abbreviations used in the
 | log_analytics                             |       log        |
 | managed_identity                          |        id        |
 | managed_redis                             |       amr        |
+| managed_redis_private_endpoint            |     amr-pep      |
 | nat_gateway                               |        ng        |
 | network_security_group                    |       nsg        |
 | postgre_endpoint                          |     psql-ep      |

--- a/providers/azure/internal/provider/function_resource_name.go
+++ b/providers/azure/internal/provider/function_resource_name.go
@@ -106,6 +106,7 @@ func getResourceAbbreviations() map[string]string {
 		"servicebus_private_endpoint":        "sbns-pep",
 		"apim_private_endpoint":              "apim-pep",
 		"app_configuration_private_endpoint": "appcs-pep",
+		"managed_redis_private_endpoint":     "amr-pep",
 
 		// Public IPs
 		"public_ip": "pip",

--- a/providers/azure/internal/provider/function_resource_name_test.go
+++ b/providers/azure/internal/provider/function_resource_name_test.go
@@ -996,3 +996,33 @@ func TestResourceNameFunction_MissingEnvironmentAndEnvShort(t *testing.T) {
 		},
 	})
 }
+
+func TestResourceNameFunction_ManagedRedisPrivateEndpoint(t *testing.T) {
+	t.Parallel()
+	// managed_redis_private_endpoint must produce the amr-pep abbreviation
+	resource.UnitTest(t, resource.TestCase{
+		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
+			tfversion.SkipBelow(tfversion.Version1_8_0),
+		},
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: `
+        output "test" {
+          value = provider::dx::resource_name({
+						prefix = "dx",
+						environment = "d",
+						location = "itn",
+						name = "cache",
+						resource_type = "managed_redis_private_endpoint",
+						instance_number = "1"
+					})
+        }
+        `,
+				ConfigStateChecks: []statecheck.StateCheck{
+					statecheck.ExpectKnownOutputValue("test", knownvalue.StringExact("dx-d-itn-cache-amr-pep-01")),
+				},
+			},
+		},
+	})
+}


### PR DESCRIPTION
## Summary

Adds a dedicated `managed_redis_private_endpoint` resource type to the DX Azure provider function `resource_name`, producing the abbreviation `amr-pep`.

This follows the same pattern already established for:
- `cosmos_private_endpoint` → `cosno-pep`
- `postgre_private_endpoint` → `psql-pep`
- `servicebus_private_endpoint` → `sbns-pep`

Previously, modules had to fall back to the generic `private_endpoint` type (`pep`), which loses the resource-specific context in the name.

## Changes

- `providers/azure/internal/provider/function_resource_name.go`: new entry `managed_redis_private_endpoint → amr-pep`
- `providers/azure/internal/provider/function_resource_name_test.go`: new test `TestResourceNameFunction_ManagedRedisPrivateEndpoint` added first as a failing test (red commit) then made green by the implementation.