### PR TITLE
Upgrade workflow actions for Node 24

### DIFF
--- a/.github/workflows/_release-aws-mcp-server-deploy-dev-v1.yaml
+++ b/.github/workflows/_release-aws-mcp-server-deploy-dev-v1.yaml
@@ -52,7 +52,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Deploy Lambda
-        uses: aws-actions/aws-lambda-deploy@29ea35c124579506cf0475e20df36198eb670d89 # v1.1.0
+        uses: aws-actions/aws-lambda-deploy@d496277188b89f0be02d7a2216fc912c0427702a # v1.1.2
         with:
           function-name: ${{ env.LAMBDA_FUNCTION_NAME }}
           package-type: Image

--- a/.github/workflows/_release-aws-mcp-server-deploy-v1.yaml
+++ b/.github/workflows/_release-aws-mcp-server-deploy-v1.yaml
@@ -49,7 +49,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Deploy Lambda
-        uses: aws-actions/aws-lambda-deploy@29ea35c124579506cf0475e20df36198eb670d89 # v1.1.0
+        uses: aws-actions/aws-lambda-deploy@d496277188b89f0be02d7a2216fc912c0427702a # v1.1.2
         with:
           function-name: ${{ env.LAMBDA_FUNCTION_NAME }}
           package-type: Image

--- a/.github/workflows/_release-docker-dx-metrics-import-v1.yaml
+++ b/.github/workflows/_release-docker-dx-metrics-import-v1.yaml
@@ -24,7 +24,7 @@ jobs:
       cancel-in-progress: false
     steps:
       - name: Checkout
-        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Docker Build and Push
         uses: pagopa/dx/actions/docker-build-push@main

--- a/.github/workflows/_release-docusaurus-docs-website.yaml
+++ b/.github/workflows/_release-docusaurus-docs-website.yaml
@@ -61,4 +61,4 @@ jobs:
     steps:
       - name: Deploy to GitHub Pages
         id: deployment
-        uses: actions/deploy-pages@d6db90164ac5ed86f2b6aed7e0febac5b3c0c03e # v4
+        uses: actions/deploy-pages@cd2ce8fcbc39b97be8ca5fce6e763baed58fa128 # v5.0.0

--- a/.github/workflows/infra_drift_detection.yml
+++ b/.github/workflows/infra_drift_detection.yml
@@ -190,7 +190,7 @@ jobs:
       - name: Get Workflow Data in order to send notifications
         if: ${{ steps.drift.outputs.drift_found == 'true' || failure() }}
         id: workflow_data
-        uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea # pin@v7
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         with:
           script: |
             const run = await github.rest.actions.getWorkflowRun({

--- a/.github/workflows/infra_plan.yaml
+++ b/.github/workflows/infra_plan.yaml
@@ -272,7 +272,7 @@ jobs:
       - name: Check for Cache
         if: github.event_name == 'pull_request'
         id: tfplan-pr-cache
-        uses: actions/cache@cdf6c1fa76f9f475f3d7449005a359c84ca0f306 # v5.0.3
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
         with:
           path: ${{ steps.directory.outputs.dir }}/.pr_plan_marker
           key: ${{ steps.cache-key.outputs.cache-key }}

--- a/.github/workflows/infra_plan.yaml
+++ b/.github/workflows/infra_plan.yaml
@@ -267,7 +267,7 @@ jobs:
       - name: Check for Cache
         if: github.event_name == 'pull_request'
         id: tfplan-pr-cache
-        uses: actions/cache@5a3ec84eff668545956fd18022155c47e93e2684 # v4.2.3
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
         with:
           path: ${{ steps.directory.outputs.dir }}/.pr_plan_marker
           key: ${{ steps.cache-key.outputs.cache-key }}

--- a/.github/workflows/release-terraform-legacy-v1.yaml
+++ b/.github/workflows/release-terraform-legacy-v1.yaml
@@ -126,7 +126,7 @@ jobs:
         uses: pagopa/dx/actions/csp-login@main
 
       - name: Terraform Setup
-        uses: hashicorp/setup-terraform@a1502cd9e758c50496cc9ac5308c4843bcd56d36
+        uses: hashicorp/setup-terraform@dfe3c3f87815947d99a8997f908cb6525fc44e9e # v4.0.1
         with:
           terraform_version: ${{ needs.get-terraform-version.outputs.terraform_version }}
           terraform_wrapper: true
@@ -186,7 +186,7 @@ jobs:
         uses: pagopa/dx/actions/csp-login@main
 
       - name: Terraform Setup
-        uses: hashicorp/setup-terraform@a1502cd9e758c50496cc9ac5308c4843bcd56d36
+        uses: hashicorp/setup-terraform@dfe3c3f87815947d99a8997f908cb6525fc44e9e # v4.0.1
         with:
           terraform_version: ${{ needs.get-terraform-version.outputs.terraform_version }}
           terraform_wrapper: true

--- a/.github/workflows/validate-v1.yaml
+++ b/.github/workflows/validate-v1.yaml
@@ -56,7 +56,7 @@ jobs:
         uses: pagopa/dx/.github/actions/node-setup@main
 
       - name: Setup Go
-        uses: actions/setup-go@44694675825211faa026b3c33043df3e48a5fa00 # v6.0.0
+        uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
         with:
           go-version-file: "go.work"
           cache-dependency-path: "providers/**/*.sum"
@@ -76,7 +76,7 @@ jobs:
             ${{ runner.os }}-nx-cache-
 
       - name: Sets the base and head SHAs required for `nx affected` command
-        uses: nrwl/nx-set-shas@3e9ad7370203c1e93d109be57f3b72eb0eb511b1
+        uses: nrwl/nx-set-shas@afb73a62d26e41464e9254689e1fd6122ee683c1 # v5.0.1
 
       - name: Run code quality checks on affected projects
         run: pnpm validate


### PR DESCRIPTION
## Summary
- upgrade non-legacy workflow action pins to Node 24-compatible SHAs
- keep SHA pinning for every upgraded external action
- leave legacy workflows unchanged and keep devcontainers workflows untouched because upstream is still on Node 20

## Rationale
Several reusable workflows were still pinned to external action revisions that declare a Node 20 runtime. Updating those pins to the latest Node 24-compatible SHAs keeps the workflows aligned with the current GitHub Actions runtime direction and reduces the risk of upstream runtime incompatibilities, while preserving supply-chain hardening through commit-level pinning.

I intentionally left workflows whose names start with `legacy` unchanged, as requested. I also left the `devcontainers/action` references untouched because the latest upstream release still runs on Node 20, so changing those workflows would not improve compatibility today.

## Notes
- `pnpm validate` completed successfully.
- No Nx version plan was added: `pnpm nx release plan` reports no touched releasable projects for these root workflow-only changes.
