### PR TITLE
Implement geo rate limiting in WAF policy

### DIFF
--- a/.nx/version-plans/version-plan-ces-2122.md
+++ b/.nx/version-plans/version-plan-ces-2122.md
@@ -1,0 +1,5 @@
+---
+azure_cdn: minor
+---
+
+Add a built-in geo rate limit rule to the optional Front Door WAF policy. When `waf_enabled` is `true`, traffic originating outside the EU/EEA is blocked once it exceeds the configurable `waf_rate_limit_threshold` (default `10000`) within a 5-minute window, mitigating DDoS-driven cost spikes.

--- a/infra/modules/azure_cdn/README.md
+++ b/infra/modules/azure_cdn/README.md
@@ -7,7 +7,7 @@ This Terraform module provisions an Azure CDN Front Door profile with endpoints,
 ## Features
 
 - **Azure Front Door CDN Profile**: Provisions a Standard Microsoft SKU profile or reuses an existing one.
-- **WAF Protection**: Optional Web Application Firewall policy with Prevention mode for enhanced security.
+- **WAF Protection**: Optional Web Application Firewall policy with Prevention mode for enhanced security. When enabled, a built-in geo rate limit rule throttles traffic originating outside the EU/EEA to mitigate DDoS-driven cost spikes. The per-IP threshold is configurable via `waf_rate_limit_threshold`.
 - **Origin Configuration**: Supports health probes and priority-based routing.
 - **Custom Domains**: Associates custom domains with the CDN endpoint, including DNS record creation.
 - **Diagnostic Settings**: Configurable diagnostic settings for monitoring and logging.
@@ -178,6 +178,7 @@ No modules.
 | <a name="input_resource_group_name"></a> [resource\_group\_name](#input\_resource\_group\_name) | Resource group name where the CDN profile will be created | `string` | n/a | yes |
 | <a name="input_tags"></a> [tags](#input\_tags) | Resource tags | `map(any)` | n/a | yes |
 | <a name="input_waf_enabled"></a> [waf\_enabled](#input\_waf\_enabled) | Whether to enable the WAF policy and associate it with the endpoint. | `bool` | `false` | no |
+| <a name="input_waf_rate_limit_threshold"></a> [waf\_rate\_limit\_threshold](#input\_waf\_rate\_limit\_threshold) | Maximum number of requests allowed from a single non-EU/EEA client IP within a 5-minute window before the geo rate limit rule starts blocking.<br/>Only applies when waf\_enabled is true. Tune this value based on the expected legitimate non-EU traffic of the product." | `number` | `10000` | no |
 
 ## Outputs
 

--- a/infra/modules/azure_cdn/cdn.tf
+++ b/infra/modules/azure_cdn/cdn.tf
@@ -90,6 +90,32 @@ resource "azurerm_cdn_frontdoor_firewall_policy" "this" {
   sku_name            = "Standard_AzureFrontDoor"
   enabled             = true
   mode                = "Prevention"
+  # Geo rate limit rule: throttle traffic originating outside the EU/EEA to
+  # mitigate DDoS-driven cost spikes (Technology guideline "Azure - Protezione
+  # DDoS e Geofiltering"). Requests from non-EU/EEA client IPs are blocked once
+  # they exceed waf_rate_limit_threshold within a 5-minute window.
+  custom_rule {
+    name     = "RateLimitNonEU"
+    enabled  = true
+    priority = 100
+    type     = "RateLimitRule"
+    action   = "Block"
+
+    rate_limit_duration_in_minutes = 5
+    rate_limit_threshold           = var.waf_rate_limit_threshold
+
+    # Azure WAF allows at most 10 match values per match condition, so the
+    # EU/EEA country list is spread across multiple GeoMatch conditions.
+    dynamic "match_condition" {
+      for_each = local.waf_eu_geo_match_value_chunks
+      content {
+        match_variable     = "SocketAddr"
+        operator           = "GeoMatch"
+        negation_condition = true
+        match_values       = match_condition.value
+      }
+    }
+  }
 
   tags = local.tags
 }

--- a/infra/modules/azure_cdn/locals.tf
+++ b/infra/modules/azure_cdn/locals.tf
@@ -44,6 +44,18 @@ locals {
   # Check if existing Profile SKU is compatible with WAF
   compatible_sku = var.existing_cdn_frontdoor_profile_id != null ? data.azurerm_cdn_frontdoor_profile.existing[0].sku_name == "Standard_AzureFrontDoor" : true
 
+  # EU/EEA country codes exempted from the geo rate limit rule. Traffic coming
+  # from any other country is rate-limited to mitigate DDoS-driven cost spikes
+  waf_eu_geo_match_values = [
+    "AT", "BE", "BG", "HR", "CY", "CZ", "DK", "EE", "FI", "FR",
+    "DE", "GR", "HU", "IE", "IT", "LV", "LT", "LU", "MT", "NL",
+    "PL", "PT", "RO", "SK", "SI", "ES", "SE", "NO", "IS", "LI"
+  ]
+
+  # Azure WAF allows at most 10 match values per match condition, so the country
+  # list is split into chunks of 10, each rendered as a separate match_condition.
+  waf_eu_geo_match_value_chunks = chunklist(local.waf_eu_geo_match_values, 10)
+
   # Construct Key Vault IDs from subscription ID and resource details
   key_vault_ids = {
     for k, v in merge(local.unique_key_vaults_rbac, local.unique_key_vaults_no_rbac) :

--- a/infra/modules/azure_cdn/tests/contract.tftest.hcl
+++ b/infra/modules/azure_cdn/tests/contract.tftest.hcl
@@ -311,3 +311,43 @@ run "valid_existing_profile_id" {
     error_message = "Data source must be created for valid existing profile ID"
   }
 }
+
+run "invalid_waf_rate_limit_threshold_zero" {
+  command = plan
+
+  variables {
+    waf_enabled              = true
+    waf_rate_limit_threshold = 0
+  }
+
+  expect_failures = [
+    var.waf_rate_limit_threshold,
+  ]
+}
+
+run "invalid_waf_rate_limit_threshold_negative" {
+  command = plan
+
+  variables {
+    waf_enabled              = true
+    waf_rate_limit_threshold = -100
+  }
+
+  expect_failures = [
+    var.waf_rate_limit_threshold,
+  ]
+}
+
+run "valid_waf_rate_limit_threshold" {
+  command = plan
+
+  variables {
+    waf_enabled              = true
+    waf_rate_limit_threshold = 1
+  }
+
+  assert {
+    condition     = one(azurerm_cdn_frontdoor_firewall_policy.this[0].custom_rule).rate_limit_threshold == 1
+    error_message = "WAF policy must accept a positive waf_rate_limit_threshold value"
+  }
+}

--- a/infra/modules/azure_cdn/tests/integration.tftest.hcl
+++ b/infra/modules/azure_cdn/tests/integration.tftest.hcl
@@ -233,6 +233,16 @@ run "apply_cdn_with_waf" {
     condition     = length(azurerm_cdn_frontdoor_security_policy.this) == 1
     error_message = "Security policy must be created"
   }
+
+  assert {
+    condition     = one(azurerm_cdn_frontdoor_firewall_policy.this[0].custom_rule).name == "RateLimitNonEU"
+    error_message = "WAF policy must include the geo rate limit custom rule"
+  }
+
+  assert {
+    condition     = one(azurerm_cdn_frontdoor_firewall_policy.this[0].custom_rule).type == "RateLimitRule"
+    error_message = "Geo rate limit rule must be of type RateLimitRule"
+  }
 }
 
 run "apply_cdn_with_multiple_origins" {

--- a/infra/modules/azure_cdn/tests/unit.tftest.hcl
+++ b/infra/modules/azure_cdn/tests/unit.tftest.hcl
@@ -253,6 +253,78 @@ run "cdn_waf_enabled" {
   }
 }
 
+run "cdn_waf_geo_rate_limit_default" {
+  command = plan
+
+  variables {
+    waf_enabled = true
+  }
+
+  assert {
+    condition     = one(azurerm_cdn_frontdoor_firewall_policy.this[0].custom_rule).name == "RateLimitNonEU"
+    error_message = "WAF policy must include the geo rate limit custom rule"
+  }
+
+  assert {
+    condition     = one(azurerm_cdn_frontdoor_firewall_policy.this[0].custom_rule).type == "RateLimitRule"
+    error_message = "Geo rate limit rule must be of type RateLimitRule"
+  }
+
+  assert {
+    condition     = one(azurerm_cdn_frontdoor_firewall_policy.this[0].custom_rule).action == "Block"
+    error_message = "Geo rate limit rule must block traffic exceeding the threshold"
+  }
+
+  assert {
+    condition     = one(azurerm_cdn_frontdoor_firewall_policy.this[0].custom_rule).rate_limit_duration_in_minutes == 5
+    error_message = "Geo rate limit window must be 5 minutes"
+  }
+
+  assert {
+    condition     = one(azurerm_cdn_frontdoor_firewall_policy.this[0].custom_rule).rate_limit_threshold == 10000
+    error_message = "Geo rate limit threshold must default to 10000 requests"
+  }
+
+  assert {
+    condition     = one(azurerm_cdn_frontdoor_firewall_policy.this[0].custom_rule).match_condition[0].operator == "GeoMatch"
+    error_message = "Geo rate limit rule must match on client geo location"
+  }
+
+  assert {
+    condition     = one(azurerm_cdn_frontdoor_firewall_policy.this[0].custom_rule).match_condition[0].negation_condition == true
+    error_message = "Geo rate limit rule must target traffic outside the EU/EEA country list"
+  }
+
+  assert {
+    condition     = alltrue([for c in one(azurerm_cdn_frontdoor_firewall_policy.this[0].custom_rule).match_condition : length(c.match_values) <= 10])
+    error_message = "Each GeoMatch condition must contain at most 10 match values (Azure WAF limit)"
+  }
+
+  assert {
+    condition     = length(flatten([for c in one(azurerm_cdn_frontdoor_firewall_policy.this[0].custom_rule).match_condition : c.match_values])) == 30
+    error_message = "Geo rate limit rule must cover all 30 EU/EEA country codes across its match conditions"
+  }
+
+  assert {
+    condition     = contains(flatten([for c in one(azurerm_cdn_frontdoor_firewall_policy.this[0].custom_rule).match_condition : c.match_values]), "IT")
+    error_message = "EU/EEA country list must include Italy"
+  }
+}
+
+run "cdn_waf_geo_rate_limit_custom_threshold" {
+  command = plan
+
+  variables {
+    waf_enabled              = true
+    waf_rate_limit_threshold = 5000
+  }
+
+  assert {
+    condition     = one(azurerm_cdn_frontdoor_firewall_policy.this[0].custom_rule).rate_limit_threshold == 5000
+    error_message = "Geo rate limit threshold must honor the waf_rate_limit_threshold variable"
+  }
+}
+
 run "cdn_waf_disabled" {
   command = plan
 

--- a/infra/modules/azure_cdn/variables.tf
+++ b/infra/modules/azure_cdn/variables.tf
@@ -73,6 +73,20 @@ variable "waf_enabled" {
   default     = false
 }
 
+variable "waf_rate_limit_threshold" {
+  type        = number
+  default     = 10000
+  description = <<-EOT
+  Maximum number of requests allowed from a single non-EU/EEA client IP within a 5-minute window before the geo rate limit rule starts blocking.
+  Only applies when waf_enabled is true. Tune this value based on the expected legitimate non-EU traffic of the product."
+  EOT
+
+  validation {
+    condition     = var.waf_rate_limit_threshold > 0
+    error_message = "waf_rate_limit_threshold must be a positive number."
+  }
+}
+
 variable "custom_domains" {
   type = list(object({
     host_name = string


### PR DESCRIPTION
Add a built-in geo rate limit rule to the Front Door WAF policy to block traffic from non-EU/EEA IPs exceeding a configurable threshold, mitigating DDoS-driven cost spikes. The rule activates when `waf_enabled` is set to true, with a default threshold of 10,000 requests within a 5-minute window. Adjustments to the threshold are validated to ensure positive values.

Close CES-2122