### PR TITLE
Document required GitHub App permissions

### DIFF
--- a/.github/workflows/validate-v1.yaml
+++ b/.github/workflows/validate-v1.yaml
@@ -35,15 +35,6 @@ jobs:
           filter: tree:0
           token: ${{ steps.generate-token.outputs.token }}
 
-      - name: Checkout workflow source
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-        with:
-          path: .dx-workflow-source
-          repository: ${{ job.workflow_repository }}
-          ref: ${{ job.workflow_sha }}
-          sparse-checkout: |
-            actions/nx-release
-
       - name: Setup Node.js
         uses: pagopa/dx/.github/actions/node-setup@main
 

--- a/.nx/version-plans/version-plan-1779715693165.md
+++ b/.nx/version-plans/version-plan-1779715693165.md
@@ -1,0 +1,5 @@
+---
+docs: patch
+---
+
+Document required GitHub App permissions for self-hosted runners in the monorepo setup guide.

--- a/apps/website/docs/monorepository-setup.mdx
+++ b/apps/website/docs/monorepository-setup.mdx
@@ -115,6 +115,9 @@ Organization permissions:
 | Metadata            | `Read-only`    |
 | Self-hosted Runners | `Read & write` |
 
+These permissions only need to be configured once for the GitHub App, by one
+of the app managers.
+
 :::info[One GitHub App per product]
 
 Each product at PagoPA has its own dedicated GitHub App for the self-hosted

--- a/apps/website/docs/monorepository-setup.mdx
+++ b/apps/website/docs/monorepository-setup.mdx
@@ -94,6 +94,27 @@ account. Otherwise, go to the [next section](#run-@pagopa/dx--cli).
 The `init` command needs a GitHub App to configure the self-hosted GitHub
 runner.
 
+Configure the GitHub App with the following permissions so the self-hosted
+runner can be managed correctly.
+
+#### Required permissions
+
+Repository permissions:
+
+| Permission       | Access         |
+| ---------------- | -------------- |
+| Actions          | `Read-only`    |
+| Administration   | `Read & write` |
+| Metadata         | `Read-only`    |
+
+Organization permissions:
+
+| Permission          | Access         |
+| ------------------- | -------------- |
+| Actions             | `Read-only`    |
+| Metadata            | `Read-only`    |
+| Self-hosted Runners | `Read & write` |
+
 :::info[One GitHub App per product]
 
 Each product at PagoPA has its own dedicated GitHub App for the self-hosted

--- a/apps/website/docs/monorepository-setup.mdx
+++ b/apps/website/docs/monorepository-setup.mdx
@@ -115,8 +115,8 @@ Organization permissions:
 | Metadata            | `Read-only`    |
 | Self-hosted Runners | `Read & write` |
 
-These permissions only need to be configured once for the GitHub App, by one
-of the app managers.
+These permissions only need to be configured once for the GitHub App, by one of
+the app managers.
 
 :::info[One GitHub App per product]
 

--- a/apps/website/docs/monorepository-setup.mdx
+++ b/apps/website/docs/monorepository-setup.mdx
@@ -101,11 +101,11 @@ runner can be managed correctly.
 
 Repository permissions:
 
-| Permission       | Access         |
-| ---------------- | -------------- |
-| Actions          | `Read-only`    |
-| Administration   | `Read & write` |
-| Metadata         | `Read-only`    |
+| Permission     | Access         |
+| -------------- | -------------- |
+| Actions        | `Read-only`    |
+| Administration | `Read & write` |
+| Metadata       | `Read-only`    |
 
 Organization permissions:
 


### PR DESCRIPTION
Add documentation for the necessary permissions required by the GitHub App to manage self-hosted runners in the monorepo setup guide. Fix formatting issues in the documentation.

Resolves CES-1986