### PR TITLE
Add VSCode launch and task configuration for dx CLI

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,20 @@
+{
+  "version": "0.2.0",
+  "configurations": [
+    {
+      "name": "dx CLI",
+      "type": "node",
+      "request": "launch",
+      "program": "${workspaceFolder}/apps/cli/bin/index.js",
+      "args": ["init"],
+      "cwd": "${workspaceFolder}",
+      "sourceMaps": true,
+      "outFiles": ["${workspaceFolder}/apps/cli/dist/**/*.js"],
+      "preLaunchTask": "build: dx-cli",
+      "console": "integratedTerminal",
+      "autoAttachChildProcesses": false,
+      "skipFiles": ["<node_internals>/**"],
+      "env": {}
+    }
+  ]
+}

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -6,7 +6,7 @@
       "type": "node",
       "request": "launch",
       "program": "${workspaceFolder}/apps/cli/bin/index.js",
-      "args": ["init"],
+      "args": ["--version"],
       "cwd": "${workspaceFolder}",
       "sourceMaps": true,
       "outFiles": ["${workspaceFolder}/apps/cli/dist/**/*.js"],

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -1,0 +1,16 @@
+{
+  "version": "2.0.0",
+  "tasks": [
+    {
+      "label": "build: dx-cli",
+      "type": "shell",
+      "command": "pnpm nx build @pagopa/dx-cli",
+      "group": "build",
+      "presentation": {
+        "reveal": "silent",
+        "panel": "shared"
+      },
+      "problemMatcher": ["$tsc"]
+    }
+  ]
+}

--- a/apps/cli/tsconfig.lib.json
+++ b/apps/cli/tsconfig.lib.json
@@ -1,5 +1,9 @@
 {
   "extends": "./tsconfig.json",
   "include": ["./src/**/*.ts"],
-  "exclude": ["**/__tests__/**"]
+  "exclude": ["**/__tests__/**"],
+  "compilerOptions": {
+    "inlineSourceMap": true,
+    "inlineSources": true
+  }
 }


### PR DESCRIPTION
Introduce a launch configuration and a build task for the dx CLI in VSCode, enabling streamlined debugging and building processes. It supports breakpoints, variables evaluation, call stack and more.

From now on, `F5` is the way to go.

Apart from dx-cli, this setup can be replicated to any typescript project, including systems in production