### PR TITLE
Wire codemod commands to presenter

### DIFF
--- a/.nx/version-plans/version-plan-1781186384467.md
+++ b/.nx/version-plans/version-plan-1781186384467.md
@@ -1,0 +1,5 @@
+---
+"@pagopa/dx-cli": patch
+---
+
+Wire codemod commands through the command presenter.

--- a/apps/cli/src/adapters/commander/command-errors.ts
+++ b/apps/cli/src/adapters/commander/command-errors.ts
@@ -7,7 +7,6 @@ import type { CommandPresenter } from "../../domain/command-presenter.js";
 
 import { formatErrorDetailed, toErrorMessage } from "./error-reporting.js";
 import { isVerbose } from "./global-options.js";
-import { JsonCommandPresenter } from "./presenters/json-command-presenter.js";
 
 /**
  * Builds a failure handler that ends the command via Commander's
@@ -47,9 +46,13 @@ export const asError =
  *   human-readable message and exits immediately.
  */
 export const reportCommandError =
-  (command: Command, presenter: CommandPresenter) =>
+  (
+    command: Command,
+    presenter: CommandPresenter,
+    outputMode: "json" | "text",
+  ) =>
   (error: Error): void => {
-    if (presenter instanceof JsonCommandPresenter) {
+    if (outputMode === "json") {
       presenter.reportError(error);
       process.exitCode = 1;
     } else {

--- a/apps/cli/src/adapters/commander/command-errors.ts
+++ b/apps/cli/src/adapters/commander/command-errors.ts
@@ -27,13 +27,15 @@ export const exitWithError =
   };
 
 /**
- * Casts an unknown thrown value to an Error instance.
+ * Casts an unknown thrown value to an Error instance with a descriptive
+ * message, preserving the original value as the cause.
  *
- * Use as the error-mapper argument for `ResultAsync.fromPromise` when no
- * specific wrapping message is needed.
+ * Use as the error-mapper argument for `ResultAsync.fromPromise`.
  */
-export const toError = (error: unknown): Error =>
-  error instanceof Error ? error : new Error(String(error));
+export const asError =
+  (message: string) =>
+  (cause: unknown): Error =>
+    new Error(message, { cause });
 
 /**
  * Builds an error handler for command actions that selects the appropriate

--- a/apps/cli/src/adapters/commander/command-errors.ts
+++ b/apps/cli/src/adapters/commander/command-errors.ts
@@ -3,8 +3,11 @@
  */
 import type { Command } from "commander";
 
+import type { CommandPresenter } from "../../domain/command-presenter.js";
+
 import { formatErrorDetailed, toErrorMessage } from "./error-reporting.js";
 import { isVerbose } from "./global-options.js";
+import { JsonCommandPresenter } from "./presenters/json-command-presenter.js";
 
 /**
  * Builds a failure handler that ends the command via Commander's
@@ -21,4 +24,33 @@ export const exitWithError =
       ? formatErrorDetailed(error)
       : toErrorMessage(error);
     command.error(message);
+  };
+
+/**
+ * Casts an unknown thrown value to an Error instance.
+ *
+ * Use as the error-mapper argument for `ResultAsync.fromPromise` when no
+ * specific wrapping message is needed.
+ */
+export const toError = (error: unknown): Error =>
+  error instanceof Error ? error : new Error(String(error));
+
+/**
+ * Builds an error handler for command actions that selects the appropriate
+ * reporting strategy based on the requested output mode.
+ *
+ * - In JSON mode the error is written to the presenter and the process exit
+ *   code is set to 1 (so the caller can return cleanly without throwing).
+ * - In text mode Commander's `command.error()` is used, which prints a
+ *   human-readable message and exits immediately.
+ */
+export const reportCommandError =
+  (command: Command, presenter: CommandPresenter) =>
+  (error: Error): void => {
+    if (presenter instanceof JsonCommandPresenter) {
+      presenter.reportError(error);
+      process.exitCode = 1;
+    } else {
+      exitWithError(command)(error);
+    }
   };

--- a/apps/cli/src/adapters/commander/commands/__tests__/codemod.test.ts
+++ b/apps/cli/src/adapters/commander/commands/__tests__/codemod.test.ts
@@ -1,0 +1,139 @@
+/**
+ * Tests for the `codemod` Commander command.
+ *
+ * Verifies that codemod subcommands emit through the shared CommandPresenter
+ * port instead of writing directly to terminal/logging adapters.
+ */
+
+import { Command } from "commander";
+import { errAsync, okAsync, ResultAsync } from "neverthrow";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import type { Codemod } from "../../../../domain/codemod.js";
+import type { ApplyCodemodById } from "../../../../use-cases/apply-codemod.js";
+import type { ListCodemods } from "../../../../use-cases/list-codemods.js";
+
+import { makeCodemodCommand } from "../codemod.js";
+
+const codemods: Codemod[] = [
+  {
+    apply: vi.fn().mockResolvedValue(undefined),
+    description: "Use pnpm",
+    id: "use-pnpm",
+  },
+];
+
+type CodemodCommandOverrides = {
+  applyCodemodById?: ApplyCodemodById;
+  listCodemods?: ListCodemods;
+};
+
+const makeSuccessfulApplyCodemodById = (): ApplyCodemodById =>
+  vi.fn(() =>
+    ResultAsync.fromPromise(Promise.resolve(), () => new Error("failed")),
+  );
+
+const runCodemodCommand = async (
+  args: string[],
+  overrides: CodemodCommandOverrides = {},
+) => {
+  const command = makeCodemodCommand({
+    applyCodemodById:
+      overrides.applyCodemodById ?? makeSuccessfulApplyCodemodById(),
+    listCodemods: overrides.listCodemods ?? vi.fn(() => okAsync(codemods)),
+  });
+  const program = new Command()
+    .exitOverride()
+    .option("--output <mode>", "Output mode", "text")
+    .addCommand(command);
+
+  await program.parseAsync(["node", "dx", ...args]);
+};
+
+describe("makeCodemodCommand", () => {
+  beforeEach(() => {
+    vi.restoreAllMocks();
+    process.exitCode = undefined;
+  });
+
+  it("reports the codemod list through the json command presenter", async () => {
+    const stdout: string[] = [];
+    vi.spyOn(process.stdout, "write").mockImplementation((data: unknown) => {
+      stdout.push(String(data));
+      return true;
+    });
+
+    await runCodemodCommand(["--output", "json", "codemod", "list"]);
+
+    expect(JSON.parse(stdout.join(""))).toStrictEqual({
+      data: [
+        {
+          description: "Use pnpm",
+          id: "use-pnpm",
+        },
+      ],
+      ok: true,
+    });
+  });
+
+  it("reports the applied codemod through the json command presenter", async () => {
+    const stdout: string[] = [];
+    const stderr: string[] = [];
+    const applyCodemodById = vi.fn(() =>
+      ResultAsync.fromPromise(Promise.resolve(), () => new Error("failed")),
+    );
+    vi.spyOn(process.stdout, "write").mockImplementation((data: unknown) => {
+      stdout.push(String(data));
+      return true;
+    });
+    vi.spyOn(process.stderr, "write").mockImplementation((data: unknown) => {
+      stderr.push(String(data));
+      return true;
+    });
+
+    await runCodemodCommand(
+      ["--output", "json", "codemod", "apply", "use-pnpm"],
+      {
+        applyCodemodById,
+      },
+    );
+
+    expect(applyCodemodById).toHaveBeenCalledWith("use-pnpm");
+    expect(stderr.map((line) => JSON.parse(line))).toStrictEqual([
+      {
+        name: "Applying codemod use-pnpm...",
+        status: "start",
+        type: "step",
+      },
+      {
+        name: "Applying codemod use-pnpm...",
+        status: "success",
+        type: "step",
+      },
+    ]);
+    expect(JSON.parse(stdout.join(""))).toStrictEqual({
+      data: {
+        id: "use-pnpm",
+      },
+      ok: true,
+    });
+  });
+
+  it("reports list errors through the json command presenter", async () => {
+    const stdout: string[] = [];
+    vi.spyOn(process.stdout, "write").mockImplementation((data: unknown) => {
+      stdout.push(String(data));
+      return true;
+    });
+
+    await runCodemodCommand(["--output", "json", "codemod", "list"], {
+      listCodemods: vi.fn(() => errAsync(new Error("registry failed"))),
+    });
+
+    expect(process.exitCode).toBe(1);
+    expect(JSON.parse(stdout.join(""))).toStrictEqual({
+      error: "registry failed",
+      ok: false,
+    });
+  });
+});

--- a/apps/cli/src/adapters/commander/commands/codemod.ts
+++ b/apps/cli/src/adapters/commander/commands/codemod.ts
@@ -4,7 +4,7 @@ import { ResultAsync } from "neverthrow";
 import type { ApplyCodemodById } from "../../../use-cases/apply-codemod.js";
 import type { ListCodemods } from "../../../use-cases/list-codemods.js";
 
-import { reportCommandError, toError } from "../command-errors.js";
+import { asError, reportCommandError } from "../command-errors.js";
 import { GlobalOptions } from "../global-options.js";
 import { createCommandPresenter } from "../presenters/index.js";
 
@@ -28,7 +28,7 @@ export const makeCodemodCommand = ({
 
           await listCodemods()
             .andTee((codemods) => presenter.reportResult(codemods))
-            .orTee(reportCommandError(this, presenter, output));
+            .orTee(reportCommandError(this, presenter));
         }),
     )
     .addCommand(
@@ -48,10 +48,10 @@ export const makeCodemodCommand = ({
                 },
               ),
             ),
-            toError,
+            asError(`Failed to apply codemod ${id}`),
           )
             .map(() => ({ id }))
             .andTee((result) => presenter.reportResult(result))
-            .orTee(reportCommandError(this, presenter, output));
+            .orTee(reportCommandError(this, presenter));
         }),
     );

--- a/apps/cli/src/adapters/commander/commands/codemod.ts
+++ b/apps/cli/src/adapters/commander/commands/codemod.ts
@@ -1,36 +1,17 @@
 import { Command } from "commander";
 import { ResultAsync } from "neverthrow";
 
-import type { CommandPresenter } from "../../../domain/command-presenter.js";
 import type { ApplyCodemodById } from "../../../use-cases/apply-codemod.js";
 import type { ListCodemods } from "../../../use-cases/list-codemods.js";
-import type { GlobalOptions } from "../index.js";
 
-import { exitWithError } from "../command-errors.js";
+import { reportCommandError, toError } from "../command-errors.js";
+import { GlobalOptions } from "../global-options.js";
 import { createCommandPresenter } from "../presenters/index.js";
 
 export type CodemodCommandDependencies = {
   applyCodemodById: ApplyCodemodById;
   listCodemods: ListCodemods;
 };
-
-const reportCommandError =
-  (
-    command: Command,
-    presenter: CommandPresenter,
-    outputMode: "json" | "text",
-  ) =>
-  (error: Error) => {
-    if (outputMode === "json") {
-      presenter.reportError(error);
-      process.exitCode = 1;
-    } else {
-      exitWithError(command)(error);
-    }
-  };
-
-const toError = (error: unknown): Error =>
-  error instanceof Error ? error : new Error(String(error));
 
 export const makeCodemodCommand = ({
   applyCodemodById,

--- a/apps/cli/src/adapters/commander/commands/codemod.ts
+++ b/apps/cli/src/adapters/commander/commands/codemod.ts
@@ -1,14 +1,36 @@
-import { getLogger } from "@logtape/logtape";
 import { Command } from "commander";
+import { ResultAsync } from "neverthrow";
 
-import { ApplyCodemodById } from "../../../use-cases/apply-codemod.js";
-import { ListCodemods } from "../../../use-cases/list-codemods.js";
+import type { CommandPresenter } from "../../../domain/command-presenter.js";
+import type { ApplyCodemodById } from "../../../use-cases/apply-codemod.js";
+import type { ListCodemods } from "../../../use-cases/list-codemods.js";
+import type { GlobalOptions } from "../index.js";
+
 import { exitWithError } from "../command-errors.js";
+import { createCommandPresenter } from "../presenters/index.js";
 
 export type CodemodCommandDependencies = {
   applyCodemodById: ApplyCodemodById;
   listCodemods: ListCodemods;
 };
+
+const reportCommandError =
+  (
+    command: Command,
+    presenter: CommandPresenter,
+    outputMode: "json" | "text",
+  ) =>
+  (error: Error) => {
+    if (outputMode === "json") {
+      presenter.reportError(error);
+      process.exitCode = 1;
+    } else {
+      exitWithError(command)(error);
+    }
+  };
+
+const toError = (error: unknown): Error =>
+  error instanceof Error ? error : new Error(String(error));
 
 export const makeCodemodCommand = ({
   applyCodemodById,
@@ -20,11 +42,12 @@ export const makeCodemodCommand = ({
       new Command("list")
         .description("List available migration scripts")
         .action(async function () {
+          const { output } = this.optsWithGlobals<GlobalOptions>();
+          const presenter = createCommandPresenter(output);
+
           await listCodemods()
-            .andTee((codemods) =>
-              console.table(codemods, ["id", "description"]),
-            )
-            .orTee(exitWithError(this));
+            .andTee((codemods) => presenter.reportResult(codemods))
+            .orTee(reportCommandError(this, presenter, output));
         }),
     )
     .addCommand(
@@ -32,11 +55,22 @@ export const makeCodemodCommand = ({
         .argument("<id>", "The id of the codemod to apply")
         .description("Apply migration scripts to the repository")
         .action(async function (id) {
-          const logger = getLogger(["dx-cli", "codemod"]);
-          await applyCodemodById(id)
-            .andTee(() => {
-              logger.info("Codemod applied ✅");
-            })
-            .orTee(exitWithError(this));
+          const { output } = this.optsWithGlobals<GlobalOptions>();
+          const presenter = createCommandPresenter(output);
+
+          await ResultAsync.fromPromise(
+            presenter.trackStep(`Applying codemod ${id}...`, () =>
+              applyCodemodById(id).match(
+                () => undefined,
+                (error) => {
+                  throw error;
+                },
+              ),
+            ),
+            toError,
+          )
+            .map(() => ({ id }))
+            .andTee((result) => presenter.reportResult(result))
+            .orTee(reportCommandError(this, presenter, output));
         }),
     );

--- a/apps/cli/src/adapters/commander/commands/codemod.ts
+++ b/apps/cli/src/adapters/commander/commands/codemod.ts
@@ -28,7 +28,7 @@ export const makeCodemodCommand = ({
 
           await listCodemods()
             .andTee((codemods) => presenter.reportResult(codemods))
-            .orTee(reportCommandError(this, presenter));
+            .orTee(reportCommandError(this, presenter, output));
         }),
     )
     .addCommand(
@@ -52,6 +52,6 @@ export const makeCodemodCommand = ({
           )
             .map(() => ({ id }))
             .andTee((result) => presenter.reportResult(result))
-            .orTee(reportCommandError(this, presenter));
+            .orTee(reportCommandError(this, presenter, output));
         }),
     );

--- a/apps/cli/src/adapters/commander/commands/codemod.ts
+++ b/apps/cli/src/adapters/commander/commands/codemod.ts
@@ -27,6 +27,9 @@ export const makeCodemodCommand = ({
           const presenter = createCommandPresenter(output);
 
           await listCodemods()
+            .map((codemods) =>
+              codemods.map(({ description, id }) => ({ description, id })),
+            )
             .andTee((codemods) => presenter.reportResult(codemods))
             .orTee(reportCommandError(this, presenter, output));
         }),

--- a/apps/cli/src/adapters/commander/commands/init.ts
+++ b/apps/cli/src/adapters/commander/commands/init.ts
@@ -24,7 +24,7 @@ import {
   getPlopInstance,
   runMonorepoActions,
 } from "../../plop/index.js";
-import { reportCommandError } from "../command-errors.js";
+import { asError, reportCommandError } from "../command-errors.js";
 import { createCommandPresenter } from "../presenters/index.js";
 
 type GitHubRepoCreationSkippedResult = {
@@ -78,11 +78,6 @@ const withSpinner = <T>(
     }),
     (cause) => new Error(failText, { cause }),
   );
-
-const asError =
-  (message: string) =>
-  (cause: unknown): Error =>
-    new Error(message, { cause });
 
 const trackStep = <T, E>(
   presenter: CommandPresenter,
@@ -522,6 +517,6 @@ export const makeInitCommand = (
         )
         .match(
           reportSummary(presenter, output),
-          reportCommandError(this, presenter, output),
+          reportCommandError(this, presenter),
         );
     });

--- a/apps/cli/src/adapters/commander/commands/init.ts
+++ b/apps/cli/src/adapters/commander/commands/init.ts
@@ -517,6 +517,6 @@ export const makeInitCommand = (
         )
         .match(
           reportSummary(presenter, output),
-          reportCommandError(this, presenter),
+          reportCommandError(this, presenter, output),
         );
     });

--- a/apps/cli/src/adapters/commander/commands/init.ts
+++ b/apps/cli/src/adapters/commander/commands/init.ts
@@ -24,7 +24,7 @@ import {
   getPlopInstance,
   runMonorepoActions,
 } from "../../plop/index.js";
-import { exitWithError } from "../command-errors.js";
+import { reportCommandError } from "../command-errors.js";
 import { createCommandPresenter } from "../presenters/index.js";
 
 type GitHubRepoCreationSkippedResult = {
@@ -473,21 +473,6 @@ const reportSummary =
       presenter.reportResult(result);
     } else {
       displaySummary(result);
-    }
-  };
-
-const reportCommandError =
-  (
-    command: Command,
-    presenter: CommandPresenter,
-    outputMode: "json" | "text",
-  ) =>
-  (error: Error) => {
-    if (outputMode === "json") {
-      presenter.reportError(error);
-      process.exitCode = 1;
-    } else {
-      exitWithError(command)(error);
     }
   };
 

--- a/apps/cli/src/adapters/commander/presenters/__tests__/text.test.ts
+++ b/apps/cli/src/adapters/commander/presenters/__tests__/text.test.ts
@@ -57,6 +57,16 @@ describe("TextCommandPresenter", () => {
         logger.reportResult({ repository: { name: "my-repo" } }),
       ).not.toThrow();
     });
+
+    it("calls console.table for array data", () => {
+      const table = vi
+        .spyOn(console, "table")
+        .mockImplementation(() => undefined);
+      const logger = new TextCommandPresenter();
+      const data = [{ description: "Use pnpm", id: "use-pnpm" }];
+      logger.reportResult(data);
+      expect(table).toHaveBeenCalledWith(data);
+    });
   });
 
   describe("reportError", () => {

--- a/apps/cli/src/adapters/commander/presenters/text-command-presenter.ts
+++ b/apps/cli/src/adapters/commander/presenters/text-command-presenter.ts
@@ -18,7 +18,11 @@ export class TextCommandPresenter implements CommandPresenter {
   }
 
   reportResult<T>(data: T): void {
-    console.log(data);
+    if (Array.isArray(data)) {
+      console.table(data);
+    } else {
+      console.log(data);
+    }
   }
 
   async trackStep<T>(name: string, task: () => Promise<T>): Promise<T> {


### PR DESCRIPTION
Route `codemod list` and `codemod apply` through the shared command presenter so text and JSON modes use the common CLI output path. JSON mode now receives structured success envelopes, apply progress events, and presenter-formatted errors.

Resolves CES-2140