### PR TITLE
Wire add environment command to CommandPresenter

### DIFF
--- a/.nx/version-plans/version-plan-1781527747749.md
+++ b/.nx/version-plans/version-plan-1781527747749.md
@@ -1,0 +1,5 @@
+---
+"@pagopa/dx-cli": patch
+---
+
+Route the `add environment` command output through the command presenter, unifying text and JSON output. Preconditions and scaffolding now emit progress as step events (NDJSON on stderr in JSON mode), and the final result is reported as a structured envelope in JSON mode while keeping the human-readable summary in text mode.

--- a/apps/cli/src/adapters/commander/commands/__tests__/add-json.test.ts
+++ b/apps/cli/src/adapters/commander/commands/__tests__/add-json.test.ts
@@ -1,0 +1,154 @@
+/**
+ * Tests for the `add environment` command JSON output contract.
+ *
+ * Verifies that the command routes progress and the final result through the
+ * shared CommandPresenter: step lifecycle events are emitted as NDJSON on
+ * stderr while the structured result envelope is written to stdout.
+ */
+import { Command } from "commander";
+import { okAsync } from "neverthrow";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { mockDeep } from "vitest-mock-extended";
+
+import type { AuthorizationService } from "../../../../domain/authorization.js";
+import type { GitHubAuthFactory } from "../../../../domain/dependencies.js";
+import type { GitHubService } from "../../../../domain/github.js";
+import type { Payload as EnvironmentPayload } from "../../../plop/generators/environment/index.js";
+
+const mocks = vi.hoisted(() => ({
+  collectDeploymentEnvironmentPayload: vi.fn(),
+  getPlopInstance: vi.fn(),
+  runDeploymentEnvironmentActions: vi.fn(),
+  tf$: vi.fn(async (...args: [TemplateStringsArray, ...unknown[]]) => {
+    void args;
+    return { stdout: '{"user":{"name":"test@example.com"}}' };
+  }),
+}));
+
+vi.mock("../../../plop/index.js", () => ({
+  collectDeploymentEnvironmentPayload:
+    mocks.collectDeploymentEnvironmentPayload,
+  getPlopInstance: mocks.getPlopInstance,
+  runDeploymentEnvironmentActions: mocks.runDeploymentEnvironmentActions,
+}));
+vi.mock("../../../execa/terraform.js", () => ({ tf$: mocks.tf$ }));
+
+import { makeAddCommand } from "../add.js";
+
+const payload: EnvironmentPayload = {
+  env: {
+    cloudAccounts: [
+      {
+        csp: "azure",
+        defaultLocation: "italynorth",
+        displayName: "DEV-FooBar",
+        id: "sub-123",
+      },
+    ],
+    name: "dev",
+    prefix: "dx",
+  },
+  github: { owner: "pagopa", repo: "test-repo" },
+  tags: { BusinessUnit: "BU", CostCenter: "TS000", ManagementTeam: "MT" },
+  workspace: { domain: "" },
+};
+
+const captureStream = (stream: NodeJS.WriteStream) => {
+  const written: string[] = [];
+  vi.spyOn(stream, "write").mockImplementation((data: unknown) => {
+    written.push(String(data));
+    return true;
+  });
+  return { written };
+};
+
+const parseNdjson = (written: string[]) =>
+  written
+    .join("")
+    .trim()
+    .split("\n")
+    .filter(Boolean)
+    .map((line) => JSON.parse(line));
+
+describe("add environment command json output", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mocks.getPlopInstance.mockResolvedValue({});
+    mocks.collectDeploymentEnvironmentPayload.mockResolvedValue({
+      generator: {},
+      payload,
+    });
+    mocks.runDeploymentEnvironmentActions.mockResolvedValue(payload);
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("emits progress events and the final result through the json presenter", async () => {
+    const stdout = captureStream(process.stdout);
+    const stderr = captureStream(process.stderr);
+    const requireGitHubAuth: GitHubAuthFactory = () =>
+      okAsync({
+        authorizationService: mockDeep<AuthorizationService>(),
+        gitHubService: mockDeep<GitHubService>(),
+      });
+
+    const program = new Command()
+      .option("--output <mode>", "Output mode", "json")
+      .addCommand(makeAddCommand(requireGitHubAuth));
+
+    await program.parseAsync([
+      "node",
+      "dx",
+      "--output",
+      "json",
+      "add",
+      "environment",
+    ]);
+
+    expect(parseNdjson(stderr.written)).toEqual([
+      {
+        name: "Checking Terraform installation...",
+        status: "start",
+        type: "step",
+      },
+      {
+        name: "Checking Terraform installation...",
+        status: "success",
+        type: "step",
+      },
+      { name: "Checking Azure login status...", status: "start", type: "step" },
+      {
+        name: "Checking Azure login status...",
+        status: "success",
+        type: "step",
+      },
+      {
+        name: "Checking Corepack installation...",
+        status: "start",
+        type: "step",
+      },
+      {
+        name: "Checking Corepack installation...",
+        status: "success",
+        type: "step",
+      },
+      {
+        name: "Initializing environment generator...",
+        status: "start",
+        type: "step",
+      },
+      {
+        name: "Initializing environment generator...",
+        status: "success",
+        type: "step",
+      },
+      { name: "Creating environment...", status: "start", type: "step" },
+      { name: "Creating environment...", status: "success", type: "step" },
+    ]);
+    expect(parseNdjson(stdout.written)).toEqual([
+      { data: { authorizationPrs: [] }, ok: true },
+    ]);
+  });
+});

--- a/apps/cli/src/adapters/commander/commands/__tests__/preconditions.test.ts
+++ b/apps/cli/src/adapters/commander/commands/__tests__/preconditions.test.ts
@@ -1,20 +1,28 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
+import type { CommandPresenter } from "../../../../domain/command-presenter.js";
+
 const mocks = vi.hoisted(() => ({
-  oraPromise: vi.fn((promise: Promise<unknown>) => promise),
   tf$: vi.fn(async (...args: [TemplateStringsArray, ...unknown[]]) => {
     void args;
     return { stdout: '{"user":{"name":"test@example.com"}}' };
   }),
 }));
 
-vi.mock("ora", () => ({ oraPromise: mocks.oraPromise }));
 vi.mock("../../../execa/terraform.js", () => ({ tf$: mocks.tf$ }));
 
 import {
-  checkAddEnvironmentPreconditions,
-  checkInitPreconditions,
+  runAddEnvironmentPreconditions,
+  runInitPreconditions,
 } from "../init.js";
+
+// A pass-through presenter runs each tracked step without rendering output, so
+// the tests focus on the underlying CLI command sequence.
+const presenter: CommandPresenter = {
+  reportError: () => undefined,
+  reportResult: () => undefined,
+  trackStep: <T>(_name: string, task: () => Promise<T>): Promise<T> => task(),
+};
 
 const calledCommands = () =>
   mocks.tf$.mock.calls.map(([strings, ...values]) =>
@@ -29,15 +37,15 @@ describe("init preconditions", () => {
     vi.clearAllMocks();
   });
 
-  it("checkInitPreconditions does not require Azure login", async () => {
-    const result = await checkInitPreconditions();
+  it("runInitPreconditions does not require Azure login", async () => {
+    const result = await runInitPreconditions(presenter);
 
     expect(result.isOk()).toBe(true);
     expect(calledCommands()).toEqual(["terraform -version", "corepack -v"]);
   });
 
-  it("checkAddEnvironmentPreconditions requires Azure login", async () => {
-    const result = await checkAddEnvironmentPreconditions();
+  it("runAddEnvironmentPreconditions requires Azure login", async () => {
+    const result = await runAddEnvironmentPreconditions(presenter);
 
     expect(result.isOk()).toBe(true);
     expect(calledCommands()).toEqual([

--- a/apps/cli/src/adapters/commander/commands/add.ts
+++ b/apps/cli/src/adapters/commander/commands/add.ts
@@ -12,7 +12,9 @@ import chalk from "chalk";
 import { Command } from "commander";
 import { okAsync, ResultAsync } from "neverthrow";
 
+import type { CommandPresenter } from "../../../domain/command-presenter.js";
 import type { Payload as EnvironmentPayload } from "../../plop/generators/environment/index.js";
+import type { GlobalOptions } from "../global-options.js";
 
 import {
   AuthorizationResult,
@@ -24,11 +26,13 @@ import { environmentShort } from "../../../domain/environment.js";
 import { type GitHubService } from "../../../domain/github.js";
 import { isAzureLocation, locationShort } from "../../azure/locations.js";
 import {
+  collectDeploymentEnvironmentPayload,
   getPlopInstance,
-  runDeploymentEnvironmentGenerator,
+  runDeploymentEnvironmentActions,
 } from "../../plop/index.js";
-import { exitWithError } from "../command-errors.js";
-import { checkAddEnvironmentPreconditions } from "./init.js";
+import { asError, reportCommandError } from "../command-errors.js";
+import { createCommandPresenter } from "../presenters/index.js";
+import { runAddEnvironmentPreconditions } from "./init.js";
 
 /**
  * Authorize a Cloud Account (Azure Subscription, AWS Account, ...), creating a Pull Request for each account that requires authorization.
@@ -123,24 +127,56 @@ const displaySummary = (result: AddResult) => {
   );
 };
 
+/**
+ * Routes the successful outcome through the presenter: JSON mode emits the
+ * structured envelope while text mode renders the human-readable summary.
+ */
+const reportSummary =
+  (presenter: CommandPresenter, outputMode: "json" | "text") =>
+  (result: AddResult): void => {
+    if (outputMode === "json") {
+      presenter.reportResult(result);
+    } else {
+      displaySummary(result);
+    }
+  };
+
+const trackStep = <T, E>(
+  presenter: CommandPresenter,
+  name: string,
+  task: () => Promise<T>,
+  mapError: (cause: unknown) => E,
+): ResultAsync<T, E> =>
+  ResultAsync.fromPromise(presenter.trackStep(name, task), mapError);
+
 const addEnvironmentAction = (
   authorizationService: AuthorizationService,
   gitHubService: GitHubService,
+  presenter: CommandPresenter,
 ): ResultAsync<AddResult, Error> =>
-  checkAddEnvironmentPreconditions()
+  runAddEnvironmentPreconditions(presenter)
     .andThen(() =>
-      ResultAsync.fromPromise(
-        getPlopInstance(),
-        (cause) => new Error("Failed to initialize plop", { cause }),
+      trackStep(
+        presenter,
+        "Initializing environment generator...",
+        getPlopInstance,
+        asError("Failed to initialize plop"),
       ),
     )
     .andThen((plop) =>
+      // The prompt phase must run outside trackStep: in text mode trackStep
+      // renders a spinner that occupies the TTY and hides the prompts.
       ResultAsync.fromPromise(
-        runDeploymentEnvironmentGenerator(plop, gitHubService),
-        (cause) =>
-          new Error("Failed to run the deployment environment generator", {
-            cause,
-          }),
+        collectDeploymentEnvironmentPayload(plop, gitHubService),
+        asError("Failed to run the deployment environment generator"),
+      ),
+    )
+    .andThen(({ generator, payload }) =>
+      trackStep(
+        presenter,
+        "Creating environment...",
+        () => runDeploymentEnvironmentActions(generator, payload),
+        asError("Failed to create the deployment environment"),
       ),
     )
     .andThen((payload) =>
@@ -159,10 +195,20 @@ export const makeAddCommand = (requireGitHubAuth: GitHubAuthFactory): Command =>
       new Command("environment")
         .description("Add a new deployment environment")
         .action(async function () {
+          const { output } = this.optsWithGlobals<GlobalOptions>();
+          const presenter = createCommandPresenter(output);
+
           await requireGitHubAuth()
             .andThen(({ authorizationService, gitHubService }) =>
-              addEnvironmentAction(authorizationService, gitHubService),
+              addEnvironmentAction(
+                authorizationService,
+                gitHubService,
+                presenter,
+              ),
             )
-            .match(displaySummary, exitWithError(this));
+            .match(
+              reportSummary(presenter, output),
+              reportCommandError(this, presenter, output),
+            );
         }),
     );

--- a/apps/cli/src/adapters/commander/commands/init.ts
+++ b/apps/cli/src/adapters/commander/commands/init.ts
@@ -5,7 +5,6 @@ import { $, ExecaError } from "execa";
 import inquirer from "inquirer";
 import { errAsync, okAsync, ResultAsync } from "neverthrow";
 import * as path from "node:path";
-import { oraPromise } from "ora";
 import { z } from "zod/v4";
 
 import type { CommandPresenter } from "../../../domain/command-presenter.js";
@@ -63,21 +62,6 @@ type RepositoryPullRequest = {
   pr?: PullRequest;
   repository: Repository;
 };
-
-const withSpinner = <T>(
-  text: string,
-  successText: ((value: T) => string) | string,
-  failText: string,
-  task: () => Promise<T>,
-): ResultAsync<T, Error> =>
-  ResultAsync.fromPromise(
-    oraPromise(task(), {
-      failText,
-      successText,
-      text,
-    }),
-    (cause) => new Error(failText, { cause }),
-  );
 
 const trackStep = <T, E>(
   presenter: CommandPresenter,
@@ -151,14 +135,6 @@ const displaySummary = (input: SummaryInput) => {
 
 const checkTerraformCli = () => tf$`terraform -version`;
 
-const checkTerraformCliIsInstalled = () =>
-  withSpinner(
-    "Checking Terraform installation...",
-    "Terraform is installed!",
-    "Please install terraform CLI before running this command. If you use tfenv, run: tfenv install latest && tfenv use latest",
-    checkTerraformCli,
-  );
-
 const trackTerraformCliIsInstalled = (presenter: CommandPresenter) =>
   trackStep(
     presenter,
@@ -170,14 +146,6 @@ const trackTerraformCliIsInstalled = (presenter: CommandPresenter) =>
   );
 
 const checkCorepack = () => tf$`corepack -v`;
-
-const checkCorepackIsInstalled = () =>
-  withSpinner(
-    "Checking Corepack installation...",
-    "Corepack is installed!",
-    "Please install Corepack before running this command.",
-    checkCorepack,
-  );
 
 const trackCorepackIsInstalled = (presenter: CommandPresenter) =>
   trackStep(
@@ -203,27 +171,27 @@ const ensureAzLogin = async (): Promise<string> => {
   return user.name;
 };
 
-const checkAzLogin = () =>
-  withSpinner(
-    "Check Azure login status...",
-    (userName) => `You are logged in to Azure (${userName})`,
-    "Please log in to Azure CLI using `az login` before running this command.",
+const trackAzLogin = (presenter: CommandPresenter) =>
+  trackStep(
+    presenter,
+    "Checking Azure login status...",
     ensureAzLogin,
+    asError(
+      "Please log in to Azure CLI using `az login` before running this command.",
+    ),
   );
 
-const runInitPreconditions = (presenter: CommandPresenter) =>
+// TODO(CES-1810): Make these checks concurrent to speed up the preconditions check phase
+export const runInitPreconditions = (presenter: CommandPresenter) =>
   trackTerraformCliIsInstalled(presenter).andThen(() =>
     trackCorepackIsInstalled(presenter),
   );
 
 // TODO(CES-1810): Make these checks concurrent to speed up the preconditions check phase
-export const checkInitPreconditions = () =>
-  checkTerraformCliIsInstalled().andThen(() => checkCorepackIsInstalled());
-
-export const checkAddEnvironmentPreconditions = () =>
-  checkTerraformCliIsInstalled()
-    .andThen(() => checkAzLogin())
-    .andThen(() => checkCorepackIsInstalled());
+export const runAddEnvironmentPreconditions = (presenter: CommandPresenter) =>
+  trackTerraformCliIsInstalled(presenter)
+    .andThen(() => trackAzLogin(presenter))
+    .andThen(() => trackCorepackIsInstalled(presenter));
 
 const DEFAULT_GITHUB_PUBLISH_CONFIRMATION = true;
 

--- a/apps/cli/src/adapters/plop/index.ts
+++ b/apps/cli/src/adapters/plop/index.ts
@@ -5,7 +5,6 @@ import { getLogger } from "@logtape/logtape";
 import { Answers } from "inquirer";
 import nodePlop from "node-plop";
 import { Octokit } from "octokit";
-import { oraPromise } from "ora";
 
 import { GitHubRepo } from "../../domain/github-repo.js";
 import { GitHubService, RepositoryNotFoundError } from "../../domain/github.js";
@@ -134,27 +133,43 @@ export const runMonorepoActions = async (
 };
 
 /**
- * Run the deployment environment generator
+ * Collect the deployment environment payload by running the generator's
+ * interactive prompts.
+ *
+ * Like {@link collectMonorepoPayload}, this phase MUST run outside any spinner:
+ * a spinner (e.g. ora) occupies the TTY and prevents the inquirer prompts from
+ * being rendered. Callers should track only the subsequent
+ * {@link runDeploymentEnvironmentActions} phase, which is non-interactive.
  *
  * @param plop - The plop instance
  * @param github - Optional GitHub repository info. When provided (by init command),
  *                 uses the explicitly passed repository. When omitted (by add command),
  *                 the generator infers it from the local git context.
  */
-export const runDeploymentEnvironmentGenerator = async (
+export const collectDeploymentEnvironmentPayload = async (
   plop: NodePlopAPI,
   gitHubService: GitHubService,
   github?: GitHubRepo,
-): Promise<EnvironmentPayload> => {
+): Promise<{ generator: PlopGenerator; payload: EnvironmentPayload }> => {
   setDeploymentEnvironmentGenerator(plop, gitHubService, github);
   const generator = plop.getGenerator(PLOP_ENVIRONMENT_GENERATOR_NAME);
   const answers = await generator.runPrompts();
   const payload = environmentPayloadSchema.parse(answers);
-  await oraPromise(runActions(generator, payload), {
-    failText: "Failed to create deployment environment",
-    successText: "Environment created successfully!",
-    text: "Creating environment...",
-  });
+  return { generator, payload };
+};
+
+/**
+ * Execute the deployment environment generator actions for an already-collected
+ * payload.
+ *
+ * This phase is non-interactive, so callers are free to wrap it in a spinner or
+ * other progress indicator.
+ */
+export const runDeploymentEnvironmentActions = async (
+  generator: PlopGenerator,
+  payload: EnvironmentPayload,
+): Promise<EnvironmentPayload> => {
+  await runActions(generator, payload);
   return payload;
 };
 


### PR DESCRIPTION
Route the add environment command output through the shared CommandPresenter so both text and JSON output modes are supported.

Closes CES-2151