### PR TITLE
Use truthy CI env values

### DIFF
--- a/.nx/version-plans/version-plan-1779803860679.md
+++ b/.nx/version-plans/version-plan-1779803860679.md
@@ -1,0 +1,5 @@
+---
+'@pagopa/dx-cli': patch
+---
+
+Use truthy values for the CLI CI environment variable

--- a/apps/cli/package.json
+++ b/apps/cli/package.json
@@ -59,6 +59,7 @@
     "@types/semver": "catalog:",
     "@vitest/coverage-v8": "catalog:",
     "eslint": "catalog:",
+    "fast-check": "^4.8.0",
     "memfs": "^4.57.2",
     "plop": "catalog:",
     "prettier": "catalog:",

--- a/apps/cli/src/adapters/commander/__tests__/env.test.ts
+++ b/apps/cli/src/adapters/commander/__tests__/env.test.ts
@@ -1,10 +1,17 @@
+import fc from "fast-check";
 /**
  * Tests for the CLI environment schema.
  * Validates that `cliEnvSchema` correctly parses `process.env`.
  */
 import { afterEach, describe, expect, it, vi } from "vitest";
+import { z } from "zod";
 
 import { cliEnvSchema } from "../env.js";
+
+// The accepted stringbool values mirror those recognised by z.stringbool().
+const CI_TRUTHY = ["true", "1", "yes", "y", "on"];
+const CI_FALSEY = ["false", "0", "no", "n", "off"];
+const CI_ACCEPTED = [...CI_TRUTHY, ...CI_FALSEY];
 
 describe("cliEnvSchema", () => {
   afterEach(() => {
@@ -12,39 +19,44 @@ describe("cliEnvSchema", () => {
   });
 
   describe("CI field", () => {
-    it("is undefined when CI is not set", () => {
-      vi.stubEnv("CI", undefined);
-      const result = cliEnvSchema.safeParse(process.env);
-      expect(result.success).toBe(true);
-      expect(result.success && result.data.CI).toBeUndefined();
+    it("should be true for truthy string-bool values", () => {
+      fc.assert(
+        fc.property(fc.constantFrom(...CI_TRUTHY), (value) => {
+          vi.stubEnv("CI", value);
+          const result = cliEnvSchema.safeParse(process.env);
+
+          expect(result.success).toBe(true);
+          expect(result.success && result.data.CI).toBe(true);
+        }),
+      );
     });
 
-    it("captures any non-empty CI value", () => {
-      vi.stubEnv("CI", "true");
-      const result = cliEnvSchema.safeParse(process.env);
-      expect(result.success).toBe(true);
-      expect(result.success && result.data.CI).toBe("true");
+    it("should be false for falsey string-bool values or when unset", () => {
+      fc.assert(
+        fc.property(fc.constantFrom(...CI_FALSEY, undefined), (value) => {
+          vi.stubEnv("CI", value);
+          const result = cliEnvSchema.safeParse(process.env);
+
+          expect(result.success).toBe(true);
+          expect(result.success && result.data.CI).toBe(false);
+        }),
+      );
     });
 
-    it("captures CI=false as a string (presence is the signal, not the value)", () => {
-      vi.stubEnv("CI", "false");
-      const result = cliEnvSchema.safeParse(process.env);
-      expect(result.success).toBe(true);
-      expect(result.success && result.data.CI).toBe("false");
-    });
+    it("should not parse unrecognised values", () => {
+      fc.assert(
+        fc.property(
+          // Every string not in the accepted list
+          fc.string().filter((s) => !CI_ACCEPTED.includes(s.toLowerCase())),
+          (value) => {
+            vi.stubEnv("CI", value);
+            const result = cliEnvSchema.safeParse(process.env);
 
-    it("captures CI=1 for numeric-style env vars", () => {
-      vi.stubEnv("CI", "1");
-      const result = cliEnvSchema.safeParse(process.env);
-      expect(result.success).toBe(true);
-      expect(result.success && result.data.CI).toBe("1");
+            expect(result.success).toBe(false);
+            expect(result.error).toBeInstanceOf(z.ZodError);
+          },
+        ),
+      );
     });
-  });
-
-  it("passes through an object with unrelated env keys without failing", () => {
-    vi.stubEnv("CI", "true");
-    const result = cliEnvSchema.safeParse(process.env);
-    expect(result.success).toBe(true);
-    expect(result.success && result.data.CI).toBe("true");
   });
 });

--- a/apps/cli/src/adapters/commander/env.ts
+++ b/apps/cli/src/adapters/commander/env.ts
@@ -10,10 +10,8 @@ import { z } from "zod";
 
 export const cliEnvSchema = z
   .object({
-    // Standard CI marker. Presence (any string value) signals an automated
-    // pipeline where interactive prompts must not block. Follows the same
-    // convention used by `is-interactive` and `ora`.
-    CI: z.string().optional(),
+    // Use a truthy value to enable CI mode.
+    CI: z.stringbool().default(false),
   })
   .loose();
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -534,6 +534,9 @@ importers:
       eslint:
         specifier: 'catalog:'
         version: 10.3.0(jiti@2.7.0)
+      fast-check:
+        specifier: ^4.8.0
+        version: 4.8.0
       memfs:
         specifier: ^4.57.2
         version: 4.57.2(tslib@2.8.1)
@@ -8435,6 +8438,10 @@ packages:
     resolution: {integrity: sha512-h5+1OzzfCC3Ef7VbtKdcv7zsstUQwUDlYpUTvjeUsJAssPgLn7QzbboPtL5ro04Mq0rPOsMzl7q5hIbRs2wD1A==}
     engines: {node: '>=8.0.0'}
 
+  fast-check@4.8.0:
+    resolution: {integrity: sha512-GOJ158CUMnN6cSahsv4+ExARvIDuzzinFjkp0E9WtiBa5zcVeLozVkWaE4IzFcc+Y48Wp1EDlUZsXRyAztQcSg==}
+    engines: {node: '>=12.17.0'}
+
   fast-content-type-parse@3.0.0:
     resolution: {integrity: sha512-ZvLdcY8P+N8mGQJahJV5G4U88CSvT1rP8ApL6uETe88MBXrBHAkZlSEySdUlyztF7ccb+Znos3TFqaepHxdhBg==}
 
@@ -11210,6 +11217,9 @@ packages:
 
   pure-rand@6.1.0:
     resolution: {integrity: sha512-bVWawvoZoBYpp6yIoQtQXHZjmz35RSVHnUOTefl8Vcjr8snTPY1wnpSPMWekcFwbxI6gtmT7rSYPFvz71ldiOA==}
+
+  pure-rand@8.4.0:
+    resolution: {integrity: sha512-IoM8YF/jY0hiugFo/wOWqfmarlE6J0wc6fDK1PhftMk7MGhVZl88sZimmqBBFomLOCSmcCCpsfj7wXASCpvK9A==}
 
   qs@6.13.0:
     resolution: {integrity: sha512-+38qI9SOr8tfZ4QmJNplMUxqjbe7LKvvZgWdExBOmd+egZTtjLB67Gu0HRX3u/XOq7UU2Nx6nsjvS16Z9uwfpg==}
@@ -21957,6 +21967,10 @@ snapshots:
       pure-rand: 6.1.0
     optional: true
 
+  fast-check@4.8.0:
+    dependencies:
+      pure-rand: 8.4.0
+
   fast-content-type-parse@3.0.0: {}
 
   fast-deep-equal@3.1.3: {}
@@ -25352,6 +25366,8 @@ snapshots:
 
   pure-rand@6.1.0:
     optional: true
+
+  pure-rand@8.4.0: {}
 
   qs@6.13.0:
     dependencies:


### PR DESCRIPTION
## Summary
- parse the CLI `CI` environment variable with explicit truthy and falsey values
- add property-based coverage for accepted and rejected `CI` values
- include a patch version plan for `@pagopa/dx-cli`

Closes CES-1946