### PR TITLE
Wire init command to presenter

### DIFF
--- a/.nx/version-plans/version-plan-1781003378530.md
+++ b/.nx/version-plans/version-plan-1781003378530.md
@@ -1,0 +1,10 @@
+---
+'@pagopa/dx-cli': patch
+---
+
+Fix init prompts not showing in text output mode
+
+The interactive prompts were wrapped in a spinner that occupied the
+terminal, hiding them from the user. Prompt collection now runs outside
+the spinner so it stays interactive, while file scaffolding keeps its
+progress indicator.

--- a/apps/cli/src/adapters/commander/commands/__tests__/init-json.test.ts
+++ b/apps/cli/src/adapters/commander/commands/__tests__/init-json.test.ts
@@ -1,0 +1,151 @@
+/**
+ * Tests for init command JSON output contract.
+ */
+import { Command } from "commander";
+import inquirer from "inquirer";
+import { okAsync } from "neverthrow";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { mockDeep } from "vitest-mock-extended";
+
+import type { AuthorizationService } from "../../../../domain/authorization.js";
+import type { GitHubAuthFactory } from "../../../../domain/dependencies.js";
+import type { GitHubService } from "../../../../domain/github.js";
+import type { Payload as MonorepoPayload } from "../../../plop/generators/monorepo/index.js";
+
+const mocks = vi.hoisted(() => ({
+  collectMonorepoPayload: vi.fn(),
+  getPlopInstance: vi.fn(),
+  runMonorepoActions: vi.fn(),
+  tf$: vi.fn(async (...args: [TemplateStringsArray, ...unknown[]]) => {
+    void args;
+    return { stdout: '{"user":{"name":"test@example.com"}}' };
+  }),
+}));
+
+vi.mock("inquirer");
+vi.mock("../../../plop/index.js", () => ({
+  collectMonorepoPayload: mocks.collectMonorepoPayload,
+  getPlopInstance: mocks.getPlopInstance,
+  runMonorepoActions: mocks.runMonorepoActions,
+}));
+vi.mock("../../../execa/terraform.js", () => ({ tf$: mocks.tf$ }));
+
+import { makeInitCommand } from "../init.js";
+
+const makePayload = (
+  overrides: Partial<MonorepoPayload> = {},
+): MonorepoPayload => ({
+  repoDescription: "A test repo",
+  repoName: "test-repo",
+  repoOwner: "pagopa",
+  ...overrides,
+});
+
+const captureStdout = () => {
+  const written: string[] = [];
+  vi.spyOn(process.stdout, "write").mockImplementation((data: unknown) => {
+    written.push(String(data));
+    return true;
+  });
+  return { written };
+};
+
+const captureStderr = () => {
+  const written: string[] = [];
+  vi.spyOn(process.stderr, "write").mockImplementation((data: unknown) => {
+    written.push(String(data));
+    return true;
+  });
+  return { written };
+};
+
+const parseNdjson = (written: string[]) =>
+  written
+    .join("")
+    .trim()
+    .split("\n")
+    .filter(Boolean)
+    .map((line) => JSON.parse(line));
+
+describe("init command json output", () => {
+  const payload = makePayload();
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.mocked(inquirer.prompt).mockResolvedValue({ confirm: false });
+    mocks.getPlopInstance.mockResolvedValue({});
+    mocks.collectMonorepoPayload.mockResolvedValue({ generator: {}, payload });
+    mocks.runMonorepoActions.mockResolvedValue(payload);
+    vi.spyOn(process, "chdir").mockImplementation(() => undefined);
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("emits progress events and final result through the real json presenter", async () => {
+    const stdout = captureStdout();
+    const stderr = captureStderr();
+    const requireGitHubAuth: GitHubAuthFactory = () =>
+      okAsync({
+        authorizationService: mockDeep<AuthorizationService>(),
+        gitHubService: mockDeep<GitHubService>(),
+      });
+    const program = new Command()
+      .option("--output <mode>", "Output mode", "json")
+      .addCommand(makeInitCommand(requireGitHubAuth));
+    await program.parseAsync(["node", "dx", "--output", "json", "init"]);
+
+    expect(parseNdjson(stderr.written)).toEqual([
+      {
+        name: "Checking Terraform installation...",
+        status: "start",
+        type: "step",
+      },
+      {
+        name: "Checking Terraform installation...",
+        status: "success",
+        type: "step",
+      },
+      {
+        name: "Checking Corepack installation...",
+        status: "start",
+        type: "step",
+      },
+      {
+        name: "Checking Corepack installation...",
+        status: "success",
+        type: "step",
+      },
+      {
+        name: "Initializing workspace generator...",
+        status: "start",
+        type: "step",
+      },
+      {
+        name: "Initializing workspace generator...",
+        status: "success",
+        type: "step",
+      },
+      {
+        name: "Scaffolding workspace...",
+        status: "start",
+        type: "step",
+      },
+      {
+        name: "Scaffolding workspace...",
+        status: "success",
+        type: "step",
+      },
+    ]);
+    expect(parseNdjson(stdout.written)).toEqual([
+      {
+        data: {
+          gitHubRepoCreationSkipped: true,
+          payload,
+        },
+        ok: true,
+      },
+    ]);
+  });
+});

--- a/apps/cli/src/adapters/commander/commands/__tests__/init.test.ts
+++ b/apps/cli/src/adapters/commander/commands/__tests__/init.test.ts
@@ -2,14 +2,54 @@
  * Tests for confirmGitHubRepoCreation in the init command.
  */
 
+import { Command } from "commander";
 import inquirer from "inquirer";
-import { afterEach, describe, expect, it, vi } from "vitest";
+import { okAsync } from "neverthrow";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { mockDeep } from "vitest-mock-extended";
 
+import type { AuthorizationService } from "../../../../domain/authorization.js";
+import type { GitHubAuthFactory } from "../../../../domain/dependencies.js";
+import type { GitHubService } from "../../../../domain/github.js";
 import type { Payload as MonorepoPayload } from "../../../plop/generators/monorepo/index.js";
 
-import { confirmGitHubRepoCreation } from "../init.js";
+const mocks = vi.hoisted(() => {
+  const presenter = {
+    reportError: vi.fn(),
+    reportResult: vi.fn(),
+    trackStep: vi.fn(async (_name: string, task: () => Promise<unknown>) =>
+      task(),
+    ),
+  };
+
+  return {
+    collectMonorepoPayload: vi.fn(),
+    createCommandPresenter: vi.fn(() => presenter),
+    getPlopInstance: vi.fn(),
+    presenter,
+    runMonorepoActions: vi.fn(),
+    tf$: vi.fn(async (...args: [TemplateStringsArray, ...unknown[]]) => {
+      void args;
+      return { stdout: '{"user":{"name":"test@example.com"}}' };
+    }),
+  };
+});
 
 vi.mock("inquirer");
+vi.mock("ora", () => ({
+  oraPromise: <T>(promise: Promise<T>) => promise,
+}));
+vi.mock("../../../plop/index.js", () => ({
+  collectMonorepoPayload: mocks.collectMonorepoPayload,
+  getPlopInstance: mocks.getPlopInstance,
+  runMonorepoActions: mocks.runMonorepoActions,
+}));
+vi.mock("../../../execa/terraform.js", () => ({ tf$: mocks.tf$ }));
+vi.mock("../../presenters/index.js", () => ({
+  createCommandPresenter: mocks.createCommandPresenter,
+}));
+
+import { confirmGitHubRepoCreation, makeInitCommand } from "../init.js";
 
 const makePayload = (
   overrides: Partial<MonorepoPayload> = {},
@@ -19,6 +59,36 @@ const makePayload = (
   repoOwner: "pagopa",
   ...overrides,
 });
+
+const silentOutput = {
+  writeErr: () => {
+    /* silence stderr in tests */
+  },
+  writeOut: () => {
+    /* silence stdout in tests */
+  },
+};
+
+const runInitCommand = async (
+  output: "json" | "text" = "json",
+  gitHubService: GitHubService = mockDeep<GitHubService>(),
+) => {
+  const requireGitHubAuth: GitHubAuthFactory = () =>
+    okAsync({
+      authorizationService: mockDeep<AuthorizationService>(),
+      gitHubService,
+    });
+  const initCommand = makeInitCommand(requireGitHubAuth);
+  initCommand.exitOverride().configureOutput(silentOutput);
+
+  const program = new Command();
+  program
+    .exitOverride()
+    .option("--output <mode>", "Output mode", output)
+    .addCommand(initCommand);
+
+  await program.parseAsync(["node", "dx", "--output", output, "init"]);
+};
 
 describe("confirmGitHubRepoCreation", () => {
   afterEach(() => {
@@ -67,5 +137,69 @@ describe("confirmGitHubRepoCreation", () => {
     const err = result._unsafeUnwrapErr();
     expect(err).toBeInstanceOf(Error);
     expect(err.cause).toBe(cause);
+  });
+});
+
+describe("makeInitCommand", () => {
+  const payload = makePayload();
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.mocked(inquirer.prompt).mockResolvedValue({ confirm: false });
+    mocks.getPlopInstance.mockResolvedValue({});
+    mocks.collectMonorepoPayload.mockResolvedValue({ generator: {}, payload });
+    mocks.runMonorepoActions.mockResolvedValue(payload);
+    vi.spyOn(process, "chdir").mockImplementation(() => undefined);
+    process.exitCode = undefined;
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+    process.exitCode = undefined;
+  });
+
+  it("uses the command presenter to report json progress and results", async () => {
+    await runInitCommand("json");
+
+    expect(mocks.createCommandPresenter).toHaveBeenCalledWith("json");
+    expect(mocks.presenter.trackStep).toHaveBeenCalledWith(
+      "Checking Terraform installation...",
+      expect.any(Function),
+    );
+    expect(mocks.presenter.trackStep).toHaveBeenCalledWith(
+      "Checking Corepack installation...",
+      expect.any(Function),
+    );
+    expect(mocks.presenter.reportResult).toHaveBeenCalledWith(
+      expect.objectContaining({
+        gitHubRepoCreationSkipped: true,
+        payload,
+      }),
+    );
+  });
+
+  it("uses the command presenter to report json errors", async () => {
+    const error = new Error("generator failed");
+    mocks.runMonorepoActions.mockRejectedValue(error);
+
+    await runInitCommand("json");
+
+    expect(mocks.presenter.reportError).toHaveBeenCalledWith(
+      expect.objectContaining({
+        message: "Failed to run the generator",
+      }),
+    );
+    expect(process.exitCode).toBe(1);
+  });
+
+  it("uses Commander error handling for text errors", async () => {
+    const error = new Error("generator failed");
+    mocks.runMonorepoActions.mockRejectedValue(error);
+
+    await expect(runInitCommand("text")).rejects.toMatchObject({
+      code: "commander.error",
+      exitCode: 1,
+    });
+    expect(mocks.presenter.reportError).not.toHaveBeenCalled();
   });
 });

--- a/apps/cli/src/adapters/commander/commands/init.ts
+++ b/apps/cli/src/adapters/commander/commands/init.ts
@@ -8,6 +8,9 @@ import * as path from "node:path";
 import { oraPromise } from "ora";
 import { z } from "zod";
 
+import type { CommandPresenter } from "../../../domain/command-presenter.js";
+import type { GlobalOptions } from "../index.js";
+
 import { GitHubAuthFactory } from "../../../domain/dependencies.js";
 import {
   GitHubService,
@@ -16,8 +19,13 @@ import {
 } from "../../../domain/github.js";
 import { tf$ } from "../../execa/terraform.js";
 import { Payload as MonorepoPayload } from "../../plop/generators/monorepo/index.js";
-import { getPlopInstance, runMonorepoGenerator } from "../../plop/index.js";
+import {
+  collectMonorepoPayload,
+  getPlopInstance,
+  runMonorepoActions,
+} from "../../plop/index.js";
 import { exitWithError } from "../index.js";
+import { createCommandPresenter } from "../presenters/index.js";
 
 type GitHubRepoCreationSkippedResult = {
   gitHubRepoCreationSkipped: true;
@@ -36,6 +44,11 @@ const isGitHubRepoCreationSkipped = (
 ): input is GitHubRepoCreationSkippedResult =>
   "gitHubRepoCreationSkipped" in input;
 
+type InitActionContext = {
+  gitHubService: GitHubService;
+  presenter: CommandPresenter;
+};
+
 type LocalWorkspace = {
   branchName: string;
   repository: Repository;
@@ -50,16 +63,29 @@ const withSpinner = <T>(
   text: string,
   successText: ((value: T) => string) | string,
   failText: string,
-  promise: Promise<T>,
+  task: () => Promise<T>,
 ): ResultAsync<T, Error> =>
   ResultAsync.fromPromise(
-    oraPromise(promise, {
+    oraPromise(task(), {
       failText,
       successText,
       text,
     }),
     (cause) => new Error(failText, { cause }),
   );
+
+const asError =
+  (message: string) =>
+  (cause: unknown): Error =>
+    new Error(message, { cause });
+
+const trackStep = <T, E>(
+  presenter: CommandPresenter,
+  name: string,
+  task: () => Promise<T>,
+  mapError: (cause: unknown) => E,
+): ResultAsync<T, E> =>
+  ResultAsync.fromPromise(presenter.trackStep(name, task), mapError);
 
 const displaySummary = (input: SummaryInput) => {
   const docsUrl = "https://dx.pagopa.it/getting-started";
@@ -123,20 +149,42 @@ const displaySummary = (input: SummaryInput) => {
   }
 };
 
+const checkTerraformCli = () => tf$`terraform -version`;
+
 const checkTerraformCliIsInstalled = () =>
   withSpinner(
     "Checking Terraform installation...",
     "Terraform is installed!",
     "Please install terraform CLI before running this command. If you use tfenv, run: tfenv install latest && tfenv use latest",
-    tf$`terraform -version`,
+    checkTerraformCli,
   );
+
+const trackTerraformCliIsInstalled = (presenter: CommandPresenter) =>
+  trackStep(
+    presenter,
+    "Checking Terraform installation...",
+    checkTerraformCli,
+    asError(
+      "Please install terraform CLI before running this command. If you use tfenv, run: tfenv install latest && tfenv use latest",
+    ),
+  );
+
+const checkCorepack = () => tf$`corepack -v`;
 
 const checkCorepackIsInstalled = () =>
   withSpinner(
     "Checking Corepack installation...",
     "Corepack is installed!",
     "Please install Corepack before running this command.",
-    tf$`corepack -v`,
+    checkCorepack,
+  );
+
+const trackCorepackIsInstalled = (presenter: CommandPresenter) =>
+  trackStep(
+    presenter,
+    "Checking Corepack installation...",
+    checkCorepack,
+    asError("Please install Corepack before running this command."),
   );
 
 const azureAccountSchema = z.object({
@@ -160,7 +208,12 @@ const checkAzLogin = () =>
     "Check Azure login status...",
     (userName) => `You are logged in to Azure (${userName})`,
     "Please log in to Azure CLI using `az login` before running this command.",
-    ensureAzLogin(),
+    ensureAzLogin,
+  );
+
+const runInitPreconditions = (presenter: CommandPresenter) =>
+  trackTerraformCliIsInstalled(presenter).andThen(() =>
+    trackCorepackIsInstalled(presenter),
   );
 
 // TODO(CES-1810): Make these checks concurrent to speed up the preconditions check phase
@@ -172,90 +225,94 @@ export const checkAddEnvironmentPreconditions = () =>
     .andThen(() => checkAzLogin())
     .andThen(() => checkCorepackIsInstalled());
 
-const createRemoteRepository = ({
-  repoName,
-  repoOwner,
-}: MonorepoPayload): ResultAsync<Repository, Error> => {
-  const logger = getLogger(["dx-cli", "init"]);
-  const repo$ = tf$({ cwd: path.resolve("infra", "repository") });
-  const applyTerraform = async () => {
-    try {
-      await repo$`terraform init`;
-      await repo$`terraform apply -auto-approve`;
-    } catch (error) {
-      if (error instanceof ExecaError) {
-        logger.error(error.shortMessage);
+const createRemoteRepositoryWithPresenter =
+  (presenter: CommandPresenter) =>
+  ({
+    repoName,
+    repoOwner,
+  }: MonorepoPayload): ResultAsync<Repository, Error> => {
+    const logger = getLogger(["dx-cli", "init"]);
+    const repo$ = tf$({ cwd: path.resolve("infra", "repository") });
+    const applyTerraform = async () => {
+      try {
+        await repo$`terraform init`;
+        await repo$`terraform apply -auto-approve`;
+      } catch (error) {
+        if (error instanceof ExecaError) {
+          logger.error(error.shortMessage);
+        }
+        throw error;
       }
-      throw error;
-    }
+    };
+    return trackStep(
+      presenter,
+      "Creating GitHub repository...",
+      applyTerraform,
+      asError("Failed to create GitHub repository."),
+    ).map(() => new Repository(repoName, repoOwner));
   };
-  return withSpinner(
-    "Creating GitHub repository...",
-    "GitHub repository created successfully!",
-    "Failed to create GitHub repository.",
-    applyTerraform(),
-  ).map(() => new Repository(repoName, repoOwner));
-};
 
-const initializeGitRepository = (repository: Repository) => {
-  const branchName = "features/scaffold-workspace";
-  const git$ = $({
-    shell: true,
-  });
-  const pushToOrigin = async () => {
-    await git$`git init`;
-    await git$`git remote add origin ${repository.origin}`;
-    await git$`git fetch origin main`;
-    await git$`git checkout -b ${branchName}`;
-    // Terraform creates `main` with an initial README commit.
-    // Reset to `origin/main` so this branch is based on the remote default branch,
-    // while keeping the scaffolded local files in the working tree for a clean PR diff.
-    await git$`git reset origin/main`;
-    await git$`git add .`;
-    await git$`git commit --no-gpg-sign -m "Scaffold workspace"`;
-    await git$`git push -u origin ${branchName}`;
+const initializeGitRepositoryWithPresenter =
+  (presenter: CommandPresenter) => (repository: Repository) => {
+    const branchName = "features/scaffold-workspace";
+    const git$ = $({
+      shell: true,
+    });
+    const pushToOrigin = async () => {
+      await git$`git init`;
+      await git$`git remote add origin ${repository.origin}`;
+      await git$`git fetch origin main`;
+      await git$`git checkout -b ${branchName}`;
+      // Terraform creates `main` with an initial README commit.
+      // Reset to `origin/main` so this branch is based on the remote default branch,
+      // while keeping the scaffolded local files in the working tree for a clean PR diff.
+      await git$`git reset origin/main`;
+      await git$`git add .`;
+      await git$`git commit --no-gpg-sign -m "Scaffold workspace"`;
+      await git$`git push -u origin ${branchName}`;
+    };
+    return trackStep(
+      presenter,
+      "Pushing code to GitHub...",
+      pushToOrigin,
+      asError("Failed to push code to GitHub."),
+    ).map(() => ({ branchName, repository }));
   };
-  return withSpinner(
-    "Pushing code to GitHub...",
-    "Code pushed to GitHub successfully!",
-    "Failed to push code to GitHub.",
-    pushToOrigin(),
-  ).map(() => ({ branchName, repository }));
-};
 
-const handleNewGitHubRepository =
-  (githubService: GitHubService) =>
-  (payload: MonorepoPayload): ResultAsync<RepositoryPullRequest, Error> =>
-    createRemoteRepository(payload)
-      .andThen(initializeGitRepository)
-      .andThen((localWorkspace) =>
-        createPullRequest(githubService)(localWorkspace).map((pr) => ({
-          pr,
-          repository: localWorkspace.repository,
-        })),
-      );
-
-const createPullRequest =
-  (githubService: GitHubService) =>
+const createPullRequestWithPresenter =
+  ({ gitHubService, presenter }: InitActionContext) =>
   ({
     branchName,
     repository,
   }: LocalWorkspace): ResultAsync<PullRequest | undefined, Error> =>
-    withSpinner(
+    trackStep(
+      presenter,
       "Creating Pull Request...",
-      "Pull Request created successfully!",
-      "Failed to create Pull Request.",
-      githubService.createPullRequest({
-        base: "main",
-        body: "This PR contains the scaffolded monorepo structure.",
-        head: branchName,
-        owner: repository.owner,
-        repo: repository.name,
-        title: "Scaffold repository",
-      }),
+      () =>
+        gitHubService.createPullRequest({
+          base: "main",
+          body: "This PR contains the scaffolded monorepo structure.",
+          head: branchName,
+          owner: repository.owner,
+          repo: repository.name,
+          title: "Scaffold repository",
+        }),
+      asError("Failed to create Pull Request."),
     )
       // If PR creation fails, don't block the workflow
       .orElse(() => okAsync(undefined));
+
+const handleNewGitHubRepositoryWithPresenter =
+  (context: InitActionContext) =>
+  (payload: MonorepoPayload): ResultAsync<RepositoryPullRequest, Error> =>
+    createRemoteRepositoryWithPresenter(context.presenter)(payload)
+      .andThen(initializeGitRepositoryWithPresenter(context.presenter))
+      .andThen((localWorkspace) =>
+        createPullRequestWithPresenter(context)(localWorkspace).map((pr) => ({
+          pr,
+          repository: localWorkspace.repository,
+        })),
+      );
 
 const handleGeneratorError = (err: unknown) => {
   const logger = getLogger(["dx-cli", "init"]);
@@ -281,6 +338,72 @@ export const confirmGitHubRepoCreation = (
       new Error("Failed to read GitHub publish confirmation", { cause }),
   );
 
+const runInitAction = ({
+  gitHubService,
+  presenter,
+}: InitActionContext): ResultAsync<SummaryInput, Error> =>
+  trackStep(
+    presenter,
+    "Initializing workspace generator...",
+    getPlopInstance,
+    asError("Failed to initialize plop"),
+  )
+    .andThen((plop) =>
+      // The prompt phase must run outside trackStep: in text mode trackStep
+      // renders a spinner that occupies the TTY and hides the prompts.
+      ResultAsync.fromPromise(
+        collectMonorepoPayload(plop, gitHubService),
+        handleGeneratorError,
+      ),
+    )
+    .andThen(({ generator, payload }) =>
+      trackStep(
+        presenter,
+        "Scaffolding workspace...",
+        () => runMonorepoActions(generator, payload),
+        handleGeneratorError,
+      ),
+    )
+    .andTee((payload) => {
+      process.chdir(payload.repoName);
+    })
+    .andThen((payload) =>
+      confirmGitHubRepoCreation(payload).andThen<SummaryInput, Error>(
+        (confirmed) =>
+          confirmed
+            ? handleNewGitHubRepositoryWithPresenter({
+                gitHubService,
+                presenter,
+              })(payload)
+            : okAsync({ gitHubRepoCreationSkipped: true, payload }),
+      ),
+    );
+
+const reportSummary =
+  (presenter: CommandPresenter, outputMode: "json" | "text") =>
+  (result: SummaryInput) => {
+    if (outputMode === "json") {
+      presenter.reportResult(result);
+    } else {
+      displaySummary(result);
+    }
+  };
+
+const reportCommandError =
+  (
+    command: Command,
+    presenter: CommandPresenter,
+    outputMode: "json" | "text",
+  ) =>
+  (error: Error) => {
+    if (outputMode === "json") {
+      presenter.reportError(error);
+      process.exitCode = 1;
+    } else {
+      exitWithError(command)(error);
+    }
+  };
+
 export const makeInitCommand = (
   requireGitHubAuth: GitHubAuthFactory,
 ): Command =>
@@ -288,30 +411,16 @@ export const makeInitCommand = (
     .name("init")
     .description("Initialize a new DX workspace")
     .action(async function () {
-      await checkInitPreconditions()
+      const { output } = this.optsWithGlobals<GlobalOptions>();
+      const presenter = createCommandPresenter(output);
+
+      await runInitPreconditions(presenter)
         .andThen(() => requireGitHubAuth())
         .andThen((auth) =>
-          ResultAsync.fromPromise(
-            getPlopInstance(),
-            (cause) => new Error("Failed to initialize plop", { cause }),
-          )
-            .andThen((plop) =>
-              ResultAsync.fromPromise(
-                runMonorepoGenerator(plop, auth.gitHubService),
-                handleGeneratorError,
-              ),
-            )
-            .andTee((payload) => {
-              process.chdir(payload.repoName);
-            })
-            .andThen((payload) =>
-              confirmGitHubRepoCreation(payload).andThen<SummaryInput, Error>(
-                (confirmed) =>
-                  confirmed
-                    ? handleNewGitHubRepository(auth.gitHubService)(payload)
-                    : okAsync({ gitHubRepoCreationSkipped: true, payload }),
-              ),
-            ),
+          runInitAction({ gitHubService: auth.gitHubService, presenter }),
         )
-        .match(displaySummary, exitWithError(this));
+        .match(
+          reportSummary(presenter, output),
+          reportCommandError(this, presenter, output),
+        );
     });

--- a/apps/cli/src/adapters/commander/index.ts
+++ b/apps/cli/src/adapters/commander/index.ts
@@ -49,7 +49,7 @@ export const makeCli = (
     .addOption(
       new Option(
         "--output <mode>",
-        "Output mode: 'text' (human-readable, default) or 'json' (structured JSON envelope on stdout, NDJSON progress events on stderr)",
+        "Output mode: text (default, human-readable) or json (structured events to stdout for agents)",
       )
         .choices(["text", "json"])
         .default("text"),

--- a/apps/cli/src/adapters/plop/index.ts
+++ b/apps/cli/src/adapters/plop/index.ts
@@ -81,20 +81,37 @@ export const runActions = async (
   }
 };
 
-export const runMonorepoGenerator = async (
+/**
+ * Collect the monorepo payload by running the generator's interactive prompts.
+ *
+ * This phase MUST run outside any spinner: a spinner (e.g. ora) occupies the
+ * TTY and prevents the inquirer prompts from being rendered. Callers should
+ * track only the subsequent {@link runMonorepoActions} phase, which is
+ * non-interactive.
+ */
+export const collectMonorepoPayload = async (
   plop: NodePlopAPI,
   githubService: GitHubService,
-): Promise<MonorepoPayload> => {
+): Promise<{ generator: PlopGenerator; payload: MonorepoPayload }> => {
   setMonorepoGenerator(plop);
   const generator = plop.getGenerator(PLOP_MONOREPO_GENERATOR_NAME);
   const answers = await generator.runPrompts();
   const payload = monorepoPayloadSchema.parse(answers);
   await validatePayload(payload, githubService);
-  await oraPromise(runActions(generator, payload), {
-    failText: "Failed to create workspace files.",
-    successText: "Workspace files created successfully!",
-    text: "Creating workspace files...",
-  });
+  return { generator, payload };
+};
+
+/**
+ * Execute the monorepo generator actions for an already-collected payload.
+ *
+ * This phase is non-interactive, so callers are free to wrap it in a spinner
+ * or other progress indicator.
+ */
+export const runMonorepoActions = async (
+  generator: PlopGenerator,
+  payload: MonorepoPayload,
+): Promise<MonorepoPayload> => {
+  await runActions(generator, payload);
   return payload;
 };
 


### PR DESCRIPTION
Route all init command output through the `CommandPresenter` abstraction, enabling both human-readable text and structured NDJSON output for AI agents (via `--output json`).

## Changes

- Add `InitActionContext` type to bundle `gitHubService` and `presenter` dependencies consistently
- Extract raw check functions (`checkTerraformCli`, `checkCorepack`) shared between text and JSON modes
- Create `trackStep` wrappers for precondition checks (`trackTerraformCliIsInstalled`, `trackCorepackIsInstalled`)
- Refactor all helper functions to use `InitActionContext` + presenter pattern
- Add `runInitAction` orchestration function driven by `presenter.trackStep`
- Add `reportSummary` and `reportCommandError` with output-mode dispatch (text → `exitWithError`, JSON → `presenter.reportError` + exit code)
- Update `makeInitCommand` to create and pass presenter based on `--output` flag
- Fix help text: JSON output goes to stdout only (not stderr)

## Testing

- Updated `init.test.ts` with mocked presenter tests covering JSON progress/result/error events and text error handling
- Added `init-json.test.ts` using the real `JsonCommandPresenter` to protect the NDJSON wire format from regressions

Depends on #1776
Closes CES-2113