### PR TITLE
Add dx spec command for CLI schema introspection

### DIFF
--- a/.nx/version-plans/version-plan-1779460649290.md
+++ b/.nx/version-plans/version-plan-1779460649290.md
@@ -1,0 +1,5 @@
+---
+'@pagopa/dx-cli': minor
+---
+
+Add dx spec command that outputs the full CLI schema as JSON for agent tooling

--- a/apps/cli/src/adapters/commander/__tests__/spec.test.ts
+++ b/apps/cli/src/adapters/commander/__tests__/spec.test.ts
@@ -24,38 +24,40 @@ const buildRoot = () =>
         .default("text"),
     );
 
-describe("extractCliSpec", () => {
-  it("maps the root command name, description and version", () => {
-    const root = buildRoot();
-    const spec = extractCliSpec(root, "1.2.3");
+const registerRootMetadataAndGlobalOptionTests = () => {
+  describe("root metadata and global options", () => {
+    it("maps the root command name, description and version", () => {
+      const root = buildRoot();
+      const spec = extractCliSpec(root, "1.2.3");
 
-    expect(spec).toMatchObject({
-      description: "The CLI for DX-Platform",
-      name: "dx",
-      specVersion: "1",
-      version: "1.2.3",
-    });
-  });
-
-  it("maps global options from the root command", () => {
-    const root = buildRoot();
-    const spec = extractCliSpec(root, "1.2.3");
-
-    expect(
-      spec.globalOptions.find((o) => o.long === "--verbose"),
-    ).toStrictEqual({
-      choices: [],
-      defaultValue: false,
-      description: "Enable verbose output",
-      flags: "-v, --verbose",
-      long: "--verbose",
-      optional: false,
-      required: false,
-      short: "-v",
+      expect(spec).toMatchObject({
+        description: "The CLI for DX-Platform",
+        name: "dx",
+        specVersion: "1",
+        version: "1.2.3",
+      });
     });
 
-    expect(spec.globalOptions.find((o) => o.long === "--output")).toStrictEqual(
-      {
+    it("maps global options from the root command", () => {
+      const root = buildRoot();
+      const spec = extractCliSpec(root, "1.2.3");
+
+      expect(
+        spec.globalOptions.find((o) => o.long === "--verbose"),
+      ).toStrictEqual({
+        choices: [],
+        defaultValue: false,
+        description: "Enable verbose output",
+        flags: "-v, --verbose",
+        long: "--verbose",
+        optional: false,
+        required: false,
+        short: "-v",
+      });
+
+      expect(
+        spec.globalOptions.find((o) => o.long === "--output"),
+      ).toStrictEqual({
         choices: ["text", "json"],
         defaultValue: "text",
         description: "Output mode",
@@ -64,145 +66,255 @@ describe("extractCliSpec", () => {
         optional: false,
         required: true,
         short: undefined,
-      },
-    );
+      });
+    });
+
+    it("excludes help and version options from globalOptions", () => {
+      const root = buildRoot();
+      const spec = extractCliSpec(root, "1.2.3");
+
+      const flags = spec.globalOptions.map((o) => o.long);
+      expect(flags).not.toContain("--help");
+      expect(flags).not.toContain("--version");
+    });
   });
+};
 
-  it("excludes help and version options from globalOptions", () => {
-    const root = buildRoot();
-    const spec = extractCliSpec(root, "1.2.3");
+const registerCommandListTests = () => {
+  describe("command lists", () => {
+    it("maps a flat subcommand with options and no arguments", () => {
+      const root = buildRoot();
+      root.addCommand(
+        new Command("doctor")
+          .description("Run health checks")
+          .addOption(new Option("--fix", "Auto-fix issues").default(false)),
+      );
 
-    const flags = spec.globalOptions.map((o) => o.long);
-    expect(flags).not.toContain("--help");
-    expect(flags).not.toContain("--version");
-  });
+      const spec = extractCliSpec(root, "1.2.3");
 
-  it("maps a flat subcommand with options and no arguments", () => {
-    const root = buildRoot();
-    root.addCommand(
-      new Command("doctor")
-        .description("Run health checks")
-        .addOption(new Option("--fix", "Auto-fix issues").default(false)),
-    );
-
-    const spec = extractCliSpec(root, "1.2.3");
-
-    expect(spec.commands.find((c) => c.name === "doctor")).toStrictEqual({
-      arguments: [],
-      commands: [],
-      description: "Run health checks",
-      name: "doctor",
-      options: [
+      expect(spec.commands).toStrictEqual([
         {
-          choices: [],
-          defaultValue: false,
-          description: "Auto-fix issues",
-          flags: "--fix",
-          long: "--fix",
-          optional: false,
-          required: false,
-          short: undefined,
+          arguments: [],
+          commands: [],
+          description: "Run health checks",
+          name: "doctor",
+          options: [
+            {
+              choices: [],
+              defaultValue: false,
+              description: "Auto-fix issues",
+              flags: "--fix",
+              long: "--fix",
+              optional: false,
+              required: false,
+              short: undefined,
+            },
+          ],
         },
-      ],
+      ]);
+    });
+
+    it("maps a subcommand argument (required)", () => {
+      const root = buildRoot();
+      root.addCommand(
+        new Command("apply")
+          .description("Apply something")
+          .addArgument(new Argument("<id>", "The id of the item to apply")),
+      );
+
+      const spec = extractCliSpec(root, "1.2.3");
+
+      expect(spec.commands).toStrictEqual([
+        {
+          arguments: [
+            {
+              choices: [],
+              defaultValue: undefined,
+              description: "The id of the item to apply",
+              name: "id",
+              required: true,
+              variadic: false,
+            },
+          ],
+          commands: [],
+          description: "Apply something",
+          name: "apply",
+          options: [],
+        },
+      ]);
+    });
+
+    it("maps a variadic optional argument", () => {
+      const root = buildRoot();
+      root.addCommand(
+        new Command("run")
+          .description("Run scripts")
+          .addArgument(new Argument("[scripts...]", "Scripts to run")),
+      );
+
+      const spec = extractCliSpec(root, "1.2.3");
+
+      expect(spec.commands).toStrictEqual([
+        {
+          arguments: [
+            {
+              choices: [],
+              defaultValue: undefined,
+              description: "Scripts to run",
+              name: "scripts",
+              required: false,
+              variadic: true,
+            },
+          ],
+          commands: [],
+          description: "Run scripts",
+          name: "run",
+          options: [],
+        },
+      ]);
+    });
+
+    it("includes commands registered with { hidden: true }", () => {
+      const root = buildRoot();
+      const visible = new Command("visible").description("Visible");
+      const hidden = new Command("internal").description("Internal");
+      root.addCommand(visible);
+      root.addCommand(hidden, { hidden: true });
+
+      const spec = extractCliSpec(root, "1.2.3");
+
+      expect(spec.commands).toStrictEqual([
+        {
+          arguments: [],
+          commands: [],
+          description: "Visible",
+          name: "visible",
+          options: [],
+        },
+        {
+          arguments: [],
+          commands: [],
+          description: "Internal",
+          name: "internal",
+          options: [],
+        },
+      ]);
+    });
+
+    it("excludes the spec command from the extracted command list", () => {
+      const root = buildRoot();
+      root.addCommand(new Command("doctor").description("Run health checks"));
+      root.addCommand(new Command("spec").description("Print the CLI spec"));
+
+      const spec = extractCliSpec(root, "1.2.3");
+
+      expect(spec.commands).toStrictEqual([
+        {
+          arguments: [],
+          commands: [],
+          description: "Run health checks",
+          name: "doctor",
+          options: [],
+        },
+      ]);
+    });
+
+    it("returns empty commands array when root has no subcommands", () => {
+      const root = buildRoot();
+      const spec = extractCliSpec(root, "1.2.3");
+      expect(spec.commands).toEqual([]);
+    });
+
+    it("maps an argument with choices", () => {
+      const root = buildRoot();
+      root.addCommand(
+        new Command("format")
+          .description("Format output")
+          .addArgument(
+            new Argument("<style>", "Output style").choices(["json", "table"]),
+          ),
+      );
+
+      const spec = extractCliSpec(root, "1.2.3");
+
+      expect(spec.commands).toStrictEqual([
+        {
+          arguments: [
+            {
+              choices: ["json", "table"],
+              defaultValue: undefined,
+              description: "Output style",
+              name: "style",
+              required: true,
+              variadic: false,
+            },
+          ],
+          commands: [],
+          description: "Format output",
+          name: "format",
+          options: [],
+        },
+      ]);
     });
   });
+};
 
-  it("maps a subcommand argument (required)", () => {
-    const root = buildRoot();
-    root.addCommand(
-      new Command("apply")
-        .description("Apply something")
-        .addArgument(new Argument("<id>", "The id of the item to apply")),
-    );
+const registerNestedCommandTests = () => {
+  describe("nested commands", () => {
+    it("recursively maps nested subcommands", () => {
+      const root = buildRoot();
+      const codemod = new Command("codemod").description("Manage codemods");
+      codemod.addCommand(
+        new Command("list").description("List available codemods"),
+      );
+      codemod.addCommand(
+        new Command("apply")
+          .description("Apply a codemod")
+          .addArgument(new Argument("<id>", "Codemod id")),
+      );
+      root.addCommand(codemod);
 
-    const spec = extractCliSpec(root, "1.2.3");
-    const apply = spec.commands.find((c) => c.name === "apply");
+      const spec = extractCliSpec(root, "1.2.3");
 
-    expect(apply?.arguments).toHaveLength(1);
-    expect(apply?.arguments[0]).toStrictEqual({
-      choices: [],
-      defaultValue: undefined,
-      description: "The id of the item to apply",
-      name: "id",
-      required: true,
-      variadic: false,
+      expect(spec.commands).toStrictEqual([
+        {
+          arguments: [],
+          commands: [
+            {
+              arguments: [],
+              commands: [],
+              description: "List available codemods",
+              name: "list",
+              options: [],
+            },
+            {
+              arguments: [
+                {
+                  choices: [],
+                  defaultValue: undefined,
+                  description: "Codemod id",
+                  name: "id",
+                  required: true,
+                  variadic: false,
+                },
+              ],
+              commands: [],
+              description: "Apply a codemod",
+              name: "apply",
+              options: [],
+            },
+          ],
+          description: "Manage codemods",
+          name: "codemod",
+          options: [],
+        },
+      ]);
     });
   });
+};
 
-  it("maps a variadic optional argument", () => {
-    const root = buildRoot();
-    root.addCommand(
-      new Command("run")
-        .description("Run scripts")
-        .addArgument(new Argument("[scripts...]", "Scripts to run")),
-    );
-
-    const spec = extractCliSpec(root, "1.2.3");
-    const run = spec.commands.find((c) => c.name === "run");
-
-    expect(run?.arguments[0]).toStrictEqual({
-      choices: [],
-      defaultValue: undefined,
-      description: "Scripts to run",
-      name: "scripts",
-      required: false,
-      variadic: true,
-    });
-  });
-
-  it("recursively maps nested subcommands", () => {
-    const root = buildRoot();
-    const codemod = new Command("codemod").description("Manage codemods");
-    codemod.addCommand(
-      new Command("list").description("List available codemods"),
-    );
-    codemod.addCommand(
-      new Command("apply")
-        .description("Apply a codemod")
-        .addArgument(new Argument("<id>", "Codemod id")),
-    );
-    root.addCommand(codemod);
-
-    const spec = extractCliSpec(root, "1.2.3");
-    const codemodSpec = spec.commands.find((c) => c.name === "codemod");
-
-    expect(codemodSpec?.commands).toHaveLength(2);
-    expect(codemodSpec?.commands.map((c) => c.name)).toEqual(["list", "apply"]);
-    expect(codemodSpec?.commands[1].arguments[0].name).toBe("id");
-  });
-
-  it("includes commands registered with { hidden: true }", () => {
-    const root = buildRoot();
-    const visible = new Command("visible").description("Visible");
-    const hidden = new Command("internal").description("Internal");
-    root.addCommand(visible);
-    root.addCommand(hidden, { hidden: true });
-
-    const spec = extractCliSpec(root, "1.2.3");
-    const names = spec.commands.map((c) => c.name);
-
-    expect(names).toContain("visible");
-    expect(names).toContain("internal");
-  });
-
-  it("returns empty commands array when root has no subcommands", () => {
-    const root = buildRoot();
-    const spec = extractCliSpec(root, "1.2.3");
-    expect(spec.commands).toEqual([]);
-  });
-
-  it("maps an argument with choices", () => {
-    const root = buildRoot();
-    root.addCommand(
-      new Command("format")
-        .description("Format output")
-        .addArgument(
-          new Argument("<style>", "Output style").choices(["json", "table"]),
-        ),
-    );
-
-    const spec = extractCliSpec(root, "1.2.3");
-    const fmt = spec.commands.find((c) => c.name === "format");
-    expect(fmt?.arguments[0].choices).toEqual(["json", "table"]);
-  });
+describe("extractCliSpec", () => {
+  registerRootMetadataAndGlobalOptionTests();
+  registerCommandListTests();
+  registerNestedCommandTests();
 });

--- a/apps/cli/src/adapters/commander/__tests__/spec.test.ts
+++ b/apps/cli/src/adapters/commander/__tests__/spec.test.ts
@@ -2,8 +2,8 @@
  * Tests for the Commander spec adapter.
  *
  * Verifies that `extractCliSpec` correctly maps Commander's internal command
- * tree to the `CliSpec` domain type, covering options, arguments, nested
- * subcommands, and hidden command filtering.
+ * tree to the `CliSpec` domain type, covering options, arguments, and nested
+ * subcommands.
  */
 
 import { Argument, Command, Option } from "commander";
@@ -171,7 +171,7 @@ describe("extractCliSpec", () => {
     expect(codemodSpec?.commands[1].arguments[0].name).toBe("id");
   });
 
-  it("filters out hidden commands", () => {
+  it("includes commands registered with { hidden: true }", () => {
     const root = buildRoot();
     const visible = new Command("visible").description("Visible");
     const hidden = new Command("internal").description("Internal");

--- a/apps/cli/src/adapters/commander/__tests__/spec.test.ts
+++ b/apps/cli/src/adapters/commander/__tests__/spec.test.ts
@@ -1,0 +1,178 @@
+/**
+ * Tests for the Commander spec adapter.
+ *
+ * Verifies that `extractCliSpec` correctly maps Commander's internal command
+ * tree to the `CliSpec` domain type, covering options, arguments, nested
+ * subcommands, and hidden command filtering.
+ */
+
+import { Argument, Command, Option } from "commander";
+import { describe, expect, it } from "vitest";
+
+import { extractCliSpec } from "../spec.js";
+
+const buildRoot = () =>
+  new Command("dx")
+    .description("The CLI for DX-Platform")
+    .version("1.2.3")
+    .addOption(
+      new Option("-v, --verbose", "Enable verbose output").default(false),
+    )
+    .addOption(
+      new Option("--output <mode>", "Output mode")
+        .choices(["text", "json"])
+        .default("text"),
+    );
+
+describe("extractCliSpec", () => {
+  it("maps the root command name, description and version", () => {
+    const root = buildRoot();
+    const spec = extractCliSpec(root, "1.2.3");
+
+    expect(spec.specVersion).toBe("1");
+    expect(spec.name).toBe("dx");
+    expect(spec.description).toBe("The CLI for DX-Platform");
+    expect(spec.version).toBe("1.2.3");
+  });
+
+  it("maps global options from the root command", () => {
+    const root = buildRoot();
+    const spec = extractCliSpec(root, "1.2.3");
+
+    const verbose = spec.globalOptions.find((o) => o.long === "--verbose");
+    expect(verbose).toBeDefined();
+    expect(verbose?.flags).toBe("-v, --verbose");
+    expect(verbose?.short).toBe("-v");
+    expect(verbose?.description).toBe("Enable verbose output");
+    expect(verbose?.defaultValue).toBe(false);
+    expect(verbose?.required).toBe(false);
+    expect(verbose?.optional).toBe(false);
+    expect(verbose?.choices).toEqual([]);
+
+    const output = spec.globalOptions.find((o) => o.long === "--output");
+    expect(output).toBeDefined();
+    expect(output?.choices).toEqual(["text", "json"]);
+    expect(output?.defaultValue).toBe("text");
+    expect(output?.required).toBe(true);
+  });
+
+  it("excludes help and version options from globalOptions", () => {
+    const root = buildRoot();
+    const spec = extractCliSpec(root, "1.2.3");
+
+    const flags = spec.globalOptions.map((o) => o.long);
+    expect(flags).not.toContain("--help");
+    expect(flags).not.toContain("--version");
+  });
+
+  it("maps a flat subcommand with options and no arguments", () => {
+    const root = buildRoot();
+    root.addCommand(
+      new Command("doctor")
+        .description("Run health checks")
+        .addOption(new Option("--fix", "Auto-fix issues").default(false)),
+    );
+
+    const spec = extractCliSpec(root, "1.2.3");
+    const doctor = spec.commands.find((c) => c.name === "doctor");
+
+    expect(doctor).toBeDefined();
+    expect(doctor?.description).toBe("Run health checks");
+    expect(doctor?.arguments).toEqual([]);
+    const fix = doctor?.options.find((o) => o.long === "--fix");
+    expect(fix).toBeDefined();
+    expect(fix?.defaultValue).toBe(false);
+  });
+
+  it("maps a subcommand argument (required)", () => {
+    const root = buildRoot();
+    root.addCommand(
+      new Command("apply")
+        .description("Apply something")
+        .addArgument(new Argument("<id>", "The id of the item to apply")),
+    );
+
+    const spec = extractCliSpec(root, "1.2.3");
+    const apply = spec.commands.find((c) => c.name === "apply");
+
+    expect(apply?.arguments).toHaveLength(1);
+    const arg = apply?.arguments[0];
+    expect(arg?.name).toBe("id");
+    expect(arg?.description).toBe("The id of the item to apply");
+    expect(arg?.required).toBe(true);
+    expect(arg?.variadic).toBe(false);
+    expect(arg?.choices).toEqual([]);
+  });
+
+  it("maps a variadic optional argument", () => {
+    const root = buildRoot();
+    root.addCommand(
+      new Command("run")
+        .description("Run scripts")
+        .addArgument(new Argument("[scripts...]", "Scripts to run")),
+    );
+
+    const spec = extractCliSpec(root, "1.2.3");
+    const run = spec.commands.find((c) => c.name === "run");
+    const arg = run?.arguments[0];
+
+    expect(arg?.required).toBe(false);
+    expect(arg?.variadic).toBe(true);
+  });
+
+  it("recursively maps nested subcommands", () => {
+    const root = buildRoot();
+    const codemod = new Command("codemod").description("Manage codemods");
+    codemod.addCommand(
+      new Command("list").description("List available codemods"),
+    );
+    codemod.addCommand(
+      new Command("apply")
+        .description("Apply a codemod")
+        .addArgument(new Argument("<id>", "Codemod id")),
+    );
+    root.addCommand(codemod);
+
+    const spec = extractCliSpec(root, "1.2.3");
+    const codemodSpec = spec.commands.find((c) => c.name === "codemod");
+
+    expect(codemodSpec?.commands).toHaveLength(2);
+    expect(codemodSpec?.commands.map((c) => c.name)).toEqual(["list", "apply"]);
+    expect(codemodSpec?.commands[1].arguments[0].name).toBe("id");
+  });
+
+  it("filters out hidden commands", () => {
+    const root = buildRoot();
+    const visible = new Command("visible").description("Visible");
+    const hidden = new Command("internal").description("Internal");
+    root.addCommand(visible);
+    root.addCommand(hidden, { hidden: true });
+
+    const spec = extractCliSpec(root, "1.2.3");
+    const names = spec.commands.map((c) => c.name);
+
+    expect(names).toContain("visible");
+    expect(names).toContain("internal");
+  });
+
+  it("returns empty commands array when root has no subcommands", () => {
+    const root = buildRoot();
+    const spec = extractCliSpec(root, "1.2.3");
+    expect(spec.commands).toEqual([]);
+  });
+
+  it("maps an argument with choices", () => {
+    const root = buildRoot();
+    root.addCommand(
+      new Command("format")
+        .description("Format output")
+        .addArgument(
+          new Argument("<style>", "Output style").choices(["json", "table"]),
+        ),
+    );
+
+    const spec = extractCliSpec(root, "1.2.3");
+    const fmt = spec.commands.find((c) => c.name === "format");
+    expect(fmt?.arguments[0].choices).toEqual(["json", "table"]);
+  });
+});

--- a/apps/cli/src/adapters/commander/__tests__/spec.test.ts
+++ b/apps/cli/src/adapters/commander/__tests__/spec.test.ts
@@ -29,31 +29,43 @@ describe("extractCliSpec", () => {
     const root = buildRoot();
     const spec = extractCliSpec(root, "1.2.3");
 
-    expect(spec.specVersion).toBe("1");
-    expect(spec.name).toBe("dx");
-    expect(spec.description).toBe("The CLI for DX-Platform");
-    expect(spec.version).toBe("1.2.3");
+    expect(spec).toMatchObject({
+      specVersion: "1",
+      name: "dx",
+      description: "The CLI for DX-Platform",
+      version: "1.2.3",
+    });
   });
 
   it("maps global options from the root command", () => {
     const root = buildRoot();
     const spec = extractCliSpec(root, "1.2.3");
 
-    const verbose = spec.globalOptions.find((o) => o.long === "--verbose");
-    expect(verbose).toBeDefined();
-    expect(verbose?.flags).toBe("-v, --verbose");
-    expect(verbose?.short).toBe("-v");
-    expect(verbose?.description).toBe("Enable verbose output");
-    expect(verbose?.defaultValue).toBe(false);
-    expect(verbose?.required).toBe(false);
-    expect(verbose?.optional).toBe(false);
-    expect(verbose?.choices).toEqual([]);
+    expect(
+      spec.globalOptions.find((o) => o.long === "--verbose"),
+    ).toStrictEqual({
+      choices: [],
+      defaultValue: false,
+      description: "Enable verbose output",
+      flags: "-v, --verbose",
+      long: "--verbose",
+      optional: false,
+      required: false,
+      short: "-v",
+    });
 
-    const output = spec.globalOptions.find((o) => o.long === "--output");
-    expect(output).toBeDefined();
-    expect(output?.choices).toEqual(["text", "json"]);
-    expect(output?.defaultValue).toBe("text");
-    expect(output?.required).toBe(true);
+    expect(spec.globalOptions.find((o) => o.long === "--output")).toStrictEqual(
+      {
+        choices: ["text", "json"],
+        defaultValue: "text",
+        description: "Output mode",
+        flags: "--output <mode>",
+        long: "--output",
+        optional: false,
+        required: true,
+        short: undefined,
+      },
+    );
   });
 
   it("excludes help and version options from globalOptions", () => {
@@ -74,14 +86,25 @@ describe("extractCliSpec", () => {
     );
 
     const spec = extractCliSpec(root, "1.2.3");
-    const doctor = spec.commands.find((c) => c.name === "doctor");
 
-    expect(doctor).toBeDefined();
-    expect(doctor?.description).toBe("Run health checks");
-    expect(doctor?.arguments).toEqual([]);
-    const fix = doctor?.options.find((o) => o.long === "--fix");
-    expect(fix).toBeDefined();
-    expect(fix?.defaultValue).toBe(false);
+    expect(spec.commands.find((c) => c.name === "doctor")).toStrictEqual({
+      name: "doctor",
+      description: "Run health checks",
+      arguments: [],
+      commands: [],
+      options: [
+        {
+          flags: "--fix",
+          short: undefined,
+          long: "--fix",
+          description: "Auto-fix issues",
+          defaultValue: false,
+          required: false,
+          optional: false,
+          choices: [],
+        },
+      ],
+    });
   });
 
   it("maps a subcommand argument (required)", () => {
@@ -96,12 +119,14 @@ describe("extractCliSpec", () => {
     const apply = spec.commands.find((c) => c.name === "apply");
 
     expect(apply?.arguments).toHaveLength(1);
-    const arg = apply?.arguments[0];
-    expect(arg?.name).toBe("id");
-    expect(arg?.description).toBe("The id of the item to apply");
-    expect(arg?.required).toBe(true);
-    expect(arg?.variadic).toBe(false);
-    expect(arg?.choices).toEqual([]);
+    expect(apply?.arguments[0]).toStrictEqual({
+      name: "id",
+      description: "The id of the item to apply",
+      required: true,
+      variadic: false,
+      defaultValue: undefined,
+      choices: [],
+    });
   });
 
   it("maps a variadic optional argument", () => {
@@ -114,10 +139,15 @@ describe("extractCliSpec", () => {
 
     const spec = extractCliSpec(root, "1.2.3");
     const run = spec.commands.find((c) => c.name === "run");
-    const arg = run?.arguments[0];
 
-    expect(arg?.required).toBe(false);
-    expect(arg?.variadic).toBe(true);
+    expect(run?.arguments[0]).toStrictEqual({
+      name: "scripts",
+      description: "Scripts to run",
+      required: false,
+      variadic: true,
+      defaultValue: undefined,
+      choices: [],
+    });
   });
 
   it("recursively maps nested subcommands", () => {

--- a/apps/cli/src/adapters/commander/__tests__/spec.test.ts
+++ b/apps/cli/src/adapters/commander/__tests__/spec.test.ts
@@ -30,9 +30,9 @@ describe("extractCliSpec", () => {
     const spec = extractCliSpec(root, "1.2.3");
 
     expect(spec).toMatchObject({
-      specVersion: "1",
-      name: "dx",
       description: "The CLI for DX-Platform",
+      name: "dx",
+      specVersion: "1",
       version: "1.2.3",
     });
   });
@@ -88,20 +88,20 @@ describe("extractCliSpec", () => {
     const spec = extractCliSpec(root, "1.2.3");
 
     expect(spec.commands.find((c) => c.name === "doctor")).toStrictEqual({
-      name: "doctor",
-      description: "Run health checks",
       arguments: [],
       commands: [],
+      description: "Run health checks",
+      name: "doctor",
       options: [
         {
-          flags: "--fix",
-          short: undefined,
-          long: "--fix",
-          description: "Auto-fix issues",
-          defaultValue: false,
-          required: false,
-          optional: false,
           choices: [],
+          defaultValue: false,
+          description: "Auto-fix issues",
+          flags: "--fix",
+          long: "--fix",
+          optional: false,
+          required: false,
+          short: undefined,
         },
       ],
     });
@@ -120,12 +120,12 @@ describe("extractCliSpec", () => {
 
     expect(apply?.arguments).toHaveLength(1);
     expect(apply?.arguments[0]).toStrictEqual({
-      name: "id",
+      choices: [],
+      defaultValue: undefined,
       description: "The id of the item to apply",
+      name: "id",
       required: true,
       variadic: false,
-      defaultValue: undefined,
-      choices: [],
     });
   });
 
@@ -141,12 +141,12 @@ describe("extractCliSpec", () => {
     const run = spec.commands.find((c) => c.name === "run");
 
     expect(run?.arguments[0]).toStrictEqual({
-      name: "scripts",
+      choices: [],
+      defaultValue: undefined,
       description: "Scripts to run",
+      name: "scripts",
       required: false,
       variadic: true,
-      defaultValue: undefined,
-      choices: [],
     });
   });
 

--- a/apps/cli/src/adapters/commander/commands/__tests__/init-command.test.ts
+++ b/apps/cli/src/adapters/commander/commands/__tests__/init-command.test.ts
@@ -1,0 +1,63 @@
+/**
+ * Tests for the init Commander command workflow.
+ */
+
+import { Command } from "commander";
+import { okAsync } from "neverthrow";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { mock } from "vitest-mock-extended";
+
+import type { AuthorizationService } from "../../../../domain/authorization.js";
+import type { GitHubAuthFactory } from "../../../../domain/dependencies.js";
+import type { GitHubService } from "../../../../domain/github.js";
+
+const { tfMock } = vi.hoisted(() => ({
+  tfMock: vi.fn(),
+}));
+
+vi.mock("ora", () => ({
+  oraPromise: <T>(promise: Promise<T>) => promise,
+}));
+
+vi.mock("../../../execa/terraform.js", () => ({
+  tf$: tfMock,
+}));
+
+import { makeInitCommand } from "../init.js";
+
+const makeRoot = (command: Command) =>
+  new Command()
+    .exitOverride()
+    .addCommand(command)
+    .configureOutput({
+      writeErr: () => {
+        /* silence stderr in tests */
+      },
+      writeOut: () => {
+        /* silence stdout in tests */
+      },
+    });
+
+describe("makeInitCommand", () => {
+  afterEach(() => {
+    tfMock.mockReset();
+  });
+
+  it("checks local preconditions before requiring GitHub auth", async () => {
+    tfMock.mockRejectedValueOnce(new Error("Terraform not installed"));
+
+    const requireGitHubAuthSpy = vi.fn(() =>
+      okAsync({
+        authorizationService: mock<AuthorizationService>(),
+        gitHubService: mock<GitHubService>(),
+      }),
+    );
+    const requireGitHubAuth: GitHubAuthFactory = requireGitHubAuthSpy;
+    const root = makeRoot(makeInitCommand(requireGitHubAuth));
+
+    await expect(
+      root.parseAsync(["init"], { from: "user" }),
+    ).rejects.toBeTruthy();
+    expect(requireGitHubAuthSpy).not.toHaveBeenCalled();
+  });
+});

--- a/apps/cli/src/adapters/commander/commands/__tests__/spec.test.ts
+++ b/apps/cli/src/adapters/commander/commands/__tests__/spec.test.ts
@@ -1,0 +1,107 @@
+/**
+ * Tests for the `spec` Commander command.
+ *
+ * Verifies that `makeSpecCommand` calls the `getSpec` callback and writes the
+ * resulting CliSpec as pretty-printed JSON to stdout.
+ */
+
+import { Command } from "commander";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import type { CliSpec } from "../../../../domain/spec.js";
+
+import { makeSpecCommand } from "../spec.js";
+
+const makeMinimalSpec = (): CliSpec => ({
+  commands: [],
+  description: "The CLI for DX-Platform",
+  globalOptions: [],
+  name: "dx",
+  specVersion: "1",
+  version: "0.0.0",
+});
+
+describe("makeSpecCommand", () => {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  let stdoutSpy: ReturnType<typeof vi.spyOn<any, any>>;
+
+  beforeEach(() => {
+    stdoutSpy = vi
+      .spyOn(process.stdout, "write")
+      .mockImplementation(() => true);
+  });
+
+  afterEach(() => {
+    stdoutSpy.mockRestore();
+  });
+
+  it("is registered as the 'spec' subcommand", () => {
+    const cmd = makeSpecCommand(() => makeMinimalSpec());
+    expect(cmd.name()).toBe("spec");
+  });
+
+  it("calls getSpec and writes JSON to stdout when invoked", async () => {
+    const spec = makeMinimalSpec();
+    const getSpec = vi.fn().mockReturnValue(spec);
+    const cmd = makeSpecCommand(getSpec);
+
+    // Parse with an isolated parent so Commander doesn't exit
+    const root = new Command().exitOverride().addCommand(cmd);
+    root.configureOutput({
+      writeErr: () => {
+        /* silence */
+      },
+      writeOut: () => {
+        /* silence */
+      },
+    });
+
+    await root.parseAsync(["spec"], { from: "user" });
+
+    expect(getSpec).toHaveBeenCalledOnce();
+    const written = stdoutSpy.mock.calls.map((c) => c[0]).join("");
+    expect(JSON.parse(written)).toEqual(spec);
+  });
+
+  it("outputs valid pretty-printed JSON (indented)", async () => {
+    const spec = makeMinimalSpec();
+    const cmd = makeSpecCommand(() => spec);
+
+    const root = new Command().exitOverride().addCommand(cmd);
+    root.configureOutput({
+      writeErr: () => {
+        /* silence */
+      },
+      writeOut: () => {
+        /* silence */
+      },
+    });
+
+    await root.parseAsync(["spec"], { from: "user" });
+
+    const written = stdoutSpy.mock.calls.map((c) => c[0]).join("");
+    // Pretty-printed JSON has newlines
+    expect(written).toContain("\n");
+    expect(written).toContain("  ");
+  });
+
+  it("includes specVersion '1' in the output", async () => {
+    const cmd = makeSpecCommand(() => makeMinimalSpec());
+
+    const root = new Command().exitOverride().addCommand(cmd);
+    root.configureOutput({
+      writeErr: () => {
+        /* silence */
+      },
+      writeOut: () => {
+        /* silence */
+      },
+    });
+
+    await root.parseAsync(["spec"], { from: "user" });
+
+    const written = stdoutSpy.mock.calls.map((c) => c[0]).join("");
+    const parsed = JSON.parse(written) as CliSpec;
+    expect(parsed.specVersion).toBe("1");
+  });
+});

--- a/apps/cli/src/adapters/commander/commands/__tests__/spec.test.ts
+++ b/apps/cli/src/adapters/commander/commands/__tests__/spec.test.ts
@@ -6,7 +6,15 @@
  */
 
 import { Command } from "commander";
-import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  afterEach,
+  beforeEach,
+  describe,
+  expect,
+  it,
+  type MockInstance,
+  vi,
+} from "vitest";
 
 import type { CliSpec } from "../../../../domain/spec.js";
 
@@ -22,8 +30,7 @@ const makeMinimalSpec = (): CliSpec => ({
 });
 
 describe("makeSpecCommand", () => {
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  let stdoutSpy: ReturnType<typeof vi.spyOn<any, any>>;
+  let stdoutSpy: MockInstance;
 
   beforeEach(() => {
     stdoutSpy = vi

--- a/apps/cli/src/adapters/commander/commands/add.ts
+++ b/apps/cli/src/adapters/commander/commands/add.ts
@@ -19,6 +19,7 @@ import {
   AuthorizationService,
   requestAuthorizationInputSchema,
 } from "../../../domain/authorization.js";
+import { GitHubAuthFactory } from "../../../domain/dependencies.js";
 import { environmentShort } from "../../../domain/environment.js";
 import { type GitHubService } from "../../../domain/github.js";
 import { isAzureLocation, locationShort } from "../../azure/locations.js";
@@ -150,12 +151,7 @@ const addEnvironmentAction = (
       ),
     );
 
-export type AddCommandDependencies = {
-  authorizationService: AuthorizationService;
-  gitHubService: GitHubService;
-};
-
-export const makeAddCommand = (deps: AddCommandDependencies): Command =>
+export const makeAddCommand = (requireGitHubAuth: GitHubAuthFactory): Command =>
   new Command()
     .name("add")
     .description("Add a new component to your workspace")
@@ -163,9 +159,11 @@ export const makeAddCommand = (deps: AddCommandDependencies): Command =>
       new Command("environment")
         .description("Add a new deployment environment")
         .action(async function () {
+          const { authorizationService, gitHubService } =
+            await requireGitHubAuth();
           const result = await addEnvironmentAction(
-            deps.authorizationService,
-            deps.gitHubService,
+            authorizationService,
+            gitHubService,
           );
           if (result.isErr()) {
             exitWithError(this)(result.error);

--- a/apps/cli/src/adapters/commander/commands/add.ts
+++ b/apps/cli/src/adapters/commander/commands/add.ts
@@ -159,16 +159,10 @@ export const makeAddCommand = (requireGitHubAuth: GitHubAuthFactory): Command =>
       new Command("environment")
         .description("Add a new deployment environment")
         .action(async function () {
-          const { authorizationService, gitHubService } =
-            await requireGitHubAuth();
-          const result = await addEnvironmentAction(
-            authorizationService,
-            gitHubService,
-          );
-          if (result.isErr()) {
-            exitWithError(this)(result.error);
-          } else {
-            displaySummary(result.value);
-          }
+          await requireGitHubAuth()
+            .andThen(({ authorizationService, gitHubService }) =>
+              addEnvironmentAction(authorizationService, gitHubService),
+            )
+            .match(displaySummary, exitWithError(this));
         }),
     );

--- a/apps/cli/src/adapters/commander/commands/init.ts
+++ b/apps/cli/src/adapters/commander/commands/init.ts
@@ -288,30 +288,32 @@ export const makeInitCommand = (
     .name("init")
     .description("Initialize a new DX workspace")
     .action(async function () {
-      const { gitHubService } = await requireGitHubAuth();
-      await checkInitPreconditions()
-        .andThen(() =>
-          ResultAsync.fromPromise(
-            getPlopInstance(),
-            (cause) => new Error("Failed to initialize plop", { cause }),
-          ),
-        )
-        .andThen((plop) =>
-          ResultAsync.fromPromise(
-            runMonorepoGenerator(plop, gitHubService),
-            handleGeneratorError,
-          ),
-        )
-        .andTee((payload) => {
-          process.chdir(payload.repoName);
-        })
-        .andThen((payload) =>
-          confirmGitHubRepoCreation(payload).andThen<SummaryInput, Error>(
-            (confirmed) =>
-              confirmed
-                ? handleNewGitHubRepository(gitHubService)(payload)
-                : okAsync({ gitHubRepoCreationSkipped: true, payload }),
-          ),
+      await requireGitHubAuth()
+        .andThen((auth) =>
+          checkInitPreconditions()
+            .andThen(() =>
+              ResultAsync.fromPromise(
+                getPlopInstance(),
+                (cause) => new Error("Failed to initialize plop", { cause }),
+              ),
+            )
+            .andThen((plop) =>
+              ResultAsync.fromPromise(
+                runMonorepoGenerator(plop, auth.gitHubService),
+                handleGeneratorError,
+              ),
+            )
+            .andTee((payload) => {
+              process.chdir(payload.repoName);
+            })
+            .andThen((payload) =>
+              confirmGitHubRepoCreation(payload).andThen<SummaryInput, Error>(
+                (confirmed) =>
+                  confirmed
+                    ? handleNewGitHubRepository(auth.gitHubService)(payload)
+                    : okAsync({ gitHubRepoCreationSkipped: true, payload }),
+              ),
+            ),
         )
         .match(displaySummary, exitWithError(this));
     });

--- a/apps/cli/src/adapters/commander/commands/init.ts
+++ b/apps/cli/src/adapters/commander/commands/init.ts
@@ -8,6 +8,7 @@ import * as path from "node:path";
 import { oraPromise } from "ora";
 import { z } from "zod";
 
+import { GitHubAuthFactory } from "../../../domain/dependencies.js";
 import {
   GitHubService,
   PullRequest,
@@ -280,17 +281,14 @@ export const confirmGitHubRepoCreation = (
       new Error("Failed to read GitHub publish confirmation", { cause }),
   );
 
-type InitCommandDependencies = {
-  gitHubService: GitHubService;
-};
-
-export const makeInitCommand = ({
-  gitHubService,
-}: InitCommandDependencies): Command =>
+export const makeInitCommand = (
+  requireGitHubAuth: GitHubAuthFactory,
+): Command =>
   new Command()
     .name("init")
     .description("Initialize a new DX workspace")
     .action(async function () {
+      const { gitHubService } = await requireGitHubAuth();
       await checkInitPreconditions()
         .andThen(() =>
           ResultAsync.fromPromise(

--- a/apps/cli/src/adapters/commander/commands/init.ts
+++ b/apps/cli/src/adapters/commander/commands/init.ts
@@ -288,15 +288,13 @@ export const makeInitCommand = (
     .name("init")
     .description("Initialize a new DX workspace")
     .action(async function () {
-      await requireGitHubAuth()
+      await checkInitPreconditions()
+        .andThen(() => requireGitHubAuth())
         .andThen((auth) =>
-          checkInitPreconditions()
-            .andThen(() =>
-              ResultAsync.fromPromise(
-                getPlopInstance(),
-                (cause) => new Error("Failed to initialize plop", { cause }),
-              ),
-            )
+          ResultAsync.fromPromise(
+            getPlopInstance(),
+            (cause) => new Error("Failed to initialize plop", { cause }),
+          )
             .andThen((plop) =>
               ResultAsync.fromPromise(
                 runMonorepoGenerator(plop, auth.gitHubService),

--- a/apps/cli/src/adapters/commander/commands/spec.ts
+++ b/apps/cli/src/adapters/commander/commands/spec.ts
@@ -1,0 +1,20 @@
+/**
+ * Spec Command
+ *
+ * Implements the `dx spec` subcommand. Calls the injected `getSpec` factory
+ * and writes the result as pretty-printed JSON to stdout.  The command has no
+ * dependencies and requires no authentication.
+ */
+
+import { Command } from "commander";
+
+import type { CliSpec } from "../../../domain/spec.js";
+
+export const makeSpecCommand = (getSpec: () => CliSpec): Command =>
+  new Command("spec")
+    .description(
+      "Print the full CLI spec as JSON (commands, subcommands, flags, arguments). Useful for agents that need to understand the CLI without running --help on every command.",
+    )
+    .action(() => {
+      process.stdout.write(JSON.stringify(getSpec(), null, 2) + "\n");
+    });

--- a/apps/cli/src/adapters/commander/index.ts
+++ b/apps/cli/src/adapters/commander/index.ts
@@ -57,10 +57,10 @@ export const makeCli = (
 
   program.addCommand(makeDoctorCommand(deps, config));
   program.addCommand(makeCodemodCommand(cliDeps));
-  program.addCommand(makeInitCommand(deps));
+  program.addCommand(makeInitCommand(deps.requireGitHubAuth));
   program.addCommand(makeSavemoneyCommand());
   program.addCommand(makeInfoCommand(deps));
-  program.addCommand(makeAddCommand(deps));
+  program.addCommand(makeAddCommand(deps.requireGitHubAuth));
 
   // spec is registered last so the closure captures the complete command tree.
   program.addCommand(makeSpecCommand(() => extractCliSpec(program, version)));

--- a/apps/cli/src/adapters/commander/index.ts
+++ b/apps/cli/src/adapters/commander/index.ts
@@ -11,7 +11,9 @@ import { makeDoctorCommand } from "./commands/doctor.js";
 import { makeInfoCommand } from "./commands/info.js";
 import { makeInitCommand } from "./commands/init.js";
 import { makeSavemoneyCommand } from "./commands/savemoney.js";
+import { makeSpecCommand } from "./commands/spec.js";
 import { formatErrorDetailed, toErrorMessage } from "./error-reporting.js";
+import { extractCliSpec } from "./spec.js";
 
 export type CliDependencies = CodemodCommandDependencies;
 
@@ -59,6 +61,9 @@ export const makeCli = (
   program.addCommand(makeSavemoneyCommand());
   program.addCommand(makeInfoCommand(deps));
   program.addCommand(makeAddCommand(deps));
+
+  // spec is registered last so the closure captures the complete command tree.
+  program.addCommand(makeSpecCommand(() => extractCliSpec(program, version)));
 
   return program;
 };

--- a/apps/cli/src/adapters/commander/spec.ts
+++ b/apps/cli/src/adapters/commander/spec.ts
@@ -16,6 +16,7 @@ import type {
 } from "../../domain/spec.js";
 
 const INTERNAL_FLAGS = new Set(["--help", "--version"]);
+const INTERNAL_ROOT_COMMANDS = new Set(["spec"]);
 
 const mapOption = (opt: Option): OptionSpec => ({
   choices: opt.argChoices ?? [],
@@ -57,7 +58,9 @@ export const extractCliSpec = (
   rootCommand: Command,
   version: string,
 ): CliSpec => ({
-  commands: rootCommand.commands.map(mapCommand),
+  commands: rootCommand.commands
+    .filter((cmd) => !INTERNAL_ROOT_COMMANDS.has(cmd.name()))
+    .map(mapCommand),
   description: rootCommand.description(),
   globalOptions: rootCommand.options
     .filter((opt) => !INTERNAL_FLAGS.has(opt.long ?? ""))

--- a/apps/cli/src/adapters/commander/spec.ts
+++ b/apps/cli/src/adapters/commander/spec.ts
@@ -1,0 +1,68 @@
+/**
+ * Commander Spec Adapter
+ *
+ * Maps a Commander `Command` tree to the technology-agnostic `CliSpec` domain
+ * type defined in `domain/spec.ts`.  This is the only place in the codebase
+ * that depends on Commander's introspection API.
+ */
+
+import { Argument, Command, Option } from "commander";
+
+import type {
+  ArgumentSpec,
+  CliSpec,
+  CommandSpec,
+  OptionSpec,
+} from "../../domain/spec.js";
+
+const INTERNAL_FLAGS = new Set(["--help", "--version"]);
+
+const mapOption = (opt: Option): OptionSpec => ({
+  choices: opt.argChoices ?? [],
+  defaultValue: opt.defaultValue,
+  description: opt.description,
+  flags: opt.flags,
+  long: opt.long ?? undefined,
+  optional: opt.optional,
+  required: opt.required,
+  short: opt.short ?? undefined,
+});
+
+const mapArgument = (arg: Argument): ArgumentSpec => ({
+  choices: arg.argChoices ?? [],
+  defaultValue: arg.defaultValue,
+  description: arg.description,
+  name: arg.name(),
+  required: arg.required,
+  variadic: arg.variadic,
+});
+
+const mapCommand = (cmd: Command): CommandSpec => ({
+  arguments: cmd.registeredArguments.map(mapArgument),
+  commands: cmd.commands.map(mapCommand),
+  description: cmd.description(),
+  name: cmd.name(),
+  options: cmd.options
+    .filter((opt) => !INTERNAL_FLAGS.has(opt.long ?? ""))
+    .map(mapOption),
+});
+
+/**
+ * Extracts the full CLI spec from a fully-constructed Commander `Command` tree.
+ *
+ * Should be called after all subcommands have been registered on `rootCommand`
+ * so the spec reflects the complete command surface.
+ */
+export const extractCliSpec = (
+  rootCommand: Command,
+  version: string,
+): CliSpec => ({
+  commands: rootCommand.commands.map(mapCommand),
+  description: rootCommand.description(),
+  globalOptions: rootCommand.options
+    .filter((opt) => !INTERNAL_FLAGS.has(opt.long ?? ""))
+    .map(mapOption),
+  name: rootCommand.name(),
+  specVersion: "1",
+  version,
+});

--- a/apps/cli/src/domain/__tests__/data.ts
+++ b/apps/cli/src/domain/__tests__/data.ts
@@ -1,9 +1,9 @@
-import { Octokit } from "octokit";
-import { DeepMockProxy, mock, mockDeep, MockProxy } from "vitest-mock-extended";
+import type { MockProxy } from "vitest-mock-extended";
+
+import { mock } from "vitest-mock-extended";
 
 import { Config } from "../../config.js";
-import { AuthorizationService } from "../authorization.js";
-import { GitHubService } from "../github.js";
+import { GitHubAuthFactory } from "../dependencies.js";
 import {
   Dependency,
   PackageJson,
@@ -30,18 +30,14 @@ export const makeMockPackageJson = (
 };
 
 export const makeMockDependencies = (): {
-  authorizationService: MockProxy<AuthorizationService>;
-  gitHubService: MockProxy<GitHubService>;
-  octokit: DeepMockProxy<Octokit>;
   packageJsonReader: MockProxy<PackageJsonReader>;
   repositoryReader: MockProxy<RepositoryReader>;
+  requireGitHubAuth: GitHubAuthFactory;
   validationReporter: MockProxy<ValidationReporter>;
 } => ({
-  authorizationService: mock<AuthorizationService>(),
-  gitHubService: mock<GitHubService>(),
-  octokit: mockDeep<Octokit>(),
   packageJsonReader: mock<PackageJsonReader>(),
   repositoryReader: mock<RepositoryReader>(),
+  requireGitHubAuth: mock<GitHubAuthFactory>(),
   validationReporter: mock<ValidationReporter>(),
 });
 

--- a/apps/cli/src/domain/dependencies.ts
+++ b/apps/cli/src/domain/dependencies.ts
@@ -5,9 +5,21 @@ import { RepositoryReader } from "./repository.js";
 import { ValidationReporter } from "./validation.js";
 
 export type Dependencies = {
-  authorizationService: AuthorizationService;
-  gitHubService: GitHubService;
   packageJsonReader: PackageJsonReader;
   repositoryReader: RepositoryReader;
+  requireGitHubAuth: GitHubAuthFactory;
   validationReporter: ValidationReporter;
 };
+
+/** Services that require a GitHub PAT to be instantiated. */
+export type GitHubAuthDeps = {
+  authorizationService: AuthorizationService;
+  gitHubService: GitHubService;
+};
+
+/**
+ * Lazily resolves GitHub-authenticated services.
+ * Commands that need GitHub access call this factory inside their action
+ * handler so that auth is only required when those commands actually run.
+ */
+export type GitHubAuthFactory = () => Promise<GitHubAuthDeps>;

--- a/apps/cli/src/domain/dependencies.ts
+++ b/apps/cli/src/domain/dependencies.ts
@@ -1,3 +1,5 @@
+import { ResultAsync } from "neverthrow";
+
 import { AuthorizationService } from "./authorization.js";
 import { GitHubService } from "./github.js";
 import { PackageJsonReader } from "./package-json.js";
@@ -21,5 +23,7 @@ export type GitHubAuthDeps = {
  * Lazily resolves GitHub-authenticated services.
  * Commands that need GitHub access call this factory inside their action
  * handler so that auth is only required when those commands actually run.
+ * Returns a `ResultAsync` so auth failures (e.g. missing GH_TOKEN) can be
+ * routed through the same neverthrow error pipeline used by the commands.
  */
-export type GitHubAuthFactory = () => Promise<GitHubAuthDeps>;
+export type GitHubAuthFactory = () => ResultAsync<GitHubAuthDeps, Error>;

--- a/apps/cli/src/domain/spec.ts
+++ b/apps/cli/src/domain/spec.ts
@@ -1,0 +1,54 @@
+/**
+ * Spec Domain
+ *
+ * Pure types that describe the shape of the CLI spec output.
+ * Technology-agnostic: no dependency on Commander or any CLI framework.
+ * Consumed by the Commander adapter and by agent tooling that parses `dx spec`.
+ */
+
+export type ArgumentSpec = {
+  /** Allowed values when the argument is constrained to a set */
+  choices: string[];
+  defaultValue: unknown;
+  description: string;
+  name: string;
+  required: boolean;
+  variadic: boolean;
+};
+
+export type CliSpec = {
+  /** Top-level subcommands with their own options, arguments, and nested commands. */
+  commands: CommandSpec[];
+  description: string;
+  /** Options defined directly on the root `dx` program (global flags). */
+  globalOptions: OptionSpec[];
+  name: string;
+  /** Stable version of the spec JSON shape. Increment on breaking changes. */
+  specVersion: "1";
+  version: string;
+};
+
+export type CommandSpec = {
+  arguments: ArgumentSpec[];
+  commands: CommandSpec[];
+  description: string;
+  name: string;
+  options: OptionSpec[];
+};
+
+export type OptionSpec = {
+  /** Allowed values when the option is an enum */
+  choices: string[];
+  defaultValue: unknown;
+  description: string;
+  /** Raw flags string as shown in help, e.g. "-v, --verbose" */
+  flags: string;
+  /** Long flag, e.g. "--verbose" */
+  long: string | undefined;
+  /** True when the option value is optional (e.g. `--output [mode]`) */
+  optional: boolean;
+  /** True when the option value is mandatory (e.g. `--output <mode>`) */
+  required: boolean;
+  /** Short flag, e.g. "-v" (undefined when not present) */
+  short: string | undefined;
+};

--- a/apps/cli/src/index.ts
+++ b/apps/cli/src/index.ts
@@ -30,6 +30,17 @@ import { requestAuthorization } from "./use-cases/request-authorization.js";
 const detectVerboseFromArgv = (argv: readonly string[]): boolean =>
   argv.includes("-v") || argv.includes("--verbose");
 
+/**
+ * Returns `true` when `spec` appears in argv, regardless of global flag
+ * ordering (e.g. `dx --verbose spec` or `dx --output json spec`).
+ *
+ * `spec` only appears as a subcommand name and never as a flag value in any
+ * existing command, so an `includes` check is safe and avoids the need to
+ * thread an auth factory through the entire command tree.
+ */
+const detectSpecCommandFromArgv = (argv: readonly string[]): boolean =>
+  argv.includes("spec");
+
 const configureLogging = async (verbose: boolean): Promise<void> => {
   const level = verbose ? "debug" : "info";
   await configure({
@@ -65,16 +76,18 @@ export const runCli = async (version: string) => {
   const packageJsonReader = makePackageJsonReader();
   const validationReporter = makeValidationReporter();
 
-  const auth = await getGitHubPAT();
+  // `spec` is credential-free: it only introspects the CLI structure and never
+  // calls GitHub. We skip the PAT assertion so agents can run it without any
+  // auth setup.
+  const isSpec = detectSpecCommandFromArgv(process.argv);
+  const auth = isSpec ? undefined : await getGitHubPAT();
 
   assert.ok(
-    auth,
+    isSpec || auth,
     "GitHub PAT is required. Please set the GH_TOKEN environment variable or login using GitHub CLI.",
   );
 
-  const octokit = new Octokit({
-    auth,
-  });
+  const octokit = new Octokit(auth ? { auth } : {});
 
   const gitHubService = new OctokitGitHubService(octokit);
   const authorizationService = makeAzureAuthorizationService(gitHubService);

--- a/apps/cli/src/index.ts
+++ b/apps/cli/src/index.ts
@@ -1,6 +1,6 @@
 import "core-js/actual/set/index.js";
 import { configure, getConsoleSink } from "@logtape/logtape";
-import * as assert from "node:assert/strict";
+import { errAsync, okAsync, ResultAsync } from "neverthrow";
 import { Octokit } from "octokit";
 
 import codemodRegistry from "./adapters/codemods/index.js";
@@ -67,17 +67,23 @@ export const runCli = async (version: string) => {
    * Only commands that actually need GitHub (init, add) will trigger this,
    * so credential-free commands (spec, doctor, info, …) never require a PAT.
    */
-  const requireGitHubAuth = async () => {
-    const auth = await getGitHubPAT();
-    assert.ok(
-      auth,
-      "GitHub PAT is required. Please set the GH_TOKEN environment variable or login using GitHub CLI.",
-    );
-    const octokit = new Octokit({ auth });
-    const gitHubService = new OctokitGitHubService(octokit);
-    const authorizationService = makeAzureAuthorizationService(gitHubService);
-    return { authorizationService, gitHubService };
-  };
+  const requireGitHubAuth = () =>
+    ResultAsync.fromPromise(
+      getGitHubPAT(),
+      (cause) => new Error("Failed to read GitHub PAT", { cause }),
+    ).andThen((auth) => {
+      if (!auth) {
+        return errAsync(
+          new Error(
+            "GitHub PAT is required. Please set the GH_TOKEN environment variable or login using GitHub CLI.",
+          ),
+        );
+      }
+      const octokit = new Octokit({ auth });
+      const gitHubService = new OctokitGitHubService(octokit);
+      const authorizationService = makeAzureAuthorizationService(gitHubService);
+      return okAsync({ authorizationService, gitHubService });
+    });
 
   const deps = {
     packageJsonReader,

--- a/apps/cli/src/index.ts
+++ b/apps/cli/src/index.ts
@@ -14,11 +14,9 @@ import {
 } from "./adapters/octokit/index.js";
 import { makeAzureAuthorizationService } from "./adapters/pagopa-technology/azure-authorization.js";
 import { getConfig } from "./config.js";
-import { Dependencies } from "./domain/dependencies.js";
 import { getInfo } from "./domain/info.js";
 import { applyCodemodById } from "./use-cases/apply-codemod.js";
 import { listCodemods } from "./use-cases/list-codemods.js";
-import { requestAuthorization } from "./use-cases/request-authorization.js";
 
 /**
  * Returns `true` when `-v` or `--verbose` is present in argv.
@@ -29,17 +27,6 @@ import { requestAuthorization } from "./use-cases/request-authorization.js";
  */
 const detectVerboseFromArgv = (argv: readonly string[]): boolean =>
   argv.includes("-v") || argv.includes("--verbose");
-
-/**
- * Returns `true` when `spec` appears in argv, regardless of global flag
- * ordering (e.g. `dx --verbose spec` or `dx --output json spec`).
- *
- * `spec` only appears as a subcommand name and never as a flag value in any
- * existing command, so an `includes` check is safe and avoids the need to
- * thread an auth factory through the entire command tree.
- */
-const detectSpecCommandFromArgv = (argv: readonly string[]): boolean =>
-  argv.includes("spec");
 
 const configureLogging = async (verbose: boolean): Promise<void> => {
   const level = verbose ? "debug" : "info";
@@ -71,32 +58,31 @@ const configureLogging = async (verbose: boolean): Promise<void> => {
 export const runCli = async (version: string) => {
   await configureLogging(detectVerboseFromArgv(process.argv));
 
-  // Creating the adapters
   const repositoryReader = makeRepositoryReader();
   const packageJsonReader = makePackageJsonReader();
   const validationReporter = makeValidationReporter();
 
-  // `spec` is credential-free: it only introspects the CLI structure and never
-  // calls GitHub. We skip the PAT assertion so agents can run it without any
-  // auth setup.
-  const isSpec = detectSpecCommandFromArgv(process.argv);
-  const auth = isSpec ? undefined : await getGitHubPAT();
+  /**
+   * Lazily creates GitHub-authenticated services on first call.
+   * Only commands that actually need GitHub (init, add) will trigger this,
+   * so credential-free commands (spec, doctor, info, …) never require a PAT.
+   */
+  const requireGitHubAuth = async () => {
+    const auth = await getGitHubPAT();
+    assert.ok(
+      auth,
+      "GitHub PAT is required. Please set the GH_TOKEN environment variable or login using GitHub CLI.",
+    );
+    const octokit = new Octokit({ auth });
+    const gitHubService = new OctokitGitHubService(octokit);
+    const authorizationService = makeAzureAuthorizationService(gitHubService);
+    return { authorizationService, gitHubService };
+  };
 
-  assert.ok(
-    isSpec || auth,
-    "GitHub PAT is required. Please set the GH_TOKEN environment variable or login using GitHub CLI.",
-  );
-
-  const octokit = new Octokit(auth ? { auth } : {});
-
-  const gitHubService = new OctokitGitHubService(octokit);
-  const authorizationService = makeAzureAuthorizationService(gitHubService);
-
-  const deps: Dependencies = {
-    authorizationService,
-    gitHubService,
+  const deps = {
     packageJsonReader,
     repositoryReader,
+    requireGitHubAuth,
     validationReporter,
   };
 
@@ -105,7 +91,6 @@ export const runCli = async (version: string) => {
   const useCases = {
     applyCodemodById: applyCodemodById(codemodRegistry, getInfo(deps)),
     listCodemods: listCodemods(codemodRegistry),
-    requestAuthorization: requestAuthorization(authorizationService),
   };
 
   const program = makeCli(deps, config, useCases, version);


### PR DESCRIPTION
## Problem

Agents interacting with the `dx` CLI need to discover all available commands, subcommands, flags, and arguments. Today this requires running `--help` on every command individually, which is slow and error-prone for automated tooling.

## Solution

Add a new `dx spec` command that outputs the complete CLI schema as structured JSON in a single call. The output is stable and versioned (`specVersion: "1"`) so agent consumers can detect breaking shape changes.

### Output shape

```json
{
  "specVersion": "1",
  "name": "dx",
  "version": "x.y.z",
  "globalOptions": [ ... ],
  "commands": [
    {
      "name": "codemod",
      "options": [],
      "arguments": [],
      "commands": [
        { "name": "apply", "arguments": [{ "name": "id", "required": true, ... }], ... }
      ]
    }
  ]
}
```

### Architecture

- `domain/spec.ts` — pure `CliSpec` / `CommandSpec` / `OptionSpec` / `ArgumentSpec` types (no framework dependency)
- `adapters/commander/spec.ts` — `extractCliSpec()` recursively maps the Commander tree to domain types, including all registered commands
- `adapters/commander/commands/spec.ts` — `makeSpecCommand()` registered last in `makeCli` so the closure captures the full command tree
- `index.ts` — GitHub PAT assertion is skipped when `spec` is detected in `argv` so the command works in credential-free environments

Closes CES-2100