### PR TITLE
Add agent-ready CLI foundations

### DIFF
--- a/.nx/version-plans/cli-agent-foundations.md
+++ b/.nx/version-plans/cli-agent-foundations.md
@@ -1,0 +1,5 @@
+---
+"@pagopa/dx-cli": minor
+---
+
+Add `--non-interactive` / `-y` and `--output <text|json>` global flags, structured exit codes, and a JSON error envelope on stdout when `--output=json` is active. No change to existing human invocations.

--- a/apps/cli/src/adapters/commander/__tests__/exit-codes.test.ts
+++ b/apps/cli/src/adapters/commander/__tests__/exit-codes.test.ts
@@ -1,0 +1,65 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  CliError,
+  ErrorCode,
+  ExitCode,
+  exitCodeForErrorCode,
+  isCliError,
+} from "../exit-codes.js";
+
+describe("ExitCode", () => {
+  it("exposes stable numeric codes", () => {
+    expect(ExitCode.OK).toBe(0);
+    expect(ExitCode.GENERIC).toBe(1);
+    expect(ExitCode.USAGE).toBe(2);
+    expect(ExitCode.MISSING_INPUT).toBe(3);
+    expect(ExitCode.PRECONDITION).toBe(4);
+    expect(ExitCode.REMOTE).toBe(5);
+    expect(ExitCode.VALIDATION).toBe(6);
+  });
+});
+
+describe("exitCodeForErrorCode", () => {
+  it("maps every known error code to a distinct exit code", () => {
+    expect(exitCodeForErrorCode(ErrorCode.USAGE)).toBe(ExitCode.USAGE);
+    expect(exitCodeForErrorCode(ErrorCode.MISSING_INPUT)).toBe(
+      ExitCode.MISSING_INPUT,
+    );
+    expect(exitCodeForErrorCode(ErrorCode.PRECONDITION)).toBe(
+      ExitCode.PRECONDITION,
+    );
+    expect(exitCodeForErrorCode(ErrorCode.REMOTE)).toBe(ExitCode.REMOTE);
+    expect(exitCodeForErrorCode(ErrorCode.VALIDATION)).toBe(
+      ExitCode.VALIDATION,
+    );
+  });
+
+  it("falls back to GENERIC for unknown / fallthrough codes", () => {
+    expect(exitCodeForErrorCode(ErrorCode.GENERIC)).toBe(ExitCode.GENERIC);
+  });
+});
+
+describe("CliError", () => {
+  it("carries the code, message and optional details", () => {
+    const err = new CliError(ErrorCode.MISSING_INPUT, "Missing repo name", {
+      details: { field: "repoName" },
+    });
+    expect(err.code).toBe(ErrorCode.MISSING_INPUT);
+    expect(err.message).toBe("Missing repo name");
+    expect(err.details).toEqual({ field: "repoName" });
+    expect(isCliError(err)).toBe(true);
+  });
+
+  it("preserves the cause chain", () => {
+    const cause = new Error("boom");
+    const err = new CliError(ErrorCode.REMOTE, "Remote call failed", { cause });
+    expect((err as { cause?: unknown }).cause).toBe(cause);
+  });
+
+  it("isCliError rejects plain Error and other values", () => {
+    expect(isCliError(new Error("nope"))).toBe(false);
+    expect(isCliError("string")).toBe(false);
+    expect(isCliError(undefined)).toBe(false);
+  });
+});

--- a/apps/cli/src/adapters/commander/__tests__/exit-with-error.test.ts
+++ b/apps/cli/src/adapters/commander/__tests__/exit-with-error.test.ts
@@ -1,6 +1,7 @@
 import { Command } from "commander";
-import { describe, expect, it } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 
+import { CliError, ErrorCode, ExitCode } from "../exit-codes.js";
 import { exitWithError, isVerbose } from "../index.js";
 
 /**
@@ -11,6 +12,8 @@ const makeProgramWith = (child: Command, argv: string[]): Command => {
   const program = new Command()
     .name("dx")
     .option("-v, --verbose", "verbose output", false)
+    .option("-y, --non-interactive", "non interactive", false)
+    .option("--output <mode>", "output mode", "text")
     .exitOverride()
     .configureOutput({
       writeErr: () => {
@@ -103,4 +106,64 @@ describe("exitWithError", () => {
       /plain string failure/,
     );
   });
+
+  it("emits a JSON error envelope on stdout when --output=json", () => {
+    const cmd = new Command("run").action(() => undefined);
+    makeProgramWith(cmd, ["--output", "json", "run"]);
+    const written: string[] = [];
+    const originalWrite = process.stdout.write.bind(process.stdout);
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    (process.stdout as any).write = (chunk: unknown): boolean => {
+      written.push(String(chunk));
+      return true;
+    };
+    const err = new CliError(ErrorCode.MISSING_INPUT, "missing field", {
+      details: { field: "name" },
+    });
+    let thrown: unknown;
+    try {
+      exitWithError(cmd)(err);
+    } catch (e) {
+      thrown = e;
+    }
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    (process.stdout as any).write = originalWrite;
+
+    const envelope = JSON.parse(written.join("").trim());
+    expect(envelope).toMatchObject({
+      command: "run",
+      error: {
+        code: ErrorCode.MISSING_INPUT,
+        details: { field: "name" },
+        message: "missing field",
+      },
+      ok: false,
+    });
+    expect((thrown as null | { exitCode?: number })?.exitCode).toBe(
+      ExitCode.MISSING_INPUT,
+    );
+  });
+
+  it("uses GENERIC exit code in json mode for non-CliError values", () => {
+    const cmd = new Command("run").action(() => undefined);
+    makeProgramWith(cmd, ["--output", "json", "run"]);
+    const originalWrite = process.stdout.write.bind(process.stdout);
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    (process.stdout as any).write = (): boolean => true;
+    let thrown: unknown;
+    try {
+      exitWithError(cmd)(new Error("boom"));
+    } catch (e) {
+      thrown = e;
+    }
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    (process.stdout as any).write = originalWrite;
+    expect((thrown as null | { exitCode?: number })?.exitCode).toBe(
+      ExitCode.GENERIC,
+    );
+  });
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
 });

--- a/apps/cli/src/adapters/commander/__tests__/output.test.ts
+++ b/apps/cli/src/adapters/commander/__tests__/output.test.ts
@@ -1,0 +1,254 @@
+import { Command } from "commander";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { CliError, ErrorCode, ExitCode } from "../exit-codes.js";
+import {
+  buildErrorEnvelope,
+  buildSuccessEnvelope,
+  emitEvent,
+  exitCodeForError,
+  getOutputMode,
+  isNonInteractive,
+  printResult,
+  toErrorPayload,
+} from "../output.js";
+
+const setIsTTY = (value: boolean): void => {
+  Object.defineProperty(process.stdout, "isTTY", {
+    configurable: true,
+    value,
+  });
+};
+
+const originalIsTTYDescriptor = Object.getOwnPropertyDescriptor(
+  process.stdout,
+  "isTTY",
+);
+
+const restoreIsTTY = (): void => {
+  if (originalIsTTYDescriptor) {
+    Object.defineProperty(process.stdout, "isTTY", originalIsTTYDescriptor);
+  } else {
+    delete (process.stdout as { isTTY?: boolean }).isTTY;
+  }
+};
+
+/**
+ * Build a root program that exposes the same global flags as the real CLI
+ * and parse the given argv, returning the child command so callers can
+ * inspect `optsWithGlobals` (which is how the output helpers read state).
+ */
+const makeProgramWith = (argv: string[]): Command => {
+  const program = new Command()
+    .name("dx")
+    .option("-v, --verbose", "verbose", false)
+    .option("-y, --non-interactive", "non interactive", false)
+    .option("--output <mode>", "output mode", "text")
+    .exitOverride()
+    .configureOutput({
+      writeErr: () => {
+        /* silence */
+      },
+      writeOut: () => {
+        /* silence */
+      },
+    });
+  const child = new Command("run")
+    .exitOverride()
+    .configureOutput({
+      writeErr: () => {
+        /* silence */
+      },
+      writeOut: () => {
+        /* silence */
+      },
+    })
+    .action(() => undefined);
+  program.addCommand(child);
+  program.parse(argv, { from: "user" });
+  return child;
+};
+
+afterEach(() => {
+  vi.restoreAllMocks();
+  restoreIsTTY();
+});
+
+describe("getOutputMode", () => {
+  it("defaults to text", () => {
+    const cmd = makeProgramWith(["run"]);
+    expect(getOutputMode(cmd)).toBe("text");
+  });
+
+  it("returns json when --output=json", () => {
+    const cmd = makeProgramWith(["--output", "json", "run"]);
+    expect(getOutputMode(cmd)).toBe("json");
+  });
+});
+
+describe("isNonInteractive", () => {
+  beforeEach(() => {
+    setIsTTY(true);
+  });
+
+  it("is false by default with a TTY", () => {
+    const cmd = makeProgramWith(["run"]);
+    expect(isNonInteractive(cmd)).toBe(false);
+  });
+
+  it("is true when --non-interactive is set", () => {
+    const cmd = makeProgramWith(["--non-interactive", "run"]);
+    expect(isNonInteractive(cmd)).toBe(true);
+  });
+
+  it("is true via -y short flag", () => {
+    const cmd = makeProgramWith(["-y", "run"]);
+    expect(isNonInteractive(cmd)).toBe(true);
+  });
+
+  it("auto-on when --output=json and no TTY", () => {
+    setIsTTY(false);
+    const cmd = makeProgramWith(["--output", "json", "run"]);
+    expect(isNonInteractive(cmd)).toBe(true);
+  });
+
+  it("stays interactive when --output=json but a TTY is attached", () => {
+    setIsTTY(true);
+    const cmd = makeProgramWith(["--output", "json", "run"]);
+    expect(isNonInteractive(cmd)).toBe(false);
+  });
+});
+
+describe("toErrorPayload", () => {
+  it("maps a CliError to its code, message and details", () => {
+    const err = new CliError(ErrorCode.MISSING_INPUT, "missing", {
+      details: { field: "x" },
+    });
+    const payload = toErrorPayload(err);
+    expect(payload.code).toBe(ErrorCode.MISSING_INPUT);
+    expect(payload.message).toBe("missing");
+    expect(payload.details).toEqual({ field: "x" });
+  });
+
+  it("maps a plain Error to E_GENERIC", () => {
+    const err = new Error("oops");
+    const payload = toErrorPayload(err);
+    expect(payload.code).toBe(ErrorCode.GENERIC);
+    expect(payload.message).toBe("oops");
+  });
+
+  it("flattens the cause chain (excluding the top-level message)", () => {
+    const root = new Error("root");
+    const mid = new Error("mid", { cause: root });
+    const top = new CliError(ErrorCode.REMOTE, "top", { cause: mid });
+    const payload = toErrorPayload(top);
+    expect(payload.cause).toBe("mid <- root");
+  });
+
+  it("handles non-Error values", () => {
+    expect(toErrorPayload("plain")).toMatchObject({
+      code: ErrorCode.GENERIC,
+      message: "plain",
+    });
+    expect(toErrorPayload({ foo: 1 })).toMatchObject({
+      code: ErrorCode.GENERIC,
+    });
+  });
+});
+
+describe("printResult", () => {
+  it("writes a single JSON line to stdout in json mode", () => {
+    const cmd = makeProgramWith(["--output", "json", "run"]);
+    const written: string[] = [];
+    printResult(cmd, buildSuccessEnvelope(cmd, { foo: "bar" }), {
+      stdout: (chunk) => written.push(chunk),
+    });
+    expect(written).toHaveLength(1);
+    const parsed = JSON.parse(written[0] ?? "");
+    expect(parsed).toEqual({
+      command: "run",
+      data: { foo: "bar" },
+      ok: true,
+    });
+    expect(written[0]?.endsWith("\n")).toBe(true);
+  });
+
+  it("is a no-op in text mode", () => {
+    const cmd = makeProgramWith(["run"]);
+    const written: string[] = [];
+    printResult(cmd, buildSuccessEnvelope(cmd, { foo: "bar" }), {
+      stdout: (chunk) => written.push(chunk),
+    });
+    expect(written).toEqual([]);
+  });
+
+  it("serialises error envelopes too", () => {
+    const cmd = makeProgramWith(["--output", "json", "run"]);
+    const written: string[] = [];
+    const err = new CliError(ErrorCode.VALIDATION, "bad input");
+    printResult(cmd, buildErrorEnvelope(cmd, err), {
+      stdout: (chunk) => written.push(chunk),
+    });
+    const parsed = JSON.parse(written[0] ?? "");
+    expect(parsed).toMatchObject({
+      command: "run",
+      error: { code: ErrorCode.VALIDATION, message: "bad input" },
+      ok: false,
+    });
+  });
+});
+
+describe("emitEvent", () => {
+  it("writes NDJSON events to stderr in json mode", () => {
+    const cmd = makeProgramWith(["--output", "json", "run"]);
+    const written: string[] = [];
+    emitEvent(
+      cmd,
+      { event: "step", name: "createRepo", status: "started" },
+      { stderr: (chunk) => written.push(chunk) },
+    );
+    emitEvent(
+      cmd,
+      {
+        durationMs: 42,
+        event: "step",
+        name: "createRepo",
+        status: "succeeded",
+      },
+      { stderr: (chunk) => written.push(chunk) },
+    );
+    expect(written).toHaveLength(2);
+    expect(JSON.parse(written[0] ?? "")).toMatchObject({
+      event: "step",
+      name: "createRepo",
+      status: "started",
+    });
+    expect(JSON.parse(written[1] ?? "")).toMatchObject({
+      durationMs: 42,
+      status: "succeeded",
+    });
+  });
+
+  it("is a no-op in text mode", () => {
+    const cmd = makeProgramWith(["run"]);
+    const written: string[] = [];
+    emitEvent(
+      cmd,
+      { event: "step", name: "noop", status: "started" },
+      { stderr: (chunk) => written.push(chunk) },
+    );
+    expect(written).toEqual([]);
+  });
+});
+
+describe("exitCodeForError", () => {
+  it("uses the CliError code", () => {
+    expect(
+      exitCodeForError(new CliError(ErrorCode.REMOTE, "remote failure")),
+    ).toBe(ExitCode.REMOTE);
+  });
+
+  it("falls back to GENERIC for plain Error", () => {
+    expect(exitCodeForError(new Error("boom"))).toBe(ExitCode.GENERIC);
+  });
+});

--- a/apps/cli/src/adapters/commander/exit-codes.ts
+++ b/apps/cli/src/adapters/commander/exit-codes.ts
@@ -1,0 +1,73 @@
+/**
+ * Process exit codes used by the DX CLI.
+ *
+ * Coding agents driving the CLI rely on these codes to decide whether a
+ * failure is retriable (e.g. transient remote error), recoverable by the
+ * agent (e.g. missing input) or terminal (e.g. validation error in a
+ * user-provided config file).
+ */
+export const ExitCode = {
+  GENERIC: 1,
+  MISSING_INPUT: 3,
+  OK: 0,
+  PRECONDITION: 4,
+  REMOTE: 5,
+  USAGE: 2,
+  VALIDATION: 6,
+} as const;
+
+export type ExitCodeName = keyof typeof ExitCode;
+export type ExitCodeValue = (typeof ExitCode)[ExitCodeName];
+
+/**
+ * Stable, machine-readable error codes embedded in JSON error envelopes.
+ * The `E_` prefix mirrors the convention used by Node's own error system.
+ */
+export const ErrorCode = {
+  GENERIC: "E_GENERIC",
+  MISSING_INPUT: "E_MISSING_INPUT",
+  PRECONDITION: "E_PRECONDITION",
+  REMOTE: "E_REMOTE",
+  USAGE: "E_USAGE",
+  VALIDATION: "E_VALIDATION",
+} as const;
+
+export type ErrorCodeName = keyof typeof ErrorCode;
+export type ErrorCodeValue = (typeof ErrorCode)[ErrorCodeName];
+
+const exitCodeByErrorCode: Record<ErrorCodeValue, ExitCodeValue> = {
+  [ErrorCode.GENERIC]: ExitCode.GENERIC,
+  [ErrorCode.MISSING_INPUT]: ExitCode.MISSING_INPUT,
+  [ErrorCode.PRECONDITION]: ExitCode.PRECONDITION,
+  [ErrorCode.REMOTE]: ExitCode.REMOTE,
+  [ErrorCode.USAGE]: ExitCode.USAGE,
+  [ErrorCode.VALIDATION]: ExitCode.VALIDATION,
+};
+
+export const exitCodeForErrorCode = (code: ErrorCodeValue): ExitCodeValue =>
+  exitCodeByErrorCode[code];
+
+/**
+ * Typed CLI error that carries a stable `code` and arbitrary `details` for
+ * structured reporting. Throw a `CliError` whenever the failure has a
+ * well-known category so the JSON output adapter and exit code mapper can
+ * report it precisely.
+ */
+export class CliError extends Error {
+  readonly code: ErrorCodeValue;
+  readonly details?: unknown;
+
+  constructor(
+    code: ErrorCodeValue,
+    message: string,
+    options?: { cause?: unknown; details?: unknown },
+  ) {
+    super(message, { cause: options?.cause });
+    this.name = "CliError";
+    this.code = code;
+    this.details = options?.details;
+  }
+}
+
+export const isCliError = (value: unknown): value is CliError =>
+  value instanceof CliError;

--- a/apps/cli/src/adapters/commander/index.ts
+++ b/apps/cli/src/adapters/commander/index.ts
@@ -1,4 +1,4 @@
-import { Command } from "commander";
+import { Command, Option } from "commander";
 
 import { Config } from "../../config.js";
 import { Dependencies } from "../../domain/dependencies.js";
@@ -12,10 +12,18 @@ import { makeInfoCommand } from "./commands/info.js";
 import { makeInitCommand } from "./commands/init.js";
 import { makeSavemoneyCommand } from "./commands/savemoney.js";
 import { formatErrorDetailed, toErrorMessage } from "./error-reporting.js";
+import {
+  buildErrorEnvelope,
+  exitCodeForError,
+  getOutputMode,
+  printResult,
+} from "./output.js";
 
 export type CliDependencies = CodemodCommandDependencies;
 
 export type GlobalOptions = {
+  nonInteractive?: boolean;
+  output?: "json" | "text";
   verbose?: boolean;
 };
 
@@ -42,6 +50,19 @@ export const makeCli = (
       "-v, --verbose",
       "Enable verbose output: debug-level logs and full error chain (with stack traces) when a command fails",
       false,
+    )
+    .option(
+      "-y, --non-interactive",
+      "Disable interactive prompts. Required values missing from flags/config cause the command to fail fast instead of blocking on stdin. Auto-on when --output=json and stdout is not a TTY.",
+      false,
+    )
+    .addOption(
+      new Option(
+        "--output <mode>",
+        "Output mode: 'text' (human-readable, default) or 'json' (machine-readable envelope on stdout, NDJSON progress on stderr)",
+      )
+        .choices(["text", "json"])
+        .default("text"),
     );
 
   program.addCommand(makeDoctorCommand(deps, config));
@@ -61,10 +82,18 @@ export const makeCli = (
  * - In normal mode, a single meaningful line is printed.
  * - When `--verbose` is active, the full cause chain and stack trace are
  *   included so users can diagnose the underlying failure.
+ * - When `--output json` is active, a structured JSON error envelope is
+ *   written to stdout and the process exits with a code that reflects the
+ *   error category (see `ExitCode`).
  */
 export const exitWithError =
   (command: Command) =>
   (error: unknown): never => {
+    if (getOutputMode(command) === "json") {
+      const envelope = buildErrorEnvelope(command, error);
+      printResult(command, envelope);
+      command.error("", { exitCode: exitCodeForError(error) });
+    }
     const message = isVerbose(command)
       ? formatErrorDetailed(error)
       : toErrorMessage(error);

--- a/apps/cli/src/adapters/commander/output.ts
+++ b/apps/cli/src/adapters/commander/output.ts
@@ -1,0 +1,219 @@
+/**
+ * Output adapter for agent-friendly CLI invocations.
+ *
+ * The DX CLI supports two output modes:
+ *
+ * - `text` (default): human-friendly output via chalk/ora, unchanged from
+ *   today's behaviour.
+ * - `json`: a single JSON envelope is written to stdout at the end of the
+ *   command; optional NDJSON progress events are written to stderr while
+ *   the command runs.
+ *
+ * Coding agents use `json` mode to consume command outputs deterministically
+ * without parsing prose.
+ */
+import { Command } from "commander";
+
+import {
+  ErrorCode,
+  ErrorCodeValue,
+  ExitCode,
+  exitCodeForErrorCode,
+  ExitCodeValue,
+  isCliError,
+} from "./exit-codes.js";
+import { GlobalOptions } from "./index.js";
+
+export type ErrorEnvelope = {
+  command: string;
+  error: {
+    cause?: string;
+    code: ErrorCodeValue;
+    details?: unknown;
+    message: string;
+  };
+  ok: false;
+};
+
+export type OutputMode = "json" | "text";
+
+export type ProgressEvent = {
+  durationMs?: number;
+  error?: string;
+  event: "step";
+  name: string;
+  status: "failed" | "started" | "succeeded";
+};
+
+export type ResultEnvelope<T> = ErrorEnvelope | SuccessEnvelope<T>;
+
+export type SuccessEnvelope<T> = {
+  command: string;
+  data: T;
+  ok: true;
+};
+
+type StreamWriter = (chunk: string) => void;
+
+const defaultStdoutWriter: StreamWriter = (chunk) =>
+  process.stdout.write(chunk);
+const defaultStderrWriter: StreamWriter = (chunk) =>
+  process.stderr.write(chunk);
+
+/**
+ * Returns the active output mode. Defaults to `text` for backward
+ * compatibility with every existing human invocation.
+ */
+export const getOutputMode = (command: Command): OutputMode =>
+  command.optsWithGlobals<GlobalOptions>().output === "json" ? "json" : "text";
+
+/**
+ * Returns `true` when the CLI must not prompt the user.
+ *
+ * The explicit `--non-interactive` / `-y` flag is the canonical signal.
+ * As a convenience, JSON output mode also implies non-interactive when
+ * stdout is not a TTY (typical when a coding agent pipes the output), so
+ * the CLI fails fast instead of blocking on a stalled stdin.
+ */
+export const isNonInteractive = (command: Command): boolean => {
+  const opts = command.optsWithGlobals<GlobalOptions>();
+  if (opts.nonInteractive === true) {
+    return true;
+  }
+  if (opts.output === "json" && !process.stdout.isTTY) {
+    return true;
+  }
+  return false;
+};
+
+const flattenCauseChain = (value: unknown): string | undefined => {
+  const messages: string[] = [];
+  const seen = new Set<unknown>();
+  let current: unknown = value;
+  while (current !== undefined && current !== null && !seen.has(current)) {
+    seen.add(current);
+    if (current instanceof Error) {
+      if (current.message.length > 0) {
+        messages.push(current.message);
+      }
+      current = (current as { cause?: unknown }).cause;
+    } else {
+      const str = String(current);
+      if (str.length > 0) {
+        messages.push(str);
+      }
+      current = undefined;
+    }
+  }
+  return messages.length > 0 ? messages.join(" <- ") : undefined;
+};
+
+/**
+ * Convert an arbitrary thrown value into a structured `ErrorEnvelope.error`.
+ */
+export const toErrorPayload = (value: unknown): ErrorEnvelope["error"] => {
+  if (isCliError(value)) {
+    return {
+      cause: flattenCauseChain((value as { cause?: unknown }).cause),
+      code: value.code,
+      details: value.details,
+      message: value.message,
+    };
+  }
+  if (value instanceof Error) {
+    return {
+      cause: flattenCauseChain((value as { cause?: unknown }).cause),
+      code: ErrorCode.GENERIC,
+      message: value.message || value.name || "Error",
+    };
+  }
+  return {
+    code: ErrorCode.GENERIC,
+    message: typeof value === "string" ? value : JSON.stringify(value),
+  };
+};
+
+/**
+ * Returns the leaf command name, used as the `command` field of every
+ * envelope. Commander commands carry their own name; the root program is
+ * `dx`, subcommands carry e.g. `init`, `add`, etc.
+ */
+const commandName = (command: Command): string => command.name();
+
+/**
+ * Build a success envelope. Pure function for easy testing.
+ */
+export const buildSuccessEnvelope = <T>(
+  command: Command,
+  data: T,
+): SuccessEnvelope<T> => ({
+  command: commandName(command),
+  data,
+  ok: true,
+});
+
+/**
+ * Build an error envelope from any thrown value. Pure function for easy
+ * testing.
+ */
+export const buildErrorEnvelope = (
+  command: Command,
+  value: unknown,
+): ErrorEnvelope => ({
+  command: commandName(command),
+  error: toErrorPayload(value),
+  ok: false,
+});
+
+export type OutputWriters = {
+  stderr?: StreamWriter;
+  stdout?: StreamWriter;
+};
+
+/**
+ * Emit the final JSON envelope on stdout when `--output json` is active.
+ *
+ * In text mode this is a no-op: each command keeps printing its own
+ * human-readable summary via chalk/ora.
+ */
+export const printResult = <T>(
+  command: Command,
+  envelope: ResultEnvelope<T>,
+  writers: OutputWriters = {},
+): void => {
+  if (getOutputMode(command) !== "json") {
+    return;
+  }
+  const write = writers.stdout ?? defaultStdoutWriter;
+  write(`${JSON.stringify(envelope)}\n`);
+};
+
+/**
+ * Emit a progress event on stderr as NDJSON when `--output json` is active.
+ *
+ * Commands typically call this when starting/finishing a long-running step
+ * (terraform apply, GitHub API call, …) so the driving agent can react
+ * without waiting for command completion.
+ */
+export const emitEvent = (
+  command: Command,
+  event: ProgressEvent,
+  writers: OutputWriters = {},
+): void => {
+  if (getOutputMode(command) !== "json") {
+    return;
+  }
+  const write = writers.stderr ?? defaultStderrWriter;
+  write(`${JSON.stringify(event)}\n`);
+};
+
+/**
+ * Map any thrown value to a process exit code, preferring the explicit code
+ * carried by a `CliError`.
+ */
+export const exitCodeForError = (value: unknown): ExitCodeValue => {
+  if (isCliError(value)) {
+    return exitCodeForErrorCode(value.code);
+  }
+  return ExitCode.GENERIC;
+};


### PR DESCRIPTION
Add global flags and structured exit codes to support autonomous invocations by coding agents.

This PR introduces:
- Global flags: --non-interactive/-y to disable prompts, --output <text|json> for machine-readable output
- Structured exit codes (0-6) with error classification (E_USAGE, E_MISSING_INPUT, E_PRECONDITION, E_REMOTE, E_VALIDATION)
- JSON error envelopes when --output=json is active
- New modules: exit-codes.ts (constants and CliError class) and output.ts (envelope builders and output adapters)

No user-facing behavior changes yet (flags have no effect until commands opt in). All 251 CLI tests pass.

Resolves CES-1946 (part 1/5)