### PR TITLE
Use dedicated private endpoint type for Azure Managed Redis

### DIFF
--- a/.nx/version-plans/version-plan-1779187310962.md
+++ b/.nx/version-plans/version-plan-1779187310962.md
@@ -1,0 +1,5 @@
+---
+azure_managed_redis: patch
+---
+
+Use dedicated private endpoint type for managed Redis private endpoint name

--- a/infra/modules/azure_managed_redis/README.md
+++ b/infra/modules/azure_managed_redis/README.md
@@ -154,7 +154,7 @@ Integration and end-to-end test layers are tracked as follow-ups under [CES-1909
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.11.0 |
 | <a name="requirement_azurerm"></a> [azurerm](#requirement\_azurerm) | ~> 4.23 |
-| <a name="requirement_dx"></a> [dx](#requirement\_dx) | ~> 0.9 |
+| <a name="requirement_dx"></a> [dx](#requirement\_dx) | ~> 0.12 |
 
 ## Modules
 

--- a/infra/modules/azure_managed_redis/examples/complete/providers.tf
+++ b/infra/modules/azure_managed_redis/examples/complete/providers.tf
@@ -8,7 +8,7 @@ terraform {
     }
     dx = {
       source  = "pagopa-dx/azure"
-      version = "~> 0.9"
+      version = "~> 0.12"
     }
     random = {
       source  = "hashicorp/random"

--- a/infra/modules/azure_managed_redis/locals.tf
+++ b/infra/modules/azure_managed_redis/locals.tf
@@ -29,7 +29,7 @@ locals {
   use_case_features = local.use_cases[var.use_case]
 
   managed_redis_name    = provider::dx::resource_name(merge(var.environment, { resource_type = "managed_redis" }))
-  private_endpoint_name = provider::dx::resource_name(merge(var.environment, { resource_type = "private_endpoint" }))
+  private_endpoint_name = provider::dx::resource_name(merge(var.environment, { resource_type = "managed_redis_private_endpoint" }))
 
   vnet_id                  = var.virtual_network_id != null ? provider::azurerm::normalise_resource_id(var.virtual_network_id) : null
   vnet_resource_group_name = var.virtual_network_id != null ? provider::azurerm::parse_resource_id(var.virtual_network_id).resource_group_name : null

--- a/infra/modules/azure_managed_redis/main.tf
+++ b/infra/modules/azure_managed_redis/main.tf
@@ -8,7 +8,7 @@ terraform {
     }
     dx = {
       source  = "pagopa-dx/azure"
-      version = "~> 0.9"
+      version = "~> 0.12"
     }
   }
 }

--- a/infra/modules/azure_managed_redis/tests/unit.tftest.hcl
+++ b/infra/modules/azure_managed_redis/tests/unit.tftest.hcl
@@ -187,6 +187,11 @@ run "managed_redis_private_endpoint" {
   command = plan
 
   assert {
+    condition     = azurerm_private_endpoint.redis[0].name == "dx-d-itn-modules-cache-amr-pep-01"
+    error_message = "Private endpoint name must use the managed_redis_private_endpoint type (amr-pep suffix)"
+  }
+
+  assert {
     condition     = azurerm_private_endpoint.redis[0].subnet_id == local.subnet_pep_id
     error_message = "Private endpoint must target the synthesized PEP subnet"
   }


### PR DESCRIPTION
## Summary

Updates the `azure_managed_redis` module to use the new `managed_redis_private_endpoint` resource type for naming the Redis private endpoint, producing `amr-pep` instead of the generic `pep` suffix.

This makes the private endpoint name self-descriptive and consistent with how other resources already work (e.g. `cosmos_private_endpoint` → `cosno-pep`).

Before: `dx-d-itn-modules-cache-pep-01`
After:  `dx-d-itn-modules-cache-amr-pep-01`

## Changes

- `infra/modules/azure_managed_redis/locals.tf`: `private_endpoint_name` now uses `resource_type = "managed_redis_private_endpoint"`
- `infra/modules/azure_managed_redis/tests/unit.tftest.hcl`: new assertion in `managed_redis_private_endpoint` run block verifies the `amr-pep` name

## Notes

> ⚠️ The unit tests for this PR will remain red until the companion provider PR is merged and the new provider version is published. After that, the module's lock file should be refreshed via `terraform init -upgrade`.

Depends on #1763