### PR TITLE
Pin init bootstrap to pnpm 10

### DIFF
--- a/.nx/version-plans/version-plan-1781253589487.md
+++ b/.nx/version-plans/version-plan-1781253589487.md
@@ -2,4 +2,4 @@
 '@pagopa/dx-cli': patch
 ---
 
-Fix dx init Nx bootstrap failure with pnpm 11
+Keep dx init on pnpm 10 during bootstrap

--- a/.nx/version-plans/version-plan-1781253589487.md
+++ b/.nx/version-plans/version-plan-1781253589487.md
@@ -1,0 +1,5 @@
+---
+'@pagopa/dx-cli': patch
+---
+
+Fix dx init Nx bootstrap failure with pnpm 11

--- a/apps/cli/src/adapters/plop/actions/setup-pnpm.ts
+++ b/apps/cli/src/adapters/plop/actions/setup-pnpm.ts
@@ -4,10 +4,12 @@ import path from "node:path";
 
 import { payloadSchema } from "../generators/monorepo/prompts.js";
 
+const pnpmBootstrapVersion = "10";
+
 export default function (plop: NodePlopAPI) {
   plop.setActionType("setupPnpm", async (data) => {
-    const payload = payloadSchema.parse(data);
-    const cwd = path.resolve(payload.repoName);
+    const { repoName } = payloadSchema.parse(data);
+    const cwd = path.resolve(repoName);
     // If this generator is started by a npm script, it will inherit some
     // config variables that will interfere with pnpm commands.
     // We filter them out here.
@@ -22,8 +24,9 @@ export default function (plop: NodePlopAPI) {
       env,
       extendEnv: false, // Don't include process.env variables
     });
-    await $`corepack enable`;
-    await $`corepack use pnpm@latest`;
+    // Keep the bootstrap on pnpm 10 so `nx init` works without the pnpm 11
+    // build-approval settings that would otherwise leak into the generated template.
+    await $`corepack use pnpm@${pnpmBootstrapVersion}`;
     await $`npx --yes nx@latest init --interactive=false --aiAgents=copilot`;
     await $`pnpm -w add -D @devcontainers/cli @nx/js @nx/eslint @nx/vitest`;
     await $`pnpm devcontainer templates apply -t ghcr.io/pagopa/devcontainer-templates/node:1`;

--- a/apps/cli/src/adapters/plop/generators/monorepo/__tests__/generation.test.ts
+++ b/apps/cli/src/adapters/plop/generators/monorepo/__tests__/generation.test.ts
@@ -99,15 +99,13 @@ describe("monorepo generator — file generation", () => {
     expect(generatedFiles).toMatchSnapshot();
   });
 
-  it("allows Nx postinstall scripts in the generated pnpm workspace", async () => {
+  it("does not add pnpm 11 build approval settings to the generated pnpm workspace", async () => {
     const generatedFiles = await readGeneratedFiles(
       path.join(tmpDir, payload.repoName),
       ["pnpm-workspace.yaml"],
     );
 
-    expect(generatedFiles["pnpm-workspace.yaml"]).toContain(
-      "allowBuilds:\n  nx: true",
-    );
+    expect(generatedFiles["pnpm-workspace.yaml"]).not.toContain("allowBuilds:");
   });
 
   it("applies the repository-specific gitignore customization", async () => {

--- a/apps/cli/src/adapters/plop/generators/monorepo/__tests__/generation.test.ts
+++ b/apps/cli/src/adapters/plop/generators/monorepo/__tests__/generation.test.ts
@@ -99,6 +99,17 @@ describe("monorepo generator — file generation", () => {
     expect(generatedFiles).toMatchSnapshot();
   });
 
+  it("allows Nx postinstall scripts in the generated pnpm workspace", async () => {
+    const generatedFiles = await readGeneratedFiles(
+      path.join(tmpDir, payload.repoName),
+      ["pnpm-workspace.yaml"],
+    );
+
+    expect(generatedFiles["pnpm-workspace.yaml"]).toContain(
+      "allowBuilds:\n  nx: true",
+    );
+  });
+
   it("applies the repository-specific gitignore customization", async () => {
     const generatedFiles = await readGeneratedFiles(
       path.join(tmpDir, payload.repoName),

--- a/apps/cli/templates/monorepo/pnpm-workspace.yaml
+++ b/apps/cli/templates/monorepo/pnpm-workspace.yaml
@@ -8,3 +8,6 @@ cleanupUnusedCatalogs: true
 
 onlyBuiltDependencies:
   - nx
+
+allowBuilds:
+  nx: true

--- a/apps/cli/templates/monorepo/pnpm-workspace.yaml
+++ b/apps/cli/templates/monorepo/pnpm-workspace.yaml
@@ -8,6 +8,3 @@ cleanupUnusedCatalogs: true
 
 onlyBuiltDependencies:
   - nx
-
-allowBuilds:
-  nx: true


### PR DESCRIPTION
Pin the init bootstrap flow to `pnpm@10` and add a regression test for the Corepack bootstrap command

`dx init` should stay on a pnpm 10 bootstrap path that works with the current Nx initialization flow and the existing pnpm workspace settings.

Resolves CES-2141