### PR TITLE
Add doctor path flag

### DIFF
--- a/.nx/version-plans/version-plan-1781173004636.md
+++ b/.nx/version-plans/version-plan-1781173004636.md
@@ -1,0 +1,5 @@
+---
+"@pagopa/dx-cli": patch
+---
+
+Add doctor command repository path flag

--- a/apps/cli/README.md
+++ b/apps/cli/README.md
@@ -75,14 +75,20 @@ Verify the repository setup according to the DevEx guidelines.
 
 ```bash
 dx doctor
+dx doctor --path apps/cli
+dx doctor -p apps/cli
 ```
 
 This command will:
 
 - Check if you're in a valid Git repository
 - Validate that required monorepo scripts are present in package.json
-- Check that the `turbo.json` file exists
-- Verify that the installed `turbo` version meets the minimum requirements
+- Verify that `.pre-commit-config.yaml` is present
+- Check that `nx.json` exists and that the installed Nx version meets the minimum requirements
+- Verify that pnpm workspaces are configured
+
+Use `-p, --path` to inspect a repository other than the current working
+directory.
 
 **Example output:**
 

--- a/apps/cli/src/adapters/commander/commands/__tests__/doctor.test.ts
+++ b/apps/cli/src/adapters/commander/commands/__tests__/doctor.test.ts
@@ -1,0 +1,45 @@
+/**
+ * Tests for the doctor Commander command flags.
+ */
+
+import { describe, expect, it } from "vitest";
+
+import {
+  makeMockConfig,
+  makeMockDependencies,
+} from "../../../../domain/__tests__/data.js";
+import { makeDoctorCommand, parseDoctorCommandOptions } from "../doctor.js";
+
+describe("parseDoctorCommandOptions", () => {
+  it("returns an empty options object when no flag is provided", () => {
+    expect(parseDoctorCommandOptions({})).toEqual({});
+  });
+
+  it("returns the provided repository path", () => {
+    expect(
+      parseDoctorCommandOptions({
+        path: "apps/cli",
+      }),
+    ).toEqual({
+      repositoryPath: "apps/cli",
+    });
+  });
+
+  it("rejects a blank repository path", () => {
+    expect(() =>
+      parseDoctorCommandOptions({
+        path: "   ",
+      }),
+    ).toThrow("Repository path cannot be empty");
+  });
+});
+
+describe("makeDoctorCommand", () => {
+  it("registers the repository path flag with a short alias", () => {
+    const command = makeDoctorCommand(makeMockDependencies(), makeMockConfig());
+
+    expect(command.options.map((option) => option.flags)).toEqual([
+      "-p, --path <path>",
+    ]);
+  });
+});

--- a/apps/cli/src/adapters/commander/commands/doctor.ts
+++ b/apps/cli/src/adapters/commander/commands/doctor.ts
@@ -1,9 +1,29 @@
-import { Command } from "commander";
-import * as process from "node:process";
+import { Command, Option } from "commander";
+import { ResultAsync } from "neverthrow";
+import { z } from "zod";
 
 import { Config } from "../../../config.js";
 import { Dependencies } from "../../../domain/dependencies.js";
-import { printDoctorResult, runDoctor } from "../../../domain/doctor.js";
+import {
+  DoctorOptions,
+  printDoctorResult,
+  runDoctor,
+} from "../../../domain/doctor.js";
+
+const doctorCommandOptionsSchema = z.object({
+  path: z.string().trim().min(1, "Repository path cannot be empty").optional(),
+});
+
+export const parseDoctorCommandOptions = (input: unknown): DoctorOptions => {
+  const result = doctorCommandOptionsSchema.safeParse(input);
+  if (!result.success) {
+    throw new Error(z.prettifyError(result.error), {
+      cause: result.error,
+    });
+  }
+
+  return result.data.path ? { repositoryPath: result.data.path } : {};
+};
 
 export const makeDoctorCommand = (
   dependencies: Dependencies,
@@ -14,10 +34,33 @@ export const makeDoctorCommand = (
     .description(
       "Verify the repository setup according to the DevEx guidelines",
     )
-    .action(async () => {
-      const result = await runDoctor(dependencies, config);
-      printDoctorResult(dependencies, result);
-
-      const exitCode = result.hasErrors ? 1 : 0;
-      process.exit(exitCode);
+    .addOption(
+      new Option(
+        "-p, --path <path>",
+        "Repository path to inspect instead of the current working directory",
+      ),
+    )
+    .action(async function (options: unknown) {
+      await ResultAsync.fromPromise(
+        Promise.resolve().then(() => parseDoctorCommandOptions(options)),
+        (cause) =>
+          cause instanceof Error
+            ? cause
+            : new Error("Failed to parse doctor command options", { cause }),
+      )
+        .andThen((doctorOpts) =>
+          ResultAsync.fromPromise(
+            runDoctor(dependencies, config, doctorOpts),
+            (cause) =>
+              cause instanceof Error
+                ? cause
+                : new Error("Failed to run doctor command", {
+                    cause,
+                  }),
+          ),
+        )
+        .match(
+          (result) => printDoctorResult(dependencies, result),
+          (error) => this.error(error.message),
+        );
     });

--- a/apps/cli/src/domain/__tests__/doctor.test.ts
+++ b/apps/cli/src/domain/__tests__/doctor.test.ts
@@ -1,0 +1,56 @@
+import { okAsync } from "neverthrow";
+import { describe, expect, it } from "vitest";
+
+import { runDoctor } from "../doctor.js";
+import { workspaceSchema } from "../workspace.js";
+import { makeMockConfig, makeMockDependencies } from "./data.js";
+
+describe("runDoctor", () => {
+  it("uses the provided repository path to find the repository root", async () => {
+    const deps = makeMockDependencies();
+    deps.repositoryReader.findRepositoryRoot.mockReturnValueOnce(
+      okAsync("a/repo/root"),
+    );
+    deps.repositoryReader.fileExists.mockReturnValueOnce(okAsync(true));
+
+    await runDoctor(deps, makeMockConfig(), {
+      repositoryPath: "apps/cli",
+    });
+
+    expect(deps.repositoryReader.findRepositoryRoot).toHaveBeenCalledWith(
+      "apps/cli",
+    );
+  });
+
+  it("runs every doctor check", async () => {
+    const deps = makeMockDependencies();
+    deps.repositoryReader.findRepositoryRoot.mockReturnValueOnce(
+      okAsync("a/repo/root"),
+    );
+    deps.repositoryReader.fileExists
+      .mockReturnValueOnce(okAsync(true))
+      .mockReturnValueOnce(okAsync(true));
+    deps.packageJsonReader.getDependencies.mockReturnValueOnce(
+      okAsync(new Map([["nx", "^22.0.0"]])),
+    );
+    deps.packageJsonReader.getRootRequiredScripts.mockReturnValue(new Map());
+    deps.packageJsonReader.getScripts.mockReturnValue(okAsync(new Map()));
+    deps.repositoryReader.getWorkspaces.mockReturnValue(
+      okAsync([
+        workspaceSchema.parse({
+          name: "workspace",
+          path: "packages/workspace",
+        }),
+      ]),
+    );
+
+    const result = await runDoctor(deps, makeMockConfig());
+
+    expect(result.checks.map(({ checkName }) => checkName)).toEqual([
+      "Pre-commit Configuration",
+      "Nx Configuration",
+      "Monorepo Scripts",
+      "Workspaces",
+    ]);
+  });
+});

--- a/apps/cli/src/domain/doctor.ts
+++ b/apps/cli/src/domain/doctor.ts
@@ -7,15 +7,28 @@ import { checkNxConfig, checkPreCommitConfig } from "./repository.js";
 import { ValidationCheck, ValidationCheckResult } from "./validation.js";
 import { checkWorkspaces } from "./workspace.js";
 
+export type DoctorOptions = {
+  repositoryPath?: string;
+};
+
+type DoctorCheckDefinition = {
+  run: () => ResultAsync<ValidationCheckResult, Error>;
+};
+
 type DoctorResult = {
   checks: ValidationCheck[];
   hasErrors: boolean;
 };
 
-export const runDoctor = async (dependencies: Dependencies, config: Config) => {
+export const runDoctor = async (
+  dependencies: Dependencies,
+  config: Config,
+  options: DoctorOptions = {},
+) => {
   // Get repository root - doctor command requires being in a repository
-  const repoRootResult =
-    await dependencies.repositoryReader.findRepositoryRoot();
+  const repoRootResult = await dependencies.repositoryReader.findRepositoryRoot(
+    options.repositoryPath,
+  );
 
   if (repoRootResult.isErr()) {
     return {
@@ -33,25 +46,40 @@ export const runDoctor = async (dependencies: Dependencies, config: Config) => {
 
   const repositoryRoot = repoRootResult.value;
 
-  const doctorChecks = [
-    ResultAsync.fromPromise(
-      checkPreCommitConfig(dependencies, repositoryRoot),
-      () => new Error("Error checking pre-commit configuration"),
-    ),
-    ResultAsync.fromPromise(
-      checkNxConfig(dependencies, repositoryRoot, config),
-      () => new Error("Error checking Nx configuration"),
-    ),
-    ResultAsync.fromPromise(
-      checkMonorepoScripts(dependencies, repositoryRoot),
-      () => new Error("Error checking monorepo scripts"),
-    ),
-    ResultAsync.fromPromise(
-      checkWorkspaces(dependencies, repositoryRoot),
-      () => new Error("Error checking workspaces"),
-    ),
+  const doctorCheckDefinitions: DoctorCheckDefinition[] = [
+    {
+      run: () =>
+        ResultAsync.fromPromise(
+          checkPreCommitConfig(dependencies, repositoryRoot),
+          () => new Error("Error checking pre-commit configuration"),
+        ),
+    },
+    {
+      run: () =>
+        ResultAsync.fromPromise(
+          checkNxConfig(dependencies, repositoryRoot, config),
+          () => new Error("Error checking Nx configuration"),
+        ),
+    },
+    {
+      run: () =>
+        ResultAsync.fromPromise(
+          checkMonorepoScripts(dependencies, repositoryRoot),
+          () => new Error("Error checking monorepo scripts"),
+        ),
+    },
+    {
+      run: () =>
+        ResultAsync.fromPromise(
+          checkWorkspaces(dependencies, repositoryRoot),
+          () => new Error("Error checking workspaces"),
+        ),
+    },
   ];
-  return ResultAsync.combine(doctorChecks).match(
+
+  return ResultAsync.combine(
+    doctorCheckDefinitions.map(({ run }) => run()),
+  ).match(
     toDoctorResult,
     (): DoctorResult => ({
       checks: [],


### PR DESCRIPTION
Allow `dx doctor` to inspect a repository from an explicit path while keeping the full doctor check set enabled. This makes the command easier to run from automation or parent directories without changing the current validation behavior.

Resolves CES-2133