### PR TITLE
Add CommandPresenter interface and CliEnv schema

### DIFF
--- a/.nx/version-plans/version-plan-1779273659000.md
+++ b/.nx/version-plans/version-plan-1779273659000.md
@@ -1,0 +1,5 @@
+---
+'@pagopa/dx-cli': minor
+---
+
+Add OutputLogger domain interface and CliEnv Zod schema to decouple output logic from use-cases. Introduce the --output <text|json> global flag on the root dx command as a prerequisite for injecting different output adapters in follow-up work.

--- a/apps/cli/src/adapters/commander/__tests__/env.test.ts
+++ b/apps/cli/src/adapters/commander/__tests__/env.test.ts
@@ -1,0 +1,45 @@
+/**
+ * Tests for the CLI environment schema.
+ * Validates that process.env is parsed correctly before being passed to the CLI.
+ */
+import { describe, expect, it } from "vitest";
+
+import { cliEnvSchema } from "../env.js";
+
+describe("cliEnvSchema", () => {
+  describe("CI field", () => {
+    it("is undefined when CI is not set", () => {
+      const result = cliEnvSchema.safeParse({});
+      expect(result.success).toBe(true);
+      expect(result.success && result.data.CI).toBeUndefined();
+    });
+
+    it("captures any non-empty CI value", () => {
+      const result = cliEnvSchema.safeParse({ CI: "true" });
+      expect(result.success).toBe(true);
+      expect(result.success && result.data.CI).toBe("true");
+    });
+
+    it("captures CI=false as a string (presence is the signal, not the value)", () => {
+      const result = cliEnvSchema.safeParse({ CI: "false" });
+      expect(result.success).toBe(true);
+      expect(result.success && result.data.CI).toBe("false");
+    });
+
+    it("captures CI=1 for numeric-style env vars", () => {
+      const result = cliEnvSchema.safeParse({ CI: "1" });
+      expect(result.success).toBe(true);
+      expect(result.success && result.data.CI).toBe("1");
+    });
+  });
+
+  it("passes through an object with unrelated env keys without failing", () => {
+    const result = cliEnvSchema.safeParse({
+      CI: "true",
+      HOME: "/home/user",
+      NODE_ENV: "test",
+    });
+    expect(result.success).toBe(true);
+    expect(result.success && result.data.CI).toBe("true");
+  });
+});

--- a/apps/cli/src/adapters/commander/__tests__/env.test.ts
+++ b/apps/cli/src/adapters/commander/__tests__/env.test.ts
@@ -1,44 +1,49 @@
 /**
  * Tests for the CLI environment schema.
- * Validates that process.env is parsed correctly before being passed to the CLI.
+ * Validates that `cliEnvSchema` correctly parses `process.env`.
  */
-import { describe, expect, it } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 
 import { cliEnvSchema } from "../env.js";
 
 describe("cliEnvSchema", () => {
+  afterEach(() => {
+    vi.unstubAllEnvs();
+  });
+
   describe("CI field", () => {
     it("is undefined when CI is not set", () => {
-      const result = cliEnvSchema.safeParse({});
+      vi.stubEnv("CI", undefined);
+      const result = cliEnvSchema.safeParse(process.env);
       expect(result.success).toBe(true);
       expect(result.success && result.data.CI).toBeUndefined();
     });
 
     it("captures any non-empty CI value", () => {
-      const result = cliEnvSchema.safeParse({ CI: "true" });
+      vi.stubEnv("CI", "true");
+      const result = cliEnvSchema.safeParse(process.env);
       expect(result.success).toBe(true);
       expect(result.success && result.data.CI).toBe("true");
     });
 
     it("captures CI=false as a string (presence is the signal, not the value)", () => {
-      const result = cliEnvSchema.safeParse({ CI: "false" });
+      vi.stubEnv("CI", "false");
+      const result = cliEnvSchema.safeParse(process.env);
       expect(result.success).toBe(true);
       expect(result.success && result.data.CI).toBe("false");
     });
 
     it("captures CI=1 for numeric-style env vars", () => {
-      const result = cliEnvSchema.safeParse({ CI: "1" });
+      vi.stubEnv("CI", "1");
+      const result = cliEnvSchema.safeParse(process.env);
       expect(result.success).toBe(true);
       expect(result.success && result.data.CI).toBe("1");
     });
   });
 
   it("passes through an object with unrelated env keys without failing", () => {
-    const result = cliEnvSchema.safeParse({
-      CI: "true",
-      HOME: "/home/user",
-      NODE_ENV: "test",
-    });
+    vi.stubEnv("CI", "true");
+    const result = cliEnvSchema.safeParse(process.env);
     expect(result.success).toBe(true);
     expect(result.success && result.data.CI).toBe("true");
   });

--- a/apps/cli/src/adapters/commander/__tests__/global-options.test.ts
+++ b/apps/cli/src/adapters/commander/__tests__/global-options.test.ts
@@ -1,0 +1,48 @@
+import { Command } from "commander";
+import { describe, expect, it } from "vitest";
+import { mock } from "vitest-mock-extended";
+
+import type { Config } from "../../../config.js";
+import type { Dependencies } from "../../../domain/dependencies.js";
+
+import { type CliDependencies, makeCli } from "../index.js";
+
+const makeProgram = (argv: string[]): Command => {
+  const program = makeCli(
+    mock<Dependencies>(),
+    mock<Config>(),
+    mock<CliDependencies>(),
+    "0.0.0",
+  );
+  program.exitOverride().configureOutput({
+    writeErr: () => {
+      /* silence stderr in tests */
+    },
+    writeOut: () => {
+      /* silence stdout in tests */
+    },
+  });
+  program.parseOptions(argv);
+  return program;
+};
+
+describe("--output option", () => {
+  it("defaults to 'text' when not provided", () => {
+    const program = makeProgram([]);
+    expect(program.opts().output).toBe("text");
+  });
+
+  it("accepts 'text' explicitly", () => {
+    const program = makeProgram(["--output", "text"]);
+    expect(program.opts().output).toBe("text");
+  });
+
+  it("accepts 'json'", () => {
+    const program = makeProgram(["--output", "json"]);
+    expect(program.opts().output).toBe("json");
+  });
+
+  it("rejects invalid values", () => {
+    expect(() => makeProgram(["--output", "xml"])).toThrow();
+  });
+});

--- a/apps/cli/src/adapters/commander/env.ts
+++ b/apps/cli/src/adapters/commander/env.ts
@@ -1,0 +1,20 @@
+/**
+ * Zod schema for the CLI environment variables.
+ *
+ * All access to `process.env` happens in the entrypoint (`src/index.ts`),
+ * which parses the raw environment once and passes the validated result as
+ * `CliEnv` to every command. This keeps env-var reads out of use-cases and
+ * adapters and makes them fully testable.
+ */
+import { z } from "zod";
+
+export const cliEnvSchema = z
+  .object({
+    // Standard CI marker. Presence (any string value) signals an automated
+    // pipeline where interactive prompts must not block. Follows the same
+    // convention used by `is-interactive` and `ora`.
+    CI: z.string().optional(),
+  })
+  .passthrough();
+
+export type CliEnv = z.infer<typeof cliEnvSchema>;

--- a/apps/cli/src/adapters/commander/env.ts
+++ b/apps/cli/src/adapters/commander/env.ts
@@ -1,8 +1,8 @@
 /**
  * Zod schema for the CLI environment variables.
  *
- * All access to `process.env` happens in the entrypoint (`src/index.ts`),
- * which parses the raw environment once and passes the validated result as
+ * Intended to centralize env parsing at the entrypoint (`src/index.ts`),
+ * which will parse the raw environment once and pass the validated result as
  * `CliEnv` to every command. This keeps env-var reads out of use-cases and
  * adapters and makes them fully testable.
  */
@@ -15,6 +15,6 @@ export const cliEnvSchema = z
     // convention used by `is-interactive` and `ora`.
     CI: z.string().optional(),
   })
-  .passthrough();
+  .loose();
 
 export type CliEnv = z.infer<typeof cliEnvSchema>;

--- a/apps/cli/src/adapters/commander/index.ts
+++ b/apps/cli/src/adapters/commander/index.ts
@@ -16,7 +16,7 @@ import { formatErrorDetailed, toErrorMessage } from "./error-reporting.js";
 export type CliDependencies = CodemodCommandDependencies;
 
 export type GlobalOptions = {
-  output?: "json" | "text";
+  output: "json" | "text";
   verbose?: boolean;
 };
 

--- a/apps/cli/src/adapters/commander/index.ts
+++ b/apps/cli/src/adapters/commander/index.ts
@@ -1,4 +1,4 @@
-import { Command } from "commander";
+import { Command, Option } from "commander";
 
 import { Config } from "../../config.js";
 import { Dependencies } from "../../domain/dependencies.js";
@@ -16,6 +16,7 @@ import { formatErrorDetailed, toErrorMessage } from "./error-reporting.js";
 export type CliDependencies = CodemodCommandDependencies;
 
 export type GlobalOptions = {
+  output?: "json" | "text";
   verbose?: boolean;
 };
 
@@ -42,6 +43,14 @@ export const makeCli = (
       "-v, --verbose",
       "Enable verbose output: debug-level logs and full error chain (with stack traces) when a command fails",
       false,
+    )
+    .addOption(
+      new Option(
+        "--output <mode>",
+        "Output mode: 'text' (human-readable, default) or 'json' (structured JSON envelope on stdout, NDJSON progress events on stderr)",
+      )
+        .choices(["text", "json"])
+        .default("text"),
     );
 
   program.addCommand(makeDoctorCommand(deps, config));

--- a/apps/cli/src/domain/command-presenter.ts
+++ b/apps/cli/src/domain/command-presenter.ts
@@ -2,8 +2,7 @@
  * CommandPresenter — domain port for all CLI output.
  *
  * Use-cases depend on this interface, not on any concrete output mechanism.
- * Adapters (TextCommandPresenter, JsonCommandPresenter) satisfy this port and
- * are injected at the entry point.
+ * Concrete implementations are injected at the entry point.
  *
  * The interface deliberately does NOT handle process exit: callers report the
  * error through `reportError`, then let the host terminate the process with
@@ -21,15 +20,11 @@ export interface CommandPresenter {
 
   /**
    * Emits the final successful result.
-   * In text mode this renders a human-readable summary; in JSON mode it emits
-   * a structured `{"ok":true,...}` envelope on stdout.
    */
   reportResult<T>(data: T): void;
 
   /**
    * Tracks `task` while emitting start/end lifecycle events for the named step.
-   * In text mode this shows an interactive progress indicator; in JSON mode it
-   * emits NDJSON step events on stderr.
    */
   trackStep<T>(name: string, task: () => Promise<T>): Promise<T>;
 }

--- a/apps/cli/src/domain/command-presenter.ts
+++ b/apps/cli/src/domain/command-presenter.ts
@@ -1,9 +1,9 @@
 /**
- * OutputLogger — domain port for all CLI output.
+ * CommandPresenter — domain port for all CLI output.
  *
  * Use-cases depend on this interface, not on any concrete output mechanism.
- * Adapters (TextOutputLogger, JsonOutputLogger) satisfy this port and are
- * injected at the entry point.
+ * Adapters (TextCommandPresenter, JsonCommandPresenter) satisfy this port and
+ * are injected at the entry point.
  *
  * The interface deliberately does NOT handle process exit: callers report the
  * error through `reportError`, then let the host terminate the process with
@@ -11,7 +11,7 @@
  */
 
 // eslint-disable-next-line @typescript-eslint/consistent-type-definitions
-export interface OutputLogger {
+export interface CommandPresenter {
   /**
    * Formats and emits the error.
    * Does NOT exit the process — that responsibility belongs to the host
@@ -27,9 +27,9 @@ export interface OutputLogger {
   reportResult<T>(data: T): void;
 
   /**
-   * Runs `task` while emitting start/end lifecycle events for the named step.
+   * Tracks `task` while emitting start/end lifecycle events for the named step.
    * In text mode this shows an interactive progress indicator; in JSON mode it
    * emits NDJSON step events on stderr.
    */
-  runStep<T>(name: string, task: () => Promise<T>): Promise<T>;
+  trackStep<T>(name: string, task: () => Promise<T>): Promise<T>;
 }

--- a/apps/cli/src/domain/output-logger.ts
+++ b/apps/cli/src/domain/output-logger.ts
@@ -1,0 +1,35 @@
+/**
+ * OutputLogger — domain port for all CLI output.
+ *
+ * Use-cases depend on this interface, not on any concrete output mechanism.
+ * Adapters (TextOutputLogger, JsonOutputLogger) satisfy it at the commander
+ * layer and are injected at the entry point.
+ *
+ * The interface deliberately does NOT handle process exit: callers report the
+ * error through `reportError`, then let commander terminate the process with
+ * the appropriate exit code.
+ */
+
+// eslint-disable-next-line @typescript-eslint/consistent-type-definitions
+export interface OutputLogger {
+  /**
+   * Formats and emits the error.
+   * Does NOT exit the process — that responsibility belongs to the commander
+   * adapter which calls `command.error(…, { exitCode })` after this.
+   */
+  reportError(error: unknown): void;
+
+  /**
+   * Emits the final successful result.
+   * In text mode this renders a human-readable summary; in JSON mode it emits
+   * a structured `{"ok":true,...}` envelope on stdout.
+   */
+  reportResult<T>(data: T): void;
+
+  /**
+   * Runs `task` while emitting start/end lifecycle events for the named step.
+   * In text mode this shows an ora spinner; in JSON mode it emits NDJSON
+   * step events on stderr.
+   */
+  runStep<T>(name: string, task: () => Promise<T>): Promise<T>;
+}

--- a/apps/cli/src/domain/output-logger.ts
+++ b/apps/cli/src/domain/output-logger.ts
@@ -2,11 +2,11 @@
  * OutputLogger — domain port for all CLI output.
  *
  * Use-cases depend on this interface, not on any concrete output mechanism.
- * Adapters (TextOutputLogger, JsonOutputLogger) satisfy it at the commander
- * layer and are injected at the entry point.
+ * Adapters (TextOutputLogger, JsonOutputLogger) satisfy this port and are
+ * injected at the entry point.
  *
  * The interface deliberately does NOT handle process exit: callers report the
- * error through `reportError`, then let commander terminate the process with
+ * error through `reportError`, then let the host terminate the process with
  * the appropriate exit code.
  */
 
@@ -14,8 +14,8 @@
 export interface OutputLogger {
   /**
    * Formats and emits the error.
-   * Does NOT exit the process — that responsibility belongs to the commander
-   * adapter which calls `command.error(…, { exitCode })` after this.
+   * Does NOT exit the process — that responsibility belongs to the host
+   * after this returns.
    */
   reportError(error: unknown): void;
 
@@ -28,8 +28,8 @@ export interface OutputLogger {
 
   /**
    * Runs `task` while emitting start/end lifecycle events for the named step.
-   * In text mode this shows an ora spinner; in JSON mode it emits NDJSON
-   * step events on stderr.
+   * In text mode this shows an interactive progress indicator; in JSON mode it
+   * emits NDJSON step events on stderr.
    */
   runStep<T>(name: string, task: () => Promise<T>): Promise<T>;
 }


### PR DESCRIPTION
Introduces the foundational building blocks for agent-friendly CLI output.

Zod v4 schema that validates `process.env` once at the entrypoint and passes a typed `CliEnv` value down. Keeps env-var reads out of use-cases and adapters and makes them fully testable.

Adds `--output <text|json>` to the root `dx` program (default: `text`).

No behaviour change — port and schema only, wiring follows in subsequent PRs.

Closes CES-1946