### PR TITLE
Remove baseUrl from tsconfig.json in opex-dashboard and website

### DIFF
--- a/apps/opex-dashboard/tsconfig.json
+++ b/apps/opex-dashboard/tsconfig.json
@@ -3,7 +3,6 @@
   "compilerOptions": {
     "declaration": true,
     "outDir": "./dist",
-    "baseUrl": ".",
     "paths": {
       "@/*": ["./src/*"]
     }

--- a/apps/website/tsconfig.json
+++ b/apps/website/tsconfig.json
@@ -2,7 +2,6 @@
   // This file is not used in compilation. It is here just for a nice editor experience.
   "extends": "@docusaurus/tsconfig",
   "compilerOptions": {
-    "baseUrl": ".",
     "jsx": "react-jsx",
     "types": ["react", "react-dom"],
     "paths": {


### PR DESCRIPTION
Eliminate the deprected baseUrl setting from the TypeScript configuration files in both the opex-dashboard and website applications.