### PR TITLE
Configure Code to use Prettier as JSON formatter

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -10,6 +10,9 @@
   "[go]": {
     "editor.defaultFormatter": "golang.go"
   },
+  "[json]": {
+    "editor.defaultFormatter": "esbenp.prettier-vscode"
+  },
   "files.watcherExclude": {
     "**/build/**": true,
     "**/dist/**": true,


### PR DESCRIPTION
Without this setting, Code use the built-in JSON formatter, that conflicts with `nx format` and our own `format` commands.