### PR TITLE
Fix infra drift on prod resources

### DIFF
--- a/infra/resources/_modules/metrics_portal/import_job.tf
+++ b/infra/resources/_modules/metrics_portal/import_job.tf
@@ -36,6 +36,10 @@ resource "azurerm_key_vault_secret" "github_app_private_key" {
   # PEM-encoded private key used to sign JWTs for GitHub App authentication.
   value_wo         = "placeholder"
   value_wo_version = 1
+
+  tags = {
+    "file-encoding" = "utf-8"
+  }
 }
 
 # Scheduled Container App Job for the data import task.


### PR DESCRIPTION
## Summary

Fixes the infrastructure drift detected by the [drift detection pipeline](https://github.com/pagopa/dx/actions/runs/26398666523/job/77705320253) on prod resources.

### Drift detected (7 resources to change)

| Resource | Drift | Fix |
|---|---|---|
| `module.metrics_portal.azurerm_key_vault_secret.github_app_private_key` | Tag `"file-encoding" = "utf-8"` present in Azure but missing in Terraform code | ✅ Code fix: tag added |
| `module.mcp_server.aws_s3_bucket_server_side_encryption_configuration.mcp_knowledge_base` | `blocked_encryption_types`/`bucket_key_enabled` schema change (AWS provider) | 🔄 Resolved by `apply` |
| `module.metrics_portal.azurerm_container_app_job.import` | Secrets ordering drift (provider behavior) | 🔄 Resolved by `apply` |
| `module.metrics_portal.module.container_app.azapi_resource.managed_certificate[0]` | Tags not yet applied to managed certificate | 🔄 Resolved by `apply` |
| `module.metrics_portal.module.container_app.azurerm_container_app.this` | `ModuleVersion` tag `4.2.0` → `4.2.2` (dynamic) | 🔄 Resolved by `apply` |
| `module.metrics_portal.module.container_app.azurerm_dns_cname_record.this[0]` | `ModuleVersion` tag `4.2.0` → `4.2.2` (dynamic) | 🔄 Resolved by `apply` |
| `module.metrics_portal.module.container_app.azurerm_dns_txt_record.validation[0]` | `ModuleVersion` tag `4.2.0` → `4.2.2` (dynamic) | 🔄 Resolved by `apply` |

### Code changes

- Added `tags = { "file-encoding" = "utf-8" }` to `azurerm_key_vault_secret.github_app_private_key` to align Terraform code with the actual Azure resource state (tag was set when the PEM private key was originally uploaded).