### PR TITLE
Push tags individually to trigger GitHub workflows

### DIFF
--- a/.nx/version-plans/version-plan-1779722380253.md
+++ b/.nx/version-plans/version-plan-1779722380253.md
@@ -1,0 +1,5 @@
+---
+nx-release: patch
+---
+
+Ensure that each new tag is pushed individually to allow GitHub workflows to trigger for each tag, as GitHub does not create tag push events when more than three tags are pushed in a single operation.

--- a/actions/nx-release/scripts/__tests__/sync-tags-releases-run.test.ts
+++ b/actions/nx-release/scripts/__tests__/sync-tags-releases-run.test.ts
@@ -114,4 +114,63 @@ describe("run", () => {
       expect.arrayContaining(["push", "origin", "--tags"]),
     );
   });
+
+  it("pushes each new tag individually so tag workflows can trigger", async () => {
+    listPullsMock.mockResolvedValue({
+      data: [
+        {
+          body: "<!-- nx-release-tags: [] -->",
+          merge_commit_sha: "abcdef0123456789",
+          merged_at: "2026-05-21T00:00:00Z",
+          number: 1782,
+        },
+      ],
+    });
+    extractTagEntriesFromPRBodyMock.mockReturnValue([
+      {
+        path: null,
+        tag: "docs@0.18.1",
+        version: "0.18.1",
+      },
+      {
+        path: null,
+        tag: "@pagopa/dx-cli@0.22.2",
+        version: "0.22.2",
+      },
+    ]);
+
+    execFilePromiseMock.mockImplementation(
+      async (file: string, args: readonly string[]) => {
+        if (file === "git" && args[0] === "ls-remote" && args[1] === "--tags") {
+          return {
+            stderr: "",
+            stdout: "",
+          };
+        }
+
+        return { stderr: "", stdout: "" };
+      },
+    );
+
+    getReleaseByTagMock.mockRejectedValue(
+      Object.assign(new Error("Not Found"), { status: 404 }),
+    );
+
+    await run("main");
+
+    expect(execFilePromiseMock).toHaveBeenCalledWith("git", [
+      "push",
+      "origin",
+      "refs/tags/docs@0.18.1",
+    ]);
+    expect(execFilePromiseMock).toHaveBeenCalledWith("git", [
+      "push",
+      "origin",
+      "refs/tags/@pagopa/dx-cli@0.22.2",
+    ]);
+    expect(execFilePromiseMock).not.toHaveBeenCalledWith(
+      "git",
+      expect.arrayContaining(["push", "origin", "--tags"]),
+    );
+  });
 });

--- a/actions/nx-release/scripts/sync-tags-releases.ts
+++ b/actions/nx-release/scripts/sync-tags-releases.ts
@@ -186,7 +186,13 @@ export async function run(base: string): Promise<void> {
   if (newTags.length === 0) {
     console.log("No new tags to push");
   } else {
-    await execFileAsync("git", ["push", "origin", "--tags"]);
+    // Push tags one by one so GitHub emits a push event for each tag.
+    // GitHub does not create tag push events when more than three tags are
+    // pushed in a single operation.
+    for (const { tag } of newTags) {
+      await execFileAsync("git", ["push", "origin", `refs/tags/${tag}`]);
+      console.log(`Pushed tag: ${tag}`);
+    }
   }
 
   for (const { path, tag, version } of allEntries.values()) {

--- a/actions/nx-release/scripts/sync-tags-releases.ts
+++ b/actions/nx-release/scripts/sync-tags-releases.ts
@@ -189,6 +189,7 @@ export async function run(base: string): Promise<void> {
     // Push tags one by one so GitHub emits a push event for each tag.
     // GitHub does not create tag push events when more than three tags are
     // pushed in a single operation.
+    // https://docs.github.com/en/webhooks/webhook-events-and-payloads#push
     for (const { tag } of newTags) {
       await execFileAsync("git", ["push", "origin", `refs/tags/${tag}`]);
       console.log(`Pushed tag: ${tag}`);


### PR DESCRIPTION
Ensure that each new tag is pushed individually to allow GitHub workflows to trigger for each tag, as GitHub does not create tag push events when more than three tags are pushed in a single operation.

Resolves CES-2083