### PR TITLE
Suppress Trivy warning for public GitHub repositories

### DIFF
--- a/.nx/version-plans/version-plan-1779786881075.md
+++ b/.nx/version-plans/version-plan-1779786881075.md
@@ -1,0 +1,5 @@
+---
+github_environment_bootstrap: patch
+---
+
+Suppress Trivy warning about public GitHub repositories

--- a/.trivyignore
+++ b/.trivyignore
@@ -1,9 +1,5 @@
 # https://avd.aquasec.com/misconfig/azure/
 
-# Github repository shouldn’t be public.
-
-AVD-GIT-0001
-
 # Ensure plaintext value is not used for GitHub Action Environment Secret.
 
 AVD-GIT-0002

--- a/infra/modules/github_environment_bootstrap/github_environments_ci.tf
+++ b/infra/modules/github_environment_bootstrap/github_environments_ci.tf
@@ -20,7 +20,6 @@ resource "github_repository_environment" "app_ci" {
   }
 }
 
-
 resource "github_repository_environment" "opex_ci" {
   for_each    = toset(var.repository.environments)
   environment = "opex-${each.value}-ci"

--- a/infra/modules/github_environment_bootstrap/github_repository.tf
+++ b/infra/modules/github_environment_bootstrap/github_repository.tf
@@ -1,3 +1,4 @@
+#trivy:ignore:AVD-GIT-0001 Github repository shouldn't be public.
 resource "github_repository" "this" {
   name        = var.repository.name
   description = var.repository.description


### PR DESCRIPTION
Suppress the Trivy warning related to public GitHub repositories and clean up the associated configurations.

Closes CES-2105