### PR TITLE
Rebuild nx-release action

### DIFF
--- a/actions/nx-release/scripts/dist/extract-projects-to-build.js
+++ b/actions/nx-release/scripts/dist/extract-projects-to-build.js
@@ -18146,10 +18146,10 @@ var TagEntrySchema = external_exports.object({
   tag: external_exports.string(),
   version: external_exports.string()
 });
-var ProjectMetadataSchema = external_exports.object({
+var ProjectMetadataSchema = external_exports.looseObject({
   root: NonEmptyStringSchema.optional(),
   tags: ProjectTagsSchema.optional()
-}).passthrough();
+});
 function createOctokit() {
   const token = process.env.GH_TOKEN;
   if (!token) {

--- a/actions/nx-release/scripts/dist/extract-tags.js
+++ b/actions/nx-release/scripts/dist/extract-tags.js
@@ -14518,10 +14518,10 @@ external_exports.object({
   tag: external_exports.string(),
   version: external_exports.string()
 });
-var ProjectMetadataSchema = external_exports.object({
+var ProjectMetadataSchema = external_exports.looseObject({
   root: NonEmptyStringSchema.optional(),
   tags: ProjectTagsSchema.optional()
-}).passthrough();
+});
 async function getNxProjectNames() {
   try {
     const { stdout } = await execFileAsync("npx", [

--- a/actions/nx-release/scripts/dist/manage-version-pr.js
+++ b/actions/nx-release/scripts/dist/manage-version-pr.js
@@ -18146,10 +18146,10 @@ external_exports.object({
   tag: external_exports.string(),
   version: external_exports.string()
 });
-external_exports.object({
+external_exports.looseObject({
   root: NonEmptyStringSchema.optional(),
   tags: ProjectTagsSchema.optional()
-}).passthrough();
+});
 function createOctokit() {
   const token = process.env.GH_TOKEN;
   if (!token) {

--- a/actions/nx-release/scripts/dist/shared.js
+++ b/actions/nx-release/scripts/dist/shared.js
@@ -18146,10 +18146,10 @@ var TagEntrySchema = external_exports.object({
   tag: external_exports.string(),
   version: external_exports.string()
 });
-var ProjectMetadataSchema = external_exports.object({
+var ProjectMetadataSchema = external_exports.looseObject({
   root: NonEmptyStringSchema.optional(),
   tags: ProjectTagsSchema.optional()
-}).passthrough();
+});
 function createOctokit() {
   const token = process.env.GH_TOKEN;
   if (!token) {

--- a/actions/nx-release/scripts/dist/sync-tags-releases.js
+++ b/actions/nx-release/scripts/dist/sync-tags-releases.js
@@ -18146,10 +18146,10 @@ var TagEntrySchema = external_exports.object({
   tag: external_exports.string(),
   version: external_exports.string()
 });
-external_exports.object({
+external_exports.looseObject({
   root: NonEmptyStringSchema.optional(),
   tags: ProjectTagsSchema.optional()
-}).passthrough();
+});
 function createOctokit() {
   const token = process.env.GH_TOKEN;
   if (!token) {
@@ -18323,7 +18323,10 @@ async function run(base) {
   if (newTags.length === 0) {
     console.log("No new tags to push");
   } else {
-    await execFileAsync2("git", ["push", "origin", "--tags"]);
+    for (const { tag } of newTags) {
+      await execFileAsync2("git", ["push", "origin", `refs/tags/${tag}`]);
+      console.log(`Pushed tag: ${tag}`);
+    }
   }
   for (const { path, tag, version: version2 } of allEntries.values()) {
     let notes = `Release ${tag}`;

--- a/actions/nx-release/scripts/dist/warn-version-plan-coverage-pr.js
+++ b/actions/nx-release/scripts/dist/warn-version-plan-coverage-pr.js
@@ -18145,10 +18145,10 @@ external_exports.object({
   tag: external_exports.string(),
   version: external_exports.string()
 });
-external_exports.object({
+external_exports.looseObject({
   root: NonEmptyStringSchema.optional(),
   tags: ProjectTagsSchema.optional()
-}).passthrough();
+});
 function createOctokit() {
   const token = process.env.GH_TOKEN;
   if (!token) {


### PR DESCRIPTION
Update the ProjectMetadataSchema to use `looseObject` instead of `object`, and modify the tag pushing logic to push tags individually.