### PR TITLE
Wire info command to presenter

### DIFF
--- a/.nx/version-plans/version-plan-1781182695903.md
+++ b/.nx/version-plans/version-plan-1781182695903.md
@@ -1,0 +1,5 @@
+---
+"@pagopa/dx-cli": patch
+---
+
+Wire info command output through the command presenter.

--- a/apps/cli/src/adapters/commander/commands/__tests__/info.test.ts
+++ b/apps/cli/src/adapters/commander/commands/__tests__/info.test.ts
@@ -1,0 +1,95 @@
+/**
+ * Tests for the `info` Commander command.
+ *
+ * Verifies that command output goes through the shared CommandPresenter port.
+ */
+
+import { Command } from "commander";
+import { errAsync, okAsync } from "neverthrow";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import type {
+  Dependencies,
+  GitHubAuthFactory,
+} from "../../../../domain/dependencies.js";
+import type { PackageJsonReader } from "../../../../domain/package-json.js";
+import type { RepositoryReader } from "../../../../domain/repository.js";
+import type { ValidationReporter } from "../../../../domain/validation.js";
+
+import { packageJsonSchema } from "../../../../domain/package-json.js";
+import { makeInfoCommand } from "../info.js";
+
+const makeDependencies = (): Dependencies => {
+  const packageJson = packageJsonSchema.parse({
+    name: "test-package",
+    packageManager: "pnpm",
+  });
+
+  const packageJsonReader: PackageJsonReader = {
+    getDependencies: vi.fn(),
+    getRootRequiredScripts: vi.fn(() => new Map()),
+    getScripts: vi.fn(),
+    readPackageJson: vi.fn(() => okAsync(packageJson)),
+  };
+
+  const repositoryReader: RepositoryReader = {
+    fileExists: vi.fn(() => okAsync(false)),
+    findRepositoryRoot: vi.fn(() => okAsync("a/repo/root")),
+    getWorkspaces: vi.fn(),
+    readFile: vi
+      .fn()
+      .mockReturnValueOnce(okAsync("22.0.0\n"))
+      .mockReturnValueOnce(okAsync("1.12.0\n")),
+  };
+
+  const requireGitHubAuth: GitHubAuthFactory = () =>
+    errAsync(new Error("not used by the info command"));
+
+  const validationReporter: ValidationReporter = {
+    reportCheckResult: vi.fn(),
+  };
+
+  return {
+    packageJsonReader,
+    repositoryReader,
+    requireGitHubAuth,
+    validationReporter,
+  };
+};
+
+const runInfoCommand = async (output: "json" | "text") => {
+  const command = makeInfoCommand(makeDependencies());
+  const program = new Command()
+    .exitOverride()
+    .option("--output <mode>", "Output mode", output)
+    .addCommand(command);
+
+  await program.parseAsync(["node", "dx", "--output", output, "info"]);
+};
+
+describe("makeInfoCommand", () => {
+  beforeEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("reports the info result through the json command presenter", async () => {
+    const stdout: string[] = [];
+    vi.spyOn(process.stdout, "write").mockImplementation((data: unknown) => {
+      stdout.push(String(data));
+      return true;
+    });
+
+    await runInfoCommand("json");
+
+    const output = stdout.join("");
+    expect(output).not.toBe("");
+    expect(JSON.parse(output)).toStrictEqual({
+      data: {
+        node: "22.0.0",
+        packageManager: "pnpm",
+        terraform: "1.12.0",
+      },
+      ok: true,
+    });
+  });
+});

--- a/apps/cli/src/adapters/commander/commands/info.ts
+++ b/apps/cli/src/adapters/commander/commands/info.ts
@@ -1,13 +1,18 @@
 import { Command } from "commander";
 
-import { Dependencies } from "../../../domain/dependencies.js";
-import { getInfo, printInfo } from "../../../domain/info.js";
+import type { Dependencies } from "../../../domain/dependencies.js";
+import type { GlobalOptions } from "../index.js";
+
+import { getInfo } from "../../../domain/info.js";
+import { createCommandPresenter } from "../presenters/index.js";
 
 export const makeInfoCommand = (dependencies: Dependencies): Command =>
   new Command()
     .name("info")
     .description("Display information about the project")
-    .action(async () => {
+    .action(async function () {
+      const { output } = this.optsWithGlobals<GlobalOptions>();
+      const presenter = createCommandPresenter(output);
       const result = await getInfo(dependencies)();
-      printInfo(result);
+      presenter.reportResult(result);
     });

--- a/apps/cli/src/domain/info.ts
+++ b/apps/cli/src/domain/info.ts
@@ -1,4 +1,3 @@
-import { getLogger } from "@logtape/logtape";
 import { join } from "node:path";
 
 import { Dependencies } from "./dependencies.js";
@@ -99,8 +98,3 @@ export const getInfo =
       turbo: await detectTurboVersion(dependencies, repositoryRoot),
     };
   };
-
-export const printInfo = (result: InfoResult): void => {
-  const logger = getLogger("json");
-  logger.info(JSON.stringify(result));
-};


### PR DESCRIPTION
Route the info command output through the shared command presenter so text and JSON modes use the same CLI output path. Remove the old domain-level logger output helper and cover the JSON presenter envelope with a command test.

Closes CES-2139