### PR TITLE
Fix devcontainer.json

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -5,7 +5,7 @@
     "ghcr.io/pagopa/devcontainer-features/acli:1": {},
     "ghcr.io/devcontainers/features/azure-cli:1": {},
     "ghcr.io/devcontainers/features/github-cli:1": {
-      "extensions": ["seachicken/gh-poi"]
+      "extensions": "seachicken/gh-poi"
     },
     "ghcr.io/devcontainers/features/terraform:1": {
       "version": "latest",


### PR DESCRIPTION
As stated in [Development Container Spec](https://containers.dev/implementors/features/#options-property) feature options can be either `bool` or `string`, and not json arrays.

The [GitHub CLI (`gh`) feature](https://github.com/devcontainers/features/tree/main/src/github-cli#options) take the `extensions` option as "comma-separated list of extensions" (`string`)