### PR TITLE
Add init command flags

### DIFF
--- a/.nx/version-plans/version-plan-1780061797434.md
+++ b/.nx/version-plans/version-plan-1780061797434.md
@@ -1,0 +1,5 @@
+---
+'@pagopa/dx-cli': patch
+---
+
+Add init command flags for non-interactive scaffolding

--- a/apps/cli/src/adapters/commander/__tests__/exit-with-error.test.ts
+++ b/apps/cli/src/adapters/commander/__tests__/exit-with-error.test.ts
@@ -1,7 +1,7 @@
 import { Command } from "commander";
 import { describe, expect, it } from "vitest";
 
-import { exitWithError, isVerbose } from "../index.js";
+import { exitWithError, isVerbose } from "../command-errors.js";
 
 /**
  * Builds a parent command that exposes the global `--verbose` flag so that

--- a/apps/cli/src/adapters/commander/__tests__/exit-with-error.test.ts
+++ b/apps/cli/src/adapters/commander/__tests__/exit-with-error.test.ts
@@ -1,7 +1,8 @@
 import { Command } from "commander";
 import { describe, expect, it } from "vitest";
 
-import { exitWithError, isVerbose } from "../command-errors.js";
+import { exitWithError } from "../command-errors.js";
+import { isVerbose } from "../global-options.js";
 
 /**
  * Builds a parent command that exposes the global `--verbose` flag so that

--- a/apps/cli/src/adapters/commander/command-errors.ts
+++ b/apps/cli/src/adapters/commander/command-errors.ts
@@ -1,23 +1,10 @@
 /**
- * Shared Commander error helpers used by individual commands.
- * Keeping them separate avoids pulling the full CLI command graph into
- * command unit tests that only need common error handling behavior.
+ * Shared Commander failure handling used by command actions.
  */
-import { Command } from "commander";
+import type { Command } from "commander";
 
 import { formatErrorDetailed, toErrorMessage } from "./error-reporting.js";
-
-export type GlobalOptions = {
-  output: "json" | "text";
-  verbose?: boolean;
-};
-
-/**
- * Returns true when the global `--verbose` flag is active on the closest
- * ancestor command that defines it (the root `dx` program in our CLI).
- */
-export const isVerbose = (command: Command): boolean =>
-  command.optsWithGlobals<GlobalOptions>().verbose === true;
+import { isVerbose } from "./global-options.js";
 
 /**
  * Builds a failure handler that ends the command via Commander's

--- a/apps/cli/src/adapters/commander/command-errors.ts
+++ b/apps/cli/src/adapters/commander/command-errors.ts
@@ -1,0 +1,37 @@
+/**
+ * Shared Commander error helpers used by individual commands.
+ * Keeping them separate avoids pulling the full CLI command graph into
+ * command unit tests that only need common error handling behavior.
+ */
+import { Command } from "commander";
+
+import { formatErrorDetailed, toErrorMessage } from "./error-reporting.js";
+
+export type GlobalOptions = {
+  output: "json" | "text";
+  verbose?: boolean;
+};
+
+/**
+ * Returns true when the global `--verbose` flag is active on the closest
+ * ancestor command that defines it (the root `dx` program in our CLI).
+ */
+export const isVerbose = (command: Command): boolean =>
+  command.optsWithGlobals<GlobalOptions>().verbose === true;
+
+/**
+ * Builds a failure handler that ends the command via Commander's
+ * `Command#error`, with an output tailored to the active verbosity.
+ *
+ * - In normal mode, a single meaningful line is printed.
+ * - When `--verbose` is active, the full cause chain and stack trace are
+ *   included so users can diagnose the underlying failure.
+ */
+export const exitWithError =
+  (command: Command) =>
+  (error: unknown): never => {
+    const message = isVerbose(command)
+      ? formatErrorDetailed(error)
+      : toErrorMessage(error);
+    command.error(message);
+  };

--- a/apps/cli/src/adapters/commander/commands/__tests__/init.test.ts
+++ b/apps/cli/src/adapters/commander/commands/__tests__/init.test.ts
@@ -51,6 +51,7 @@ vi.mock("../../presenters/index.js", () => ({
 
 import {
   confirmGitHubRepoCreation,
+  getMonorepoInitialAnswers,
   makeInitCommand,
   parseInitCommandOptions,
 } from "../init.js";
@@ -156,25 +157,41 @@ describe("parseInitCommandOptions", () => {
   it("returns the provided init flags", () => {
     expect(
       parseInitCommandOptions({
-        publishToGitHub: false,
-        repoDescription: "My DX workspace",
-        repoName: "my-dx-workspace",
-        repoOwner: "pagopa",
+        description: "My DX workspace",
+        name: "my-dx-workspace",
+        owner: "pagopa",
+        publish: true,
       }),
     ).toEqual({
-      publishToGitHub: false,
+      description: "My DX workspace",
+      name: "my-dx-workspace",
+      owner: "pagopa",
+      publish: true,
+    });
+  });
+
+  it("formats blank string validation errors with zod context", () => {
+    expect(() =>
+      parseInitCommandOptions({
+        name: "   ",
+      }),
+    ).toThrow(/name/);
+  });
+});
+
+describe("getMonorepoInitialAnswers", () => {
+  it("maps init CLI options to the monorepo payload keys", () => {
+    expect(
+      getMonorepoInitialAnswers({
+        description: "My DX workspace",
+        name: "my-dx-workspace",
+        owner: "pagopa",
+      }),
+    ).toEqual({
       repoDescription: "My DX workspace",
       repoName: "my-dx-workspace",
       repoOwner: "pagopa",
     });
-  });
-
-  it("rejects blank string flags", () => {
-    expect(() =>
-      parseInitCommandOptions({
-        repoName: "   ",
-      }),
-    ).toThrow("Repository name cannot be empty");
   });
 });
 
@@ -211,11 +228,10 @@ describe("makeInitCommand", () => {
 
     expect(flags).toEqual(
       expect.arrayContaining([
-        "--repo-name <repo-name>",
-        "--repo-owner <repo-owner>",
-        "--repo-description <repo-description>",
-        "--publish-to-github",
-        "--no-publish-to-github",
+        "--name <name>",
+        "--owner <owner>",
+        "--description <description>",
+        "--publish",
       ]),
     );
   });

--- a/apps/cli/src/adapters/commander/commands/__tests__/init.test.ts
+++ b/apps/cli/src/adapters/commander/commands/__tests__/init.test.ts
@@ -49,7 +49,11 @@ vi.mock("../../presenters/index.js", () => ({
   createCommandPresenter: mocks.createCommandPresenter,
 }));
 
-import { confirmGitHubRepoCreation, makeInitCommand } from "../init.js";
+import {
+  confirmGitHubRepoCreation,
+  makeInitCommand,
+  parseInitCommandOptions,
+} from "../init.js";
 
 const makePayload = (
   overrides: Partial<MonorepoPayload> = {},
@@ -93,6 +97,14 @@ const runInitCommand = async (
 describe("confirmGitHubRepoCreation", () => {
   afterEach(() => {
     vi.restoreAllMocks();
+  });
+
+  it("returns the provided publish choice without prompting again", async () => {
+    const result = await confirmGitHubRepoCreation(makePayload(), false);
+
+    expect(result.isOk()).toBe(true);
+    expect(result._unsafeUnwrap()).toBe(false);
+    expect(inquirer.prompt).not.toHaveBeenCalled();
   });
 
   it("returns true when the user confirms", async () => {
@@ -140,6 +152,32 @@ describe("confirmGitHubRepoCreation", () => {
   });
 });
 
+describe("parseInitCommandOptions", () => {
+  it("returns the provided init flags", () => {
+    expect(
+      parseInitCommandOptions({
+        publishToGitHub: false,
+        repoDescription: "My DX workspace",
+        repoName: "my-dx-workspace",
+        repoOwner: "pagopa",
+      }),
+    ).toEqual({
+      publishToGitHub: false,
+      repoDescription: "My DX workspace",
+      repoName: "my-dx-workspace",
+      repoOwner: "pagopa",
+    });
+  });
+
+  it("rejects blank string flags", () => {
+    expect(() =>
+      parseInitCommandOptions({
+        repoName: "   ",
+      }),
+    ).toThrow("Repository name cannot be empty");
+  });
+});
+
 describe("makeInitCommand", () => {
   const payload = makePayload();
 
@@ -156,6 +194,30 @@ describe("makeInitCommand", () => {
   afterEach(() => {
     vi.restoreAllMocks();
     process.exitCode = undefined;
+  });
+
+  it("registers flags for every init input", () => {
+    const requireGitHubAuth: GitHubAuthFactory = () =>
+      okAsync({
+        authorizationService: mockDeep<AuthorizationService>(),
+        gitHubService: mockDeep<GitHubService>(),
+      });
+    const command = makeInitCommand(requireGitHubAuth);
+
+    const flags = command.options.flatMap((option) => [
+      option.flags,
+      option.long,
+    ]);
+
+    expect(flags).toEqual(
+      expect.arrayContaining([
+        "--repo-name <repo-name>",
+        "--repo-owner <repo-owner>",
+        "--repo-description <repo-description>",
+        "--publish-to-github",
+        "--no-publish-to-github",
+      ]),
+    );
   });
 
   it("uses the command presenter to report json progress and results", async () => {

--- a/apps/cli/src/adapters/commander/commands/__tests__/init.test.ts
+++ b/apps/cli/src/adapters/commander/commands/__tests__/init.test.ts
@@ -186,8 +186,10 @@ describe("getMonorepoInitialAnswers", () => {
         description: "My DX workspace",
         name: "my-dx-workspace",
         owner: "pagopa",
+        publish: true,
       }),
     ).toEqual({
+      publishToGitHub: true,
       repoDescription: "My DX workspace",
       repoName: "my-dx-workspace",
       repoOwner: "pagopa",

--- a/apps/cli/src/adapters/commander/commands/add.ts
+++ b/apps/cli/src/adapters/commander/commands/add.ts
@@ -27,7 +27,7 @@ import {
   getPlopInstance,
   runDeploymentEnvironmentGenerator,
 } from "../../plop/index.js";
-import { exitWithError } from "../index.js";
+import { exitWithError } from "../command-errors.js";
 import { checkAddEnvironmentPreconditions } from "./init.js";
 
 /**

--- a/apps/cli/src/adapters/commander/commands/codemod.ts
+++ b/apps/cli/src/adapters/commander/commands/codemod.ts
@@ -3,7 +3,7 @@ import { Command } from "commander";
 
 import { ApplyCodemodById } from "../../../use-cases/apply-codemod.js";
 import { ListCodemods } from "../../../use-cases/list-codemods.js";
-import { exitWithError } from "../index.js";
+import { exitWithError } from "../command-errors.js";
 
 export type CodemodCommandDependencies = {
   applyCodemodById: ApplyCodemodById;

--- a/apps/cli/src/adapters/commander/commands/init.ts
+++ b/apps/cli/src/adapters/commander/commands/init.ts
@@ -378,12 +378,21 @@ const handleGeneratorError = (err: unknown) => {
   return new Error("Failed to run the generator", { cause: err });
 };
 
+/**
+ * Resolves whether the scaffolded repository should be published to GitHub.
+ *
+ * When the caller already knows the answer (e.g. the user passed `--publish`
+ * on the command line), that value is used as-is and no prompt is shown. When
+ * the preference is left undefined (flag omitted), the user is asked
+ * interactively.
+ */
 export const confirmGitHubRepoCreation = (
   payload: MonorepoPayload,
-  confirmed?: boolean,
+  publishPreference?: boolean,
 ): ResultAsync<boolean, Error> =>
-  typeof confirmed === "boolean"
-    ? okAsync(confirmed)
+  // A preference provided up-front (via `--publish`) skips the interactive prompt.
+  publishPreference !== undefined
+    ? okAsync(publishPreference)
     : ResultAsync.fromPromise(
         inquirer.prompt({
           default: DEFAULT_GITHUB_PUBLISH_CONFIRMATION,

--- a/apps/cli/src/adapters/commander/commands/init.ts
+++ b/apps/cli/src/adapters/commander/commands/init.ts
@@ -1,15 +1,15 @@
 import { getLogger } from "@logtape/logtape";
 import chalk from "chalk";
-import { Command } from "commander";
+import { Command, Option } from "commander";
 import { $, ExecaError } from "execa";
 import inquirer from "inquirer";
-import { okAsync, ResultAsync } from "neverthrow";
+import { errAsync, okAsync, ResultAsync } from "neverthrow";
 import * as path from "node:path";
 import { oraPromise } from "ora";
-import { z } from "zod";
+import { z } from "zod/v4";
 
 import type { CommandPresenter } from "../../../domain/command-presenter.js";
-import type { GlobalOptions } from "../index.js";
+import type { GlobalOptions } from "../command-errors.js";
 
 import { GitHubAuthFactory } from "../../../domain/dependencies.js";
 import {
@@ -24,7 +24,7 @@ import {
   getPlopInstance,
   runMonorepoActions,
 } from "../../plop/index.js";
-import { exitWithError } from "../index.js";
+import { exitWithError } from "../command-errors.js";
 import { createCommandPresenter } from "../presenters/index.js";
 
 type GitHubRepoCreationSkippedResult = {
@@ -46,7 +46,9 @@ const isGitHubRepoCreationSkipped = (
 
 type InitActionContext = {
   gitHubService: GitHubService;
+  initialAnswers?: Partial<MonorepoPayload>;
   presenter: CommandPresenter;
+  publishToGitHub?: boolean;
 };
 
 type LocalWorkspace = {
@@ -225,6 +227,53 @@ export const checkAddEnvironmentPreconditions = () =>
     .andThen(() => checkAzLogin())
     .andThen(() => checkCorepackIsInstalled());
 
+const DEFAULT_GITHUB_PUBLISH_CONFIRMATION = true;
+
+export const initCommandOptionsSchema = z.object({
+  publishToGitHub: z.boolean().optional(),
+  repoDescription: z.string().optional(),
+  repoName: z
+    .string()
+    .trim()
+    .min(1, "Repository name cannot be empty")
+    .optional(),
+  repoOwner: z
+    .string()
+    .trim()
+    .min(1, "GitHub organization cannot be empty")
+    .optional(),
+});
+
+export type InitCommandOptions = z.infer<typeof initCommandOptionsSchema>;
+
+const formatInitCommandOptionsError = (error: z.ZodError) => {
+  const message = error.issues.map((issue) => issue.message).join("; ");
+  return message.length > 0
+    ? `Invalid init command options: ${message}`
+    : "Invalid init command options";
+};
+
+export const parseInitCommandOptions = (input: unknown): InitCommandOptions => {
+  const result = initCommandOptionsSchema.safeParse(input);
+  if (!result.success) {
+    throw new Error(formatInitCommandOptionsError(result.error), {
+      cause: result.error,
+    });
+  }
+
+  return result.data;
+};
+
+export const getMonorepoInitialAnswers = ({
+  repoDescription,
+  repoName,
+  repoOwner,
+}: InitCommandOptions): Partial<MonorepoPayload> => ({
+  ...(typeof repoDescription === "undefined" ? {} : { repoDescription }),
+  ...(typeof repoName === "undefined" ? {} : { repoName }),
+  ...(typeof repoOwner === "undefined" ? {} : { repoOwner }),
+});
+
 const createRemoteRepositoryWithPresenter =
   (presenter: CommandPresenter) =>
   ({
@@ -251,8 +300,6 @@ const createRemoteRepositoryWithPresenter =
       asError("Failed to create GitHub repository."),
     ).map(() => new Repository(repoName, repoOwner));
   };
-
-const initializeGitRepositoryWithPresenter =
   (presenter: CommandPresenter) => (repository: Repository) => {
     const branchName = "features/scaffold-workspace";
     const git$ = $({
@@ -324,23 +371,41 @@ const handleGeneratorError = (err: unknown) => {
 
 export const confirmGitHubRepoCreation = (
   payload: MonorepoPayload,
+  confirmed?: boolean,
 ): ResultAsync<boolean, Error> =>
-  ResultAsync.fromPromise(
-    inquirer
-      .prompt({
-        default: true,
-        message: `The project is created on ${chalk.green(payload.repoName)}. Would you like to publish it to GitHub at ${chalk.green(`${payload.repoOwner}/${payload.repoName}`)} now?`,
-        name: "confirm",
-        type: "confirm",
-      })
-      .then(({ confirm }: { confirm: boolean }) => confirm),
-    (cause) =>
-      new Error("Failed to read GitHub publish confirmation", { cause }),
-  );
+  typeof confirmed === "boolean"
+    ? okAsync(confirmed)
+    : ResultAsync.fromPromise(
+        inquirer.prompt({
+          default: DEFAULT_GITHUB_PUBLISH_CONFIRMATION,
+          message: `The project is created on ${chalk.green(payload.repoName)}. Would you like to publish it to GitHub at ${chalk.green(`${payload.repoOwner}/${payload.repoName}`)} now?`,
+          name: "confirm",
+          type: "confirm",
+        }),
+        (cause) =>
+          new Error("Failed to read GitHub publish confirmation", { cause }),
+      ).andThen((answer) => {
+        const parsedAnswer = z
+          .object({
+            confirm: z.boolean(),
+          })
+          .safeParse(answer);
+        if (!parsedAnswer.success) {
+          return errAsync(
+            new Error("Invalid GitHub publish confirmation", {
+              cause: parsedAnswer.error,
+            }),
+          );
+        }
+
+        return okAsync(parsedAnswer.data.confirm);
+      });
 
 const runInitAction = ({
   gitHubService,
+  initialAnswers = {},
   presenter,
+  publishToGitHub,
 }: InitActionContext): ResultAsync<SummaryInput, Error> =>
   trackStep(
     presenter,
@@ -352,7 +417,7 @@ const runInitAction = ({
       // The prompt phase must run outside trackStep: in text mode trackStep
       // renders a spinner that occupies the TTY and hides the prompts.
       ResultAsync.fromPromise(
-        collectMonorepoPayload(plop, gitHubService),
+        collectMonorepoPayload(plop, gitHubService, initialAnswers),
         handleGeneratorError,
       ),
     )
@@ -368,7 +433,10 @@ const runInitAction = ({
       process.chdir(payload.repoName);
     })
     .andThen((payload) =>
-      confirmGitHubRepoCreation(payload).andThen<SummaryInput, Error>(
+      confirmGitHubRepoCreation(payload, publishToGitHub).andThen<
+        SummaryInput,
+        Error
+      >(
         (confirmed) =>
           confirmed
             ? handleNewGitHubRepositoryWithPresenter({
@@ -410,14 +478,53 @@ export const makeInitCommand = (
   new Command()
     .name("init")
     .description("Initialize a new DX workspace")
-    .action(async function () {
+    .addOption(new Option("--repo-name <repo-name>", "Repository name"))
+    .addOption(
+      new Option(
+        "--repo-owner <repo-owner>",
+        "GitHub organization or user that will own the repository",
+      ),
+    )
+    .addOption(
+      new Option(
+        "--repo-description <repo-description>",
+        "Repository description",
+      ),
+    )
+    .addOption(
+      new Option(
+        "--publish-to-github",
+        "Publish the scaffolded repository to GitHub without prompting",
+      ).default(undefined),
+    )
+    .addOption(
+      new Option(
+        "--no-publish-to-github",
+        "Skip GitHub publishing without prompting",
+      ).default(undefined),
+    )
+    .action(async function (options: unknown) {
       const { output } = this.optsWithGlobals<GlobalOptions>();
       const presenter = createCommandPresenter(output);
 
-      await runInitPreconditions(presenter)
-        .andThen(() => requireGitHubAuth())
-        .andThen((auth) =>
-          runInitAction({ gitHubService: auth.gitHubService, presenter }),
+      await ResultAsync.fromPromise(
+        Promise.resolve().then(() => parseInitCommandOptions(options)),
+        (cause) =>
+          cause instanceof Error
+            ? cause
+            : new Error("Failed to parse init command options", { cause }),
+      )
+        .andThen((initOptions) =>
+          runInitPreconditions(presenter)
+            .andThen(() => requireGitHubAuth())
+            .andThen((auth) =>
+              runInitAction({
+                gitHubService: auth.gitHubService,
+                initialAnswers: getMonorepoInitialAnswers(initOptions),
+                presenter,
+                publishToGitHub: initOptions.publishToGitHub,
+              }),
+            ),
         )
         .match(
           reportSummary(presenter, output),

--- a/apps/cli/src/adapters/commander/commands/init.ts
+++ b/apps/cli/src/adapters/commander/commands/init.ts
@@ -46,8 +46,11 @@ const isGitHubRepoCreationSkipped = (
 
 type InitActionContext = {
   gitHubService: GitHubService;
-  initialAnswers?: Partial<MonorepoPayload>;
+  initialAnswers?: InitInitialAnswers;
   presenter: CommandPresenter;
+};
+
+type InitInitialAnswers = Partial<MonorepoPayload> & {
   publishToGitHub?: boolean;
 };
 
@@ -256,8 +259,9 @@ export const getMonorepoInitialAnswers = ({
   description,
   name,
   owner,
-}: InitCommandOptions): Partial<MonorepoPayload> => {
-  const initialAnswers: Partial<MonorepoPayload> = {};
+  publish,
+}: InitCommandOptions): InitInitialAnswers => {
+  const initialAnswers: InitInitialAnswers = {};
 
   if (description) {
     initialAnswers.repoDescription = description;
@@ -269,6 +273,10 @@ export const getMonorepoInitialAnswers = ({
 
   if (name) {
     initialAnswers.repoName = name;
+  }
+
+  if (typeof publish === "boolean") {
+    initialAnswers.publishToGitHub = publish;
   }
 
   return initialAnswers;
@@ -406,9 +414,10 @@ const runInitAction = ({
   gitHubService,
   initialAnswers = {},
   presenter,
-  publishToGitHub,
-}: InitActionContext): ResultAsync<SummaryInput, Error> =>
-  trackStep(
+}: InitActionContext): ResultAsync<SummaryInput, Error> => {
+  const { publishToGitHub, ...monorepoInitialAnswers } = initialAnswers;
+
+  return trackStep(
     presenter,
     "Initializing workspace generator...",
     getPlopInstance,
@@ -418,7 +427,7 @@ const runInitAction = ({
       // The prompt phase must run outside trackStep: in text mode trackStep
       // renders a spinner that occupies the TTY and hides the prompts.
       ResultAsync.fromPromise(
-        collectMonorepoPayload(plop, gitHubService, initialAnswers),
+        collectMonorepoPayload(plop, gitHubService, monorepoInitialAnswers),
         handleGeneratorError,
       ),
     )
@@ -446,6 +455,7 @@ const runInitAction = ({
           : okAsync({ gitHubRepoCreationSkipped: true, payload }),
       ),
     );
+};
 
 const reportSummary =
   (presenter: CommandPresenter, outputMode: "json" | "text") =>
@@ -513,7 +523,6 @@ export const makeInitCommand = (
                 gitHubService: auth.gitHubService,
                 initialAnswers: getMonorepoInitialAnswers(initOptions),
                 presenter,
-                publishToGitHub: initOptions.publish,
               }),
             ),
         )

--- a/apps/cli/src/adapters/commander/commands/init.ts
+++ b/apps/cli/src/adapters/commander/commands/init.ts
@@ -230,49 +230,49 @@ export const checkAddEnvironmentPreconditions = () =>
 const DEFAULT_GITHUB_PUBLISH_CONFIRMATION = true;
 
 export const initCommandOptionsSchema = z.object({
-  publishToGitHub: z.boolean().optional(),
-  repoDescription: z.string().optional(),
-  repoName: z
-    .string()
-    .trim()
-    .min(1, "Repository name cannot be empty")
-    .optional(),
-  repoOwner: z
-    .string()
-    .trim()
-    .min(1, "GitHub organization cannot be empty")
-    .optional(),
+  description: z.string().optional(),
+  name: z.string().trim().min(1, "Repository name cannot be empty").optional(),
+  owner: z.string().trim().min(1, "GitHub owner cannot be empty").optional(),
+  publish: z.boolean().optional(),
 });
 
 export type InitCommandOptions = z.infer<typeof initCommandOptionsSchema>;
 
-const formatInitCommandOptionsError = (error: z.ZodError) => {
-  const message = error.issues.map((issue) => issue.message).join("; ");
-  return message.length > 0
-    ? `Invalid init command options: ${message}`
-    : "Invalid init command options";
-};
-
 export const parseInitCommandOptions = (input: unknown): InitCommandOptions => {
   const result = initCommandOptionsSchema.safeParse(input);
   if (!result.success) {
-    throw new Error(formatInitCommandOptionsError(result.error), {
-      cause: result.error,
-    });
+    throw new Error(
+      `Invalid init command options:\n${z.prettifyError(result.error)}`,
+      {
+        cause: result.error,
+      },
+    );
   }
 
   return result.data;
 };
 
 export const getMonorepoInitialAnswers = ({
-  repoDescription,
-  repoName,
-  repoOwner,
-}: InitCommandOptions): Partial<MonorepoPayload> => ({
-  ...(typeof repoDescription === "undefined" ? {} : { repoDescription }),
-  ...(typeof repoName === "undefined" ? {} : { repoName }),
-  ...(typeof repoOwner === "undefined" ? {} : { repoOwner }),
-});
+  description,
+  name,
+  owner,
+}: InitCommandOptions): Partial<MonorepoPayload> => {
+  const initialAnswers: Partial<MonorepoPayload> = {};
+
+  if (description) {
+    initialAnswers.repoDescription = description;
+  }
+
+  if (owner) {
+    initialAnswers.repoOwner = owner;
+  }
+
+  if (name) {
+    initialAnswers.repoName = name;
+  }
+
+  return initialAnswers;
+};
 
 const createRemoteRepositoryWithPresenter =
   (presenter: CommandPresenter) =>
@@ -478,29 +478,20 @@ export const makeInitCommand = (
   new Command()
     .name("init")
     .description("Initialize a new DX workspace")
-    .addOption(new Option("--repo-name <repo-name>", "Repository name"))
+    .addOption(new Option("--name <name>", "Repository name"))
     .addOption(
       new Option(
-        "--repo-owner <repo-owner>",
+        "--owner <owner>",
         "GitHub organization or user that will own the repository",
       ),
     )
     .addOption(
-      new Option(
-        "--repo-description <repo-description>",
-        "Repository description",
-      ),
+      new Option("--description <description>", "Repository description"),
     )
     .addOption(
       new Option(
-        "--publish-to-github",
+        "--publish",
         "Publish the scaffolded repository to GitHub without prompting",
-      ).default(undefined),
-    )
-    .addOption(
-      new Option(
-        "--no-publish-to-github",
-        "Skip GitHub publishing without prompting",
       ).default(undefined),
     )
     .action(async function (options: unknown) {
@@ -522,7 +513,7 @@ export const makeInitCommand = (
                 gitHubService: auth.gitHubService,
                 initialAnswers: getMonorepoInitialAnswers(initOptions),
                 presenter,
-                publishToGitHub: initOptions.publishToGitHub,
+                publishToGitHub: initOptions.publish,
               }),
             ),
         )

--- a/apps/cli/src/adapters/commander/commands/init.ts
+++ b/apps/cli/src/adapters/commander/commands/init.ts
@@ -9,7 +9,7 @@ import { oraPromise } from "ora";
 import { z } from "zod/v4";
 
 import type { CommandPresenter } from "../../../domain/command-presenter.js";
-import type { GlobalOptions } from "../command-errors.js";
+import type { GlobalOptions } from "../global-options.js";
 
 import { GitHubAuthFactory } from "../../../domain/dependencies.js";
 import {
@@ -300,6 +300,7 @@ const createRemoteRepositoryWithPresenter =
       asError("Failed to create GitHub repository."),
     ).map(() => new Repository(repoName, repoOwner));
   };
+const initializeGitRepositoryWithPresenter =
   (presenter: CommandPresenter) => (repository: Repository) => {
     const branchName = "features/scaffold-workspace";
     const git$ = $({
@@ -436,14 +437,13 @@ const runInitAction = ({
       confirmGitHubRepoCreation(payload, publishToGitHub).andThen<
         SummaryInput,
         Error
-      >(
-        (confirmed) =>
-          confirmed
-            ? handleNewGitHubRepositoryWithPresenter({
-                gitHubService,
-                presenter,
-              })(payload)
-            : okAsync({ gitHubRepoCreationSkipped: true, payload }),
+      >((confirmed) =>
+        confirmed
+          ? handleNewGitHubRepositoryWithPresenter({
+              gitHubService,
+              presenter,
+            })(payload)
+          : okAsync({ gitHubRepoCreationSkipped: true, payload }),
       ),
     );
 

--- a/apps/cli/src/adapters/commander/commands/savemoney.ts
+++ b/apps/cli/src/adapters/commander/commands/savemoney.ts
@@ -5,7 +5,7 @@ import { Command, InvalidArgumentError } from "commander";
 import { oraPromise } from "ora";
 import { z } from "zod";
 
-import { exitWithError, GlobalOptions } from "../index.js";
+import { exitWithError, GlobalOptions } from "../command-errors.js";
 
 export const makeSavemoneyCommand = () =>
   new Command("savemoney")

--- a/apps/cli/src/adapters/commander/commands/savemoney.ts
+++ b/apps/cli/src/adapters/commander/commands/savemoney.ts
@@ -5,7 +5,8 @@ import { Command, InvalidArgumentError } from "commander";
 import { oraPromise } from "ora";
 import { z } from "zod";
 
-import { exitWithError, GlobalOptions } from "../command-errors.js";
+import { exitWithError } from "../command-errors.js";
+import { GlobalOptions } from "../global-options.js";
 
 export const makeSavemoneyCommand = () =>
   new Command("savemoney")

--- a/apps/cli/src/adapters/commander/global-options.ts
+++ b/apps/cli/src/adapters/commander/global-options.ts
@@ -1,0 +1,15 @@
+/**
+ * Shared root CLI options exposed to nested Commander commands.
+ *
+ * The root `dx` program defines these options once, and nested commands read
+ * them via `optsWithGlobals()` to keep cross-command behavior consistent.
+ */
+import type { Command } from "commander";
+
+export type GlobalOptions = {
+  output: "json" | "text";
+  verbose?: boolean;
+};
+
+export const isVerbose = (command: Command): boolean =>
+  command.optsWithGlobals<GlobalOptions>().verbose === true;

--- a/apps/cli/src/adapters/commander/index.ts
+++ b/apps/cli/src/adapters/commander/index.ts
@@ -12,22 +12,9 @@ import { makeInfoCommand } from "./commands/info.js";
 import { makeInitCommand } from "./commands/init.js";
 import { makeSavemoneyCommand } from "./commands/savemoney.js";
 import { makeSpecCommand } from "./commands/spec.js";
-import { formatErrorDetailed, toErrorMessage } from "./error-reporting.js";
 import { extractCliSpec } from "./spec.js";
 
 export type CliDependencies = CodemodCommandDependencies;
-
-export type GlobalOptions = {
-  output: "json" | "text";
-  verbose?: boolean;
-};
-
-/**
- * Returns true when the global `--verbose` flag is active on the closest
- * ancestor command that defines it (the root `dx` program in our CLI).
- */
-export const isVerbose = (command: Command): boolean =>
-  command.optsWithGlobals<GlobalOptions>().verbose === true;
 
 export const makeCli = (
   deps: Dependencies,
@@ -67,20 +54,3 @@ export const makeCli = (
 
   return program;
 };
-
-/**
- * Builds a failure handler that ends the command via Commander's
- * `Command#error`, with an output tailored to the active verbosity.
- *
- * - In normal mode, a single meaningful line is printed.
- * - When `--verbose` is active, the full cause chain and stack trace are
- *   included so users can diagnose the underlying failure.
- */
-export const exitWithError =
-  (command: Command) =>
-  (error: unknown): never => {
-    const message = isVerbose(command)
-      ? formatErrorDetailed(error)
-      : toErrorMessage(error);
-    command.error(message);
-  };

--- a/apps/cli/src/adapters/plop/generators/monorepo/__tests__/prompts.test.ts
+++ b/apps/cli/src/adapters/plop/generators/monorepo/__tests__/prompts.test.ts
@@ -12,11 +12,7 @@ describe("getPrompts", () => {
       repoName: "my-dx-workspace",
     });
 
-    expect(prompts).toHaveLength(2);
-    expect(prompts).not.toEqual(
-      expect.arrayContaining([expect.objectContaining({ name: "repoName" })]),
-    );
-    expect(prompts).toEqual(
+    expect(prompts).toStrictEqual(
       expect.arrayContaining([
         expect.objectContaining({ name: "repoOwner" }),
         expect.objectContaining({ name: "repoDescription" }),
@@ -31,17 +27,17 @@ describe("getPrompts", () => {
         repoName: "my-dx-workspace",
         repoOwner: "pagopa",
       }),
-    ).toHaveLength(0);
+    ).toStrictEqual([]);
   });
 
-  it("keeps the existing repo owner default when the owner is still prompted", () => {
-    const prompts = getPrompts({
-      repoName: "my-dx-workspace",
-    });
+  it("ask all prompts", () => {
+    const prompts = getPrompts();
 
-    expect(prompts).toEqual(
+    expect(prompts).toStrictEqual(
       expect.arrayContaining([
-        expect.objectContaining({ default: "pagopa", name: "repoOwner" }),
+        expect.objectContaining({ name: "repoName" }),
+        expect.objectContaining({ name: "repoOwner" }),
+        expect.objectContaining({ name: "repoDescription" }),
       ]),
     );
   });

--- a/apps/cli/src/adapters/plop/generators/monorepo/__tests__/prompts.test.ts
+++ b/apps/cli/src/adapters/plop/generators/monorepo/__tests__/prompts.test.ts
@@ -1,0 +1,48 @@
+/**
+ * Verifies how the monorepo generator prompts behave when init pre-fills
+ * answers from CLI flags before invoking plop.
+ */
+import { describe, expect, it } from "vitest";
+
+import { getPrompts } from "../prompts.js";
+
+describe("getPrompts", () => {
+  it("asks only for init answers that were not provided via flags", () => {
+    const prompts = getPrompts({
+      repoName: "my-dx-workspace",
+    });
+
+    expect(prompts).toHaveLength(2);
+    expect(prompts).not.toEqual(
+      expect.arrayContaining([expect.objectContaining({ name: "repoName" })]),
+    );
+    expect(prompts).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ name: "repoOwner" }),
+        expect.objectContaining({ name: "repoDescription" }),
+      ]),
+    );
+  });
+
+  it("asks no payload questions when all init answers were provided via flags", () => {
+    expect(
+      getPrompts({
+        repoDescription: "My DX workspace",
+        repoName: "my-dx-workspace",
+        repoOwner: "pagopa",
+      }),
+    ).toHaveLength(0);
+  });
+
+  it("keeps the existing repo owner default when the owner is still prompted", () => {
+    const prompts = getPrompts({
+      repoName: "my-dx-workspace",
+    });
+
+    expect(prompts).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ default: "pagopa", name: "repoOwner" }),
+      ]),
+    );
+  });
+});

--- a/apps/cli/src/adapters/plop/generators/monorepo/index.ts
+++ b/apps/cli/src/adapters/plop/generators/monorepo/index.ts
@@ -14,6 +14,7 @@ export default function (
   plop: NodePlopAPI,
   templatesPath: string,
   octokit: Octokit,
+  initialAnswers: Partial<Payload> = {},
 ) {
   setSetupPnpmAction(plop);
   setGetNodeVersionAction(plop);
@@ -21,6 +22,6 @@ export default function (
   plop.setGenerator(PLOP_MONOREPO_GENERATOR_NAME, {
     actions: getActions(templatesPath),
     description: "A scaffold for a monorepo repository",
-    prompts: getPrompts(),
+    prompts: getPrompts(initialAnswers),
   });
 }

--- a/apps/cli/src/adapters/plop/generators/monorepo/prompts.ts
+++ b/apps/cli/src/adapters/plop/generators/monorepo/prompts.ts
@@ -26,7 +26,7 @@ const createRepoNamePrompt = () => ({
 
 const createRepoOwnerPrompt = () => ({
   default: DEFAULT_REPO_OWNER,
-  message: "GitHub Organization",
+  message: "GitHub owner",
   name: "repoOwner" as const,
   validate: validatePrompt(payloadSchema.shape.repoOwner),
 });
@@ -47,15 +47,15 @@ type PromptFactory = {
 const promptFactories: PromptFactory[] = [
   {
     create: createRepoNamePrompt,
-    isMissing: ({ repoName }) => typeof repoName === "undefined",
+    isMissing: ({ repoName }) => repoName === undefined,
   },
   {
     create: createRepoOwnerPrompt,
-    isMissing: ({ repoOwner }) => typeof repoOwner === "undefined",
+    isMissing: ({ repoOwner }) => repoOwner === undefined,
   },
   {
     create: createRepoDescriptionPrompt,
-    isMissing: ({ repoDescription }) => typeof repoDescription === "undefined",
+    isMissing: ({ repoDescription }) => repoDescription === undefined,
   },
 ];
 

--- a/apps/cli/src/adapters/plop/generators/monorepo/prompts.ts
+++ b/apps/cli/src/adapters/plop/generators/monorepo/prompts.ts
@@ -18,52 +18,34 @@ export const payloadSchema = z.object({
 
 export type Payload = z.infer<typeof payloadSchema>;
 
-const createRepoNamePrompt = () => ({
-  message: "Name",
-  name: "repoName" as const,
-  validate: validatePrompt(payloadSchema.shape.repoName),
-});
-
-const createRepoOwnerPrompt = () => ({
-  default: DEFAULT_REPO_OWNER,
-  message: "GitHub owner",
-  name: "repoOwner" as const,
-  validate: validatePrompt(payloadSchema.shape.repoOwner),
-});
-
-const createRepoDescriptionPrompt = () => ({
-  message: "Description",
-  name: "repoDescription" as const,
-});
-
-type PromptFactory = {
-  create: () =>
-    | ReturnType<typeof createRepoDescriptionPrompt>
-    | ReturnType<typeof createRepoNamePrompt>
-    | ReturnType<typeof createRepoOwnerPrompt>;
-  isMissing: (answers: Partial<Payload>) => boolean;
+type MonorepoPrompt = {
+  default?: string;
+  message: string;
+  name: keyof Payload;
+  validate?: ReturnType<typeof validatePrompt>;
 };
 
-const promptFactories: PromptFactory[] = [
+const prompts: MonorepoPrompt[] = [
   {
-    create: createRepoNamePrompt,
-    isMissing: ({ repoName }) => repoName === undefined,
+    message: "Name",
+    name: "repoName",
+    validate: validatePrompt(payloadSchema.shape.repoName),
   },
   {
-    create: createRepoOwnerPrompt,
-    isMissing: ({ repoOwner }) => repoOwner === undefined,
+    default: DEFAULT_REPO_OWNER,
+    message: "GitHub owner",
+    name: "repoOwner",
+    validate: validatePrompt(payloadSchema.shape.repoOwner),
   },
   {
-    create: createRepoDescriptionPrompt,
-    isMissing: ({ repoDescription }) => repoDescription === undefined,
+    message: "Description",
+    name: "repoDescription",
   },
 ];
 
 export const getPrompts = (
   answers: Partial<Payload> = {},
 ): PlopGeneratorConfig["prompts"] =>
-  promptFactories
-    .filter(({ isMissing }) => isMissing(answers))
-    .map(({ create }) => create());
+  prompts.filter(({ name }) => answers[name] === undefined);
 
 export default getPrompts;

--- a/apps/cli/src/adapters/plop/generators/monorepo/prompts.ts
+++ b/apps/cli/src/adapters/plop/generators/monorepo/prompts.ts
@@ -1,32 +1,69 @@
+/**
+ * Defines the interactive questions for the monorepo plop generator.
+ * The init command can prefill some answers via CLI flags, so we only
+ * return prompts for values that are still missing.
+ */
 import { type PlopGeneratorConfig } from "node-plop";
 import { z } from "zod/v4";
 
 import { validatePrompt } from "../../helpers/validate-prompt.js";
 
+export const DEFAULT_REPO_OWNER = "pagopa";
+
 export const payloadSchema = z.object({
   repoDescription: z.string().optional(),
   repoName: z.string().trim().min(1, "Repository name cannot be empty"),
-  repoOwner: z.string().trim().default("pagopa"),
+  repoOwner: z.string().trim().default(DEFAULT_REPO_OWNER),
 });
 
 export type Payload = z.infer<typeof payloadSchema>;
 
-const getPrompts = (): PlopGeneratorConfig["prompts"] => [
+const createRepoNamePrompt = () => ({
+  message: "Name",
+  name: "repoName" as const,
+  validate: validatePrompt(payloadSchema.shape.repoName),
+});
+
+const createRepoOwnerPrompt = () => ({
+  default: DEFAULT_REPO_OWNER,
+  message: "GitHub Organization",
+  name: "repoOwner" as const,
+  validate: validatePrompt(payloadSchema.shape.repoOwner),
+});
+
+const createRepoDescriptionPrompt = () => ({
+  message: "Description",
+  name: "repoDescription" as const,
+});
+
+type PromptFactory = {
+  create: () =>
+    | ReturnType<typeof createRepoDescriptionPrompt>
+    | ReturnType<typeof createRepoNamePrompt>
+    | ReturnType<typeof createRepoOwnerPrompt>;
+  isMissing: (answers: Partial<Payload>) => boolean;
+};
+
+const promptFactories: PromptFactory[] = [
   {
-    message: "Name",
-    name: "repoName",
-    validate: validatePrompt(payloadSchema.shape.repoName),
+    create: createRepoNamePrompt,
+    isMissing: ({ repoName }) => typeof repoName === "undefined",
   },
   {
-    default: payloadSchema.shape.repoOwner.def.defaultValue,
-    message: "GitHub Organization",
-    name: "repoOwner",
-    validate: validatePrompt(payloadSchema.shape.repoOwner),
+    create: createRepoOwnerPrompt,
+    isMissing: ({ repoOwner }) => typeof repoOwner === "undefined",
   },
   {
-    message: "Description",
-    name: "repoDescription",
+    create: createRepoDescriptionPrompt,
+    isMissing: ({ repoDescription }) => typeof repoDescription === "undefined",
   },
 ];
+
+export const getPrompts = (
+  answers: Partial<Payload> = {},
+): PlopGeneratorConfig["prompts"] =>
+  promptFactories
+    .filter(({ isMissing }) => isMissing(answers))
+    .map(({ create }) => create());
 
 export default getPrompts;

--- a/apps/cli/src/adapters/plop/index.ts
+++ b/apps/cli/src/adapters/plop/index.ts
@@ -28,7 +28,12 @@ export const setMonorepoGenerator = (
   initialAnswers: Partial<MonorepoPayload> = {},
 ) => {
   const octokit = new Octokit({ auth: process.env.GITHUB_TOKEN });
-  createMonorepoGenerator(plop, resolveTemplatesPath("monorepo"), octokit, initialAnswers);
+  createMonorepoGenerator(
+    plop,
+    resolveTemplatesPath("monorepo"),
+    octokit,
+    initialAnswers,
+  );
 };
 
 const validatePayload = async (

--- a/apps/cli/src/adapters/plop/index.ts
+++ b/apps/cli/src/adapters/plop/index.ts
@@ -23,9 +23,12 @@ import createMonorepoGenerator, {
 } from "../plop/generators/monorepo/index.js";
 import { resolveTemplatesPath } from "./templates-path.js";
 
-export const setMonorepoGenerator = (plop: NodePlopAPI) => {
+export const setMonorepoGenerator = (
+  plop: NodePlopAPI,
+  initialAnswers: Partial<MonorepoPayload> = {},
+) => {
   const octokit = new Octokit({ auth: process.env.GITHUB_TOKEN });
-  createMonorepoGenerator(plop, resolveTemplatesPath("monorepo"), octokit);
+  createMonorepoGenerator(plop, resolveTemplatesPath("monorepo"), octokit, initialAnswers);
 };
 
 const validatePayload = async (
@@ -92,11 +95,21 @@ export const runActions = async (
 export const collectMonorepoPayload = async (
   plop: NodePlopAPI,
   githubService: GitHubService,
+  initialAnswers: Partial<MonorepoPayload> = {},
 ): Promise<{ generator: PlopGenerator; payload: MonorepoPayload }> => {
-  setMonorepoGenerator(plop);
+  setMonorepoGenerator(plop, initialAnswers);
   const generator = plop.getGenerator(PLOP_MONOREPO_GENERATOR_NAME);
   const answers = await generator.runPrompts();
-  const payload = monorepoPayloadSchema.parse(answers);
+  const payloadResult = monorepoPayloadSchema.safeParse({
+    ...initialAnswers,
+    ...answers,
+  });
+  if (!payloadResult.success) {
+    throw new Error("Invalid monorepo generator answers", {
+      cause: payloadResult.error,
+    });
+  }
+  const payload = payloadResult.data;
   await validatePayload(payload, githubService);
   return { generator, payload };
 };


### PR DESCRIPTION
This makes `dx init` usable in non-interactive workflows while preserving the existing guided prompts when flags are omitted.

A dd flags for every `dx init` input (`repo-name`, `repo-owner`, `repo-description`, `publish-to-github`) and validate provided flags with Zod and only prompt for values that were not passed on the command line.

Closes CES-2132