### PR TITLE
Increase minimum release age in pnpm workspace

### DIFF
--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -62,7 +62,7 @@ cleanupUnusedCatalogs: true
 
 linkWorkspacePackages: true
 
-minimumReleaseAge: 1440
+minimumReleaseAge: 4320
 
 onlyBuiltDependencies:
   - '@swc/core'


### PR DESCRIPTION
Update the minimum release age from 1440 to 4320 minutes to allow for a longer delay before releases.