### PR TITLE
Remove tsconfig.lib.json from Dockerfile configuration copy

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,20 @@
+{
+  "version": "0.2.0",
+  "configurations": [
+    {
+      "name": "dx CLI",
+      "type": "node",
+      "request": "launch",
+      "program": "${workspaceFolder}/apps/cli/bin/index.js",
+      "args": ["--version"],
+      "cwd": "${workspaceFolder}",
+      "sourceMaps": true,
+      "outFiles": ["${workspaceFolder}/apps/cli/dist/**/*.js"],
+      "preLaunchTask": "build: dx-cli",
+      "console": "integratedTerminal",
+      "autoAttachChildProcesses": false,
+      "skipFiles": ["<node_internals>/**"],
+      "env": {}
+    }
+  ]
+}

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -1,0 +1,16 @@
+{
+  "version": "2.0.0",
+  "tasks": [
+    {
+      "label": "build: dx-cli",
+      "type": "shell",
+      "command": "pnpm nx build @pagopa/dx-cli",
+      "group": "build",
+      "presentation": {
+        "reveal": "silent",
+        "panel": "shared"
+      },
+      "problemMatcher": ["$tsc"]
+    }
+  ]
+}

--- a/apps/cli/src/adapters/commander/commands/info.ts
+++ b/apps/cli/src/adapters/commander/commands/info.ts
@@ -1,9 +1,9 @@
 import { Command } from "commander";
 
 import type { Dependencies } from "../../../domain/dependencies.js";
-import type { GlobalOptions } from "../index.js";
 
 import { getInfo } from "../../../domain/info.js";
+import { GlobalOptions } from "../global-options.js";
 import { createCommandPresenter } from "../presenters/index.js";
 
 export const makeInfoCommand = (dependencies: Dependencies): Command =>

--- a/apps/cli/tsconfig.lib.json
+++ b/apps/cli/tsconfig.lib.json
@@ -1,5 +1,9 @@
 {
   "extends": "./tsconfig.json",
   "include": ["./src/**/*.ts"],
-  "exclude": ["**/__tests__/**"]
+  "exclude": ["**/__tests__/**"],
+  "compilerOptions": {
+    "inlineSourceMap": true,
+    "inlineSources": true
+  }
 }

--- a/apps/mcpserver/Dockerfile
+++ b/apps/mcpserver/Dockerfile
@@ -6,7 +6,7 @@ RUN corepack enable
 WORKDIR /app
 
 # 3. Copy monorepo configuration files
-COPY ./pnpm-lock.yaml ./pnpm-workspace.yaml ./package.json ./nx.json ./tsconfig.json ./tsconfig.lib.json ./
+COPY ./pnpm-lock.yaml ./pnpm-workspace.yaml ./package.json ./nx.json ./tsconfig.json ./
 
 # 4. Copy source code for apps and packages
 COPY ./apps ./apps


### PR DESCRIPTION
Eliminate the inclusion of `tsconfig.lib.json` in the Dockerfile to streamline the configuration file copy process.