### PR TITLE
Remove tsconfig.lib.json from Dockerfile

### DIFF
--- a/apps/mcpserver/Dockerfile
+++ b/apps/mcpserver/Dockerfile
@@ -6,7 +6,7 @@ RUN corepack enable
 WORKDIR /app
 
 # 3. Copy monorepo configuration files
-COPY ./pnpm-lock.yaml ./pnpm-workspace.yaml ./package.json ./nx.json ./tsconfig.json ./tsconfig.lib.json ./
+COPY ./pnpm-lock.yaml ./pnpm-workspace.yaml ./package.json ./nx.json ./tsconfig.json ./
 
 # 4. Copy source code for apps and packages
 COPY ./apps ./apps


### PR DESCRIPTION
Eliminate the inclusion of `tsconfig.lib.json` in the Dockerfile configuration copy to streamline the build process.