### PR TITLE
Add linter step for Docker image production

### DIFF
--- a/.github/workflows/validate-docker-image-v1.yaml
+++ b/.github/workflows/validate-docker-image-v1.yaml
@@ -68,7 +68,7 @@ jobs:
         with:
           dockerfile: ${{ inputs.dockerfile_path }}
           output-file: ./hadolint-results.txt
-          ignore: DL3059
+          ignore: DL3059 # Prefer cache benefits over intermediate layer size reduction
 
       - name: Format Linter Results
         id: format-results

--- a/.github/workflows/validate-docker-image-v1.yaml
+++ b/.github/workflows/validate-docker-image-v1.yaml
@@ -4,12 +4,12 @@ on:
       dockerfile_path:
         type: string
         required: false
-        default: './Dockerfile'
+        default: "./Dockerfile"
         description: Dockerfile path
       dockerfile_context:
         type: string
         required: false
-        default: '.'
+        default: "."
         description: Dockerfile build context
       docker_image_name:
         type: string
@@ -36,13 +36,14 @@ on:
         description: Image runtime platform, supports multiple values
 
 jobs:
-
   build:
     name: Build Docker Image
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: write
 
     steps:
-
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         name: Checkout
 
@@ -57,5 +58,69 @@ jobs:
           build_args: ${{ inputs.build_args }}
           build_platforms: ${{ inputs.build_platforms }}
           push_to_registry: false
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Run Linter
+        id: hadolint
+        uses: hadolint/hadolint-action@2332a7b74a6de0dda2e2221d575162eba76ba5e5 # v3.3.0
+        continue-on-error: true
+        with:
+          dockerfile: ${{ inputs.dockerfile_path }}
+          output-file: ./hadolint-results.txt
+          ignore: DL3059
+
+      - name: Format Linter Results
+        id: format-results
+        if: always() && github.event_name == 'pull_request'
+        env:
+          DOCKERFILE: ${{ inputs.dockerfile_path }}
+        run: |
+
+          # Check if hadolint found any issues
+          if [ ! -s ./hadolint-results.txt ]; then
+            # No issues found
+            cat > ./hadolint-comment.md << 'EOF'
+          ## 🐳 Dockerfile Linter
+
+          ### ✅ No issues found
+
+          Your Dockerfile passes all linting checks!
+
+          **Analyzed:** \`$DOCKERFILE\`
+          EOF
+          else
+            # Issues found - format them nicely
+            cat > ./hadolint-comment.md << 'EOF'
+          ## 🐳 Dockerfile Linter
+
+          ### ⚠️ Issues detected
+
+          The following issues were found in your Dockerfile:
+
+          <details>
+          <summary>📋 View details</summary>
+
+          ```
+          EOF
+            cat ./hadolint-results.txt >> ./hadolint-comment.md
+            cat >> ./hadolint-comment.md << 'EOF'
+          ```
+
+          </details>
+
+          ---
+
+          💡 **Tip:** Fix these issues to ensure your Docker image follows best practices. Learn more in the [Hadolint documentation](https://github.com/hadolint/hadolint).
+          EOF
+          fi
+
+      - name: Post Linter Results on PR
+        id: comment
+        if: always() && github.event_name == 'pull_request'
+        uses: pagopa/dx/actions/pr-comment@main
+        with:
+          comment-body-file: ./hadolint-comment.md
+          search-pattern: "Dockerfile Linter"
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/validate-docker-image-v1.yaml
+++ b/.github/workflows/validate-docker-image-v1.yaml
@@ -74,9 +74,11 @@ jobs:
         id: format-results
         if: always() && github.event_name == 'pull_request'
         shell: bash
+        env:
+          HADOLINT_OUTCOME: ${{ steps.hadolint.outcome }}
         run: |
           # Check if hadolint step failed to run
-          if [[ "${{ steps.hadolint.outcome }}" == "failure" ]] && [ ! -f ./hadolint-results.txt ]; then
+          if [[ "$HADOLINT_OUTCOME" == "failure" ]] && [ ! -f ./hadolint-results.txt ]; then
             # Linter failed to execute
             cat > ./hadolint-comment.md << 'EOF'
           ## 🐳 Dockerfile Linter

--- a/.github/workflows/validate-docker-image-v1.yaml
+++ b/.github/workflows/validate-docker-image-v1.yaml
@@ -63,6 +63,7 @@ jobs:
 
       - name: Run Linter
         id: hadolint
+        if: always()
         uses: hadolint/hadolint-action@2332a7b74a6de0dda2e2221d575162eba76ba5e5 # v3.3.0
         continue-on-error: true
         with:

--- a/.github/workflows/validate-docker-image-v1.yaml
+++ b/.github/workflows/validate-docker-image-v1.yaml
@@ -74,12 +74,23 @@ jobs:
       - name: Format Linter Results
         id: format-results
         if: always() && github.event_name == 'pull_request'
-        env:
-          DOCKERFILE: ${{ inputs.dockerfile_path }}
+        shell: bash
         run: |
+          # Check if hadolint step failed to run
+          if [[ "${{ steps.hadolint.outcome }}" == "failure" ]] && [ ! -f ./hadolint-results.txt ]; then
+            # Linter failed to execute
+            cat > ./hadolint-comment.md << 'EOF'
+          ## 🐳 Dockerfile Linter
 
-          # Check if hadolint found any issues
-          if [ ! -s ./hadolint-results.txt ]; then
+          ### ❌ Linter failed to run
+
+          The Dockerfile linter could not analyze the file. Please check:
+          - The Dockerfile path is correct
+          - The Dockerfile syntax is valid
+          - The hadolint action completed successfully
+
+          EOF
+          elif [ ! -s ./hadolint-results.txt ]; then
             # No issues found
             cat > ./hadolint-comment.md << 'EOF'
           ## 🐳 Dockerfile Linter

--- a/.github/workflows/validate-docker-image-v1.yaml
+++ b/.github/workflows/validate-docker-image-v1.yaml
@@ -88,7 +88,6 @@ jobs:
 
           Your Dockerfile passes all linting checks!
 
-          **Analyzed:** \`$DOCKERFILE\`
           EOF
           else
             # Issues found - format them nicely

--- a/.github/workflows/validate-docker-image-v1.yaml
+++ b/.github/workflows/validate-docker-image-v1.yaml
@@ -65,7 +65,6 @@ jobs:
         id: hadolint
         if: always()
         uses: hadolint/hadolint-action@2332a7b74a6de0dda2e2221d575162eba76ba5e5 # v3.3.0
-        continue-on-error: true
         with:
           dockerfile: ${{ inputs.dockerfile_path }}
           output-file: ./hadolint-results.txt


### PR DESCRIPTION
Introduce a linter step in the workflow to analyze Dockerfiles for best practices and report results in pull requests. This enhancement ensures that Docker images adhere to quality standards during the build process.

Close CES-438