### PR TITLE
Add coverage to .prettierignore for dx-metrics and dx-metrics-import

### DIFF
--- a/apps/dx-metrics-import/.prettierignore
+++ b/apps/dx-metrics-import/.prettierignore
@@ -1,1 +1,3 @@
 dist
+coverage
+

--- a/apps/dx-metrics/.prettierignore
+++ b/apps/dx-metrics/.prettierignore
@@ -1,2 +1,3 @@
 dist
+coverage
 CHANGELOG.md


### PR DESCRIPTION
Include coverage in the .prettierignore files for both dx-metrics and dx-metrics-import to prevent formatting issues with coverage files.