### PR TITLE
Suppress Trivy warnings in azure bootstrapper for secrets

### DIFF
--- a/.nx/version-plans/version-plan-1779786478478.md
+++ b/.nx/version-plans/version-plan-1779786478478.md
@@ -2,4 +2,4 @@
 azure_github_environment_bootstrap: patch
 ---
 
-Suppress Trivy warning classified as false positive
+Suppress Trivy warning classified as a false positive

--- a/.nx/version-plans/version-plan-1779786478478.md
+++ b/.nx/version-plans/version-plan-1779786478478.md
@@ -1,0 +1,5 @@
+---
+azure_github_environment_bootstrap: patch
+---
+
+Suppress Trivy warning classified as false positive

--- a/infra/modules/azure_github_environment_bootstrap/github_environments_secrets_cd.tf
+++ b/infra/modules/azure_github_environment_bootstrap/github_environments_secrets_cd.tf
@@ -1,3 +1,4 @@
+#trivy:ignore:AVD-GIT-0002
 resource "github_actions_environment_secret" "infra_cd" {
   for_each = local.infra_cd.secrets
 
@@ -7,6 +8,7 @@ resource "github_actions_environment_secret" "infra_cd" {
   plaintext_value = each.value
 }
 
+#trivy:ignore:AVD-GIT-0002
 resource "github_actions_environment_secret" "app_cd" {
   for_each = local.app_cd.secrets
 
@@ -16,6 +18,7 @@ resource "github_actions_environment_secret" "app_cd" {
   plaintext_value = each.value
 }
 
+#trivy:ignore:AVD-GIT-0002
 resource "github_actions_environment_secret" "opex_cd" {
   for_each = local.opex_cd.secrets
 

--- a/infra/modules/azure_github_environment_bootstrap/github_environments_secrets_ci.tf
+++ b/infra/modules/azure_github_environment_bootstrap/github_environments_secrets_ci.tf
@@ -1,3 +1,4 @@
+#trivy:ignore:AVD-GIT-0002
 resource "github_actions_environment_secret" "app_ci" {
   for_each = local.app_ci.secrets
 
@@ -7,6 +8,7 @@ resource "github_actions_environment_secret" "app_ci" {
   plaintext_value = each.value
 }
 
+#trivy:ignore:AVD-GIT-0002
 resource "github_actions_environment_secret" "infra_ci" {
   for_each = local.infra_ci.secrets
 
@@ -16,6 +18,7 @@ resource "github_actions_environment_secret" "infra_ci" {
   plaintext_value = each.value
 }
 
+#trivy:ignore:AVD-GIT-0002
 resource "github_actions_environment_secret" "opex_ci" {
   for_each = local.opex_ci.secrets
 
@@ -24,4 +27,3 @@ resource "github_actions_environment_secret" "opex_ci" {
   secret_name     = each.key
   plaintext_value = each.value
 }
-

--- a/infra/modules/azure_github_environment_bootstrap/github_repository_secrets.tf
+++ b/infra/modules/azure_github_environment_bootstrap/github_repository_secrets.tf
@@ -1,3 +1,4 @@
+#trivy:ignore:AVD-GIT-0002
 resource "github_actions_secret" "repo_secrets" {
   for_each = local.repo_secrets
 


### PR DESCRIPTION
Suppress false positive Trivy warnings related to GitHub Actions environment secrets and update the changelog accordingly.

Closes CES-2104