### PR TITLE
Add flags for add environment

### DIFF
--- a/.nx/version-plans/version-plan-1781532388837.md
+++ b/.nx/version-plans/version-plan-1781532388837.md
@@ -1,0 +1,5 @@
+---
+'@pagopa/dx-cli': patch
+---
+
+Add flags for dx add environment.

--- a/apps/cli/src/adapters/commander/commands/__tests__/add-command.test.ts
+++ b/apps/cli/src/adapters/commander/commands/__tests__/add-command.test.ts
@@ -39,7 +39,11 @@ vi.mock("../../../plop/index.js", () => ({
 }));
 vi.mock("../../../execa/terraform.js", () => ({ tf$: mocks.tf$ }));
 
-import { makeAddCommand, parseAddEnvironmentCommandOptions } from "../add.js";
+import {
+  getEnvironmentInitialAnswers,
+  makeAddCommand,
+  parseAddEnvironmentCommandOptions,
+} from "../add.js";
 
 const payload: EnvironmentPayload = {
   env: {
@@ -237,6 +241,23 @@ describe("makeAddCommand", () => {
           },
         },
       );
+    } finally {
+      await rm(tempDir, { force: true, recursive: true });
+    }
+  });
+
+  it("rejects an empty private key file", async () => {
+    const tempDir = await mkdtemp(path.join(tmpdir(), "dx-cli-add-command-"));
+    const privateKeyPath = path.join(tempDir, "runner-app.pem");
+
+    await writeFile(privateKeyPath, "   \n");
+
+    try {
+      await expect(
+        getEnvironmentInitialAnswers(
+          parseAddEnvironmentCommandOptions({ privateKeyPath }),
+        ),
+      ).rejects.toThrow(/Private key file at .* is empty\./);
     } finally {
       await rm(tempDir, { force: true, recursive: true });
     }

--- a/apps/cli/src/adapters/commander/commands/__tests__/add-command.test.ts
+++ b/apps/cli/src/adapters/commander/commands/__tests__/add-command.test.ts
@@ -7,6 +7,9 @@
 
 import { Command } from "commander";
 import { okAsync } from "neverthrow";
+import { mkdtemp, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import * as path from "node:path";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { mock } from "vitest-mock-extended";
 
@@ -119,6 +122,7 @@ describe("makeAddCommand", () => {
 
     expect(flags).toEqual(
       expect.arrayContaining([
+        "-y, --yes",
         "--name <name>",
         "--account <subscription-id>",
         "--location <subscription-id=region>",
@@ -126,6 +130,10 @@ describe("makeAddCommand", () => {
         "--domain <domain>",
         "--business-unit <business-unit>",
         "--management-team <management-team>",
+        "--runner-app-id <runner-app-id>",
+        "--client-id <client-id>",
+        "--installation-id <installation-id>",
+        "--private-key-path <private-key-path>",
       ]),
     );
   });
@@ -185,6 +193,51 @@ describe("makeAddCommand", () => {
       expect.anything(),
       payload,
     );
+  });
+
+  it("passes provided initialization flags to the deployment environment generator as prefilled answers", async () => {
+    const program = makeProgram();
+    const tempDir = await mkdtemp(path.join(tmpdir(), "dx-cli-add-command-"));
+    const privateKeyPath = path.join(tempDir, "runner-app.pem");
+
+    await writeFile(privateKeyPath, "private-key-from-file\n");
+
+    try {
+      await program.parseAsync([
+        "node",
+        "dx",
+        "add",
+        "environment",
+        "--yes",
+        "--runner-app-id",
+        "app-id",
+        "--client-id",
+        "app-client-id",
+        "--installation-id",
+        "installation-id",
+        "--private-key-path",
+        privateKeyPath,
+      ]);
+
+      expect(mocks.collectDeploymentEnvironmentPayload).toHaveBeenCalledWith(
+        expect.anything(),
+        expect.anything(),
+        undefined,
+        {
+          init: {
+            confirm: true,
+            runnerAppCredentials: {
+              clientId: "app-client-id",
+              id: "app-id",
+              installationId: "installation-id",
+              key: "private-key-from-file\n",
+            },
+          },
+        },
+      );
+    } finally {
+      await rm(tempDir, { force: true, recursive: true });
+    }
   });
 
   it("rejects malformed location mappings with a validation error", async () => {

--- a/apps/cli/src/adapters/commander/commands/__tests__/add-command.test.ts
+++ b/apps/cli/src/adapters/commander/commands/__tests__/add-command.test.ts
@@ -81,7 +81,7 @@ const makeProgram = () => {
       gitHubService: mock<GitHubService>(),
     });
 
-  const addCommand = makeAddCommand(requireGitHubAuth);
+  const addCommand = makeAddCommand(requireGitHubAuth, { CI: false });
   addCommand.exitOverride().configureOutput(silentOutput);
 
   return new Command()
@@ -112,7 +112,9 @@ describe("makeAddCommand", () => {
         authorizationService: mock<AuthorizationService>(),
         gitHubService: mock<GitHubService>(),
       });
-    const environmentCommand = makeAddCommand(requireGitHubAuth).commands[0];
+    const environmentCommand = makeAddCommand(requireGitHubAuth, {
+      CI: false,
+    }).commands[0];
 
     const flags =
       environmentCommand?.options.flatMap((option) => [

--- a/apps/cli/src/adapters/commander/commands/__tests__/add-command.test.ts
+++ b/apps/cli/src/adapters/commander/commands/__tests__/add-command.test.ts
@@ -16,8 +16,9 @@ import type { GitHubService } from "../../../../domain/github.js";
 import type { Payload as EnvironmentPayload } from "../../../plop/generators/environment/index.js";
 
 const mocks = vi.hoisted(() => ({
+  collectDeploymentEnvironmentPayload: vi.fn(),
   getPlopInstance: vi.fn(),
-  runDeploymentEnvironmentGenerator: vi.fn(),
+  runDeploymentEnvironmentActions: vi.fn(),
   tf$: vi.fn(async (...args: [TemplateStringsArray, ...unknown[]]) => {
     void args;
     return { stdout: '{"user":{"name":"test@example.com"}}' };
@@ -28,8 +29,10 @@ vi.mock("ora", () => ({
   oraPromise: <T>(promise: Promise<T>) => promise,
 }));
 vi.mock("../../../plop/index.js", () => ({
+  collectDeploymentEnvironmentPayload:
+    mocks.collectDeploymentEnvironmentPayload,
   getPlopInstance: mocks.getPlopInstance,
-  runDeploymentEnvironmentGenerator: mocks.runDeploymentEnvironmentGenerator,
+  runDeploymentEnvironmentActions: mocks.runDeploymentEnvironmentActions,
 }));
 vi.mock("../../../execa/terraform.js", () => ({ tf$: mocks.tf$ }));
 
@@ -88,7 +91,11 @@ describe("makeAddCommand", () => {
   beforeEach(() => {
     vi.clearAllMocks();
     mocks.getPlopInstance.mockResolvedValue({});
-    mocks.runDeploymentEnvironmentGenerator.mockResolvedValue(payload);
+    mocks.collectDeploymentEnvironmentPayload.mockResolvedValue({
+      generator: {},
+      payload,
+    });
+    mocks.runDeploymentEnvironmentActions.mockResolvedValue(payload);
     vi.spyOn(console, "log").mockImplementation(() => undefined);
   });
 
@@ -151,7 +158,7 @@ describe("makeAddCommand", () => {
       "Engineering",
     ]);
 
-    expect(mocks.runDeploymentEnvironmentGenerator).toHaveBeenCalledWith(
+    expect(mocks.collectDeploymentEnvironmentPayload).toHaveBeenCalledWith(
       expect.anything(),
       expect.anything(),
       undefined,
@@ -173,6 +180,10 @@ describe("makeAddCommand", () => {
           domain: "payments",
         },
       },
+    );
+    expect(mocks.runDeploymentEnvironmentActions).toHaveBeenCalledWith(
+      expect.anything(),
+      payload,
     );
   });
 

--- a/apps/cli/src/adapters/commander/commands/__tests__/add-command.test.ts
+++ b/apps/cli/src/adapters/commander/commands/__tests__/add-command.test.ts
@@ -1,0 +1,187 @@
+/**
+ * Tests for the `add environment` Commander command flags.
+ *
+ * Covers the user-facing CLI contract for CES-2134: flag registration,
+ * validation, and passing prefilled answers into the environment generator.
+ */
+
+import { Command } from "commander";
+import { okAsync } from "neverthrow";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { mock } from "vitest-mock-extended";
+
+import type { AuthorizationService } from "../../../../domain/authorization.js";
+import type { GitHubAuthFactory } from "../../../../domain/dependencies.js";
+import type { GitHubService } from "../../../../domain/github.js";
+import type { Payload as EnvironmentPayload } from "../../../plop/generators/environment/index.js";
+
+const mocks = vi.hoisted(() => ({
+  getPlopInstance: vi.fn(),
+  runDeploymentEnvironmentGenerator: vi.fn(),
+  tf$: vi.fn(async (...args: [TemplateStringsArray, ...unknown[]]) => {
+    void args;
+    return { stdout: '{"user":{"name":"test@example.com"}}' };
+  }),
+}));
+
+vi.mock("ora", () => ({
+  oraPromise: <T>(promise: Promise<T>) => promise,
+}));
+vi.mock("../../../plop/index.js", () => ({
+  getPlopInstance: mocks.getPlopInstance,
+  runDeploymentEnvironmentGenerator: mocks.runDeploymentEnvironmentGenerator,
+}));
+vi.mock("../../../execa/terraform.js", () => ({ tf$: mocks.tf$ }));
+
+import { makeAddCommand, parseAddEnvironmentCommandOptions } from "../add.js";
+
+const payload: EnvironmentPayload = {
+  env: {
+    cloudAccounts: [
+      {
+        csp: "azure",
+        defaultLocation: "italynorth",
+        displayName: "DEV-FooBar",
+        id: "sub-123",
+      },
+    ],
+    name: "dev",
+    prefix: "dx",
+  },
+  github: { owner: "pagopa", repo: "dx" },
+  tags: {
+    BusinessUnit: "Platform",
+    CostCenter: "TS000",
+    ManagementTeam: "Engineering",
+  },
+  workspace: {
+    domain: "payments",
+  },
+};
+
+const silentOutput = {
+  writeErr: () => {
+    /* silence stderr in tests */
+  },
+  writeOut: () => {
+    /* silence stdout in tests */
+  },
+};
+
+const makeProgram = () => {
+  const requireGitHubAuth: GitHubAuthFactory = () =>
+    okAsync({
+      authorizationService: mock<AuthorizationService>(),
+      gitHubService: mock<GitHubService>(),
+    });
+
+  const addCommand = makeAddCommand(requireGitHubAuth);
+  addCommand.exitOverride().configureOutput(silentOutput);
+
+  return new Command()
+    .exitOverride()
+    .addCommand(addCommand)
+    .configureOutput(silentOutput);
+};
+
+describe("makeAddCommand", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mocks.getPlopInstance.mockResolvedValue({});
+    mocks.runDeploymentEnvironmentGenerator.mockResolvedValue(payload);
+    vi.spyOn(console, "log").mockImplementation(() => undefined);
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("registers flags for the agreed add environment inputs", () => {
+    const requireGitHubAuth: GitHubAuthFactory = () =>
+      okAsync({
+        authorizationService: mock<AuthorizationService>(),
+        gitHubService: mock<GitHubService>(),
+      });
+    const environmentCommand = makeAddCommand(requireGitHubAuth).commands[0];
+
+    const flags =
+      environmentCommand?.options.flatMap((option) => [
+        option.flags,
+        option.long,
+      ]) ?? [];
+
+    expect(flags).toEqual(
+      expect.arrayContaining([
+        "--name <name>",
+        "--account <subscription-id>",
+        "--location <subscription-id=region>",
+        "--prefix <prefix>",
+        "--domain <domain>",
+        "--business-unit <business-unit>",
+        "--management-team <management-team>",
+      ]),
+    );
+  });
+
+  it("passes provided flags to the deployment environment generator as prefilled answers", async () => {
+    const program = makeProgram();
+
+    await program.parseAsync([
+      "node",
+      "dx",
+      "add",
+      "environment",
+      "--name",
+      "dev",
+      "--account",
+      "sub-123",
+      "--account",
+      "sub-456",
+      "--location",
+      "sub-123=italynorth",
+      "--location",
+      "sub-456=westeurope",
+      "--prefix",
+      "dx",
+      "--domain",
+      "payments",
+      "--business-unit",
+      "Platform",
+      "--management-team",
+      "Engineering",
+    ]);
+
+    expect(mocks.runDeploymentEnvironmentGenerator).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.anything(),
+      undefined,
+      {
+        env: {
+          cloudAccountIds: ["sub-123", "sub-456"],
+          locations: {
+            "sub-123": "italynorth",
+            "sub-456": "westeurope",
+          },
+          name: "dev",
+          prefix: "dx",
+        },
+        tags: {
+          BusinessUnit: "Platform",
+          ManagementTeam: "Engineering",
+        },
+        workspace: {
+          domain: "payments",
+        },
+      },
+    );
+  });
+
+  it("rejects malformed location mappings with a validation error", async () => {
+    expect(() =>
+      parseAddEnvironmentCommandOptions({
+        account: ["sub-123"],
+        location: ["sub-123"],
+      }),
+    ).toThrow(/Invalid add environment command options/);
+  });
+});

--- a/apps/cli/src/adapters/commander/commands/add.ts
+++ b/apps/cli/src/adapters/commander/commands/add.ts
@@ -208,6 +208,20 @@ export const getEnvironmentInitialAnswers = async (
           );
         });
 
+  // Fail fast on an empty (or whitespace-only) key file: the file contents are
+  // never trimmed, so an empty value would otherwise skip the recovery prompt
+  // and surface as an opaque schema error (or a silently invalid key) later.
+  if (privateKey !== undefined && privateKey.trim().length === 0) {
+    throw new Error(
+      `Private key file at "${options.privateKeyPath}" is empty.`,
+    );
+  }
+
+  // Prefill runner-app credentials only when at least one credential flag was
+  // provided. Unspecified fields stay `undefined` on purpose so the generator
+  // prompts for the missing pieces and validates the complete set later. With
+  // no credential flag at all, leave this `undefined` to keep initialization
+  // fully interactive.
   const runnerAppCredentials =
     options.runnerAppId === undefined &&
     options.clientId === undefined &&

--- a/apps/cli/src/adapters/commander/commands/add.ts
+++ b/apps/cli/src/adapters/commander/commands/add.ts
@@ -10,6 +10,7 @@ import chalk from "chalk";
  */
 import { Command, Option } from "commander";
 import { okAsync, ResultAsync } from "neverthrow";
+import { readFile } from "node:fs/promises";
 import { z } from "zod/v4";
 
 import type { CommandPresenter } from "../../../domain/command-presenter.js";
@@ -91,7 +92,13 @@ const addEnvironmentCommandOptionsSchema = z
       .trim()
       .min(1, "Business unit cannot be empty")
       .optional(),
+    clientId: z.string().trim().min(1, "Client id cannot be empty").optional(),
     domain: workspaceSchema.shape.domain.optional(),
+    installationId: z
+      .string()
+      .trim()
+      .min(1, "Installation id cannot be empty")
+      .optional(),
     location: z.array(locationOptionSchema).optional(),
     managementTeam: z
       .string()
@@ -100,6 +107,17 @@ const addEnvironmentCommandOptionsSchema = z
       .optional(),
     name: environmentSchema.shape.name.optional(),
     prefix: environmentSchema.shape.prefix.optional(),
+    privateKeyPath: z
+      .string()
+      .trim()
+      .min(1, "Private key path cannot be empty")
+      .optional(),
+    runnerAppId: z
+      .string()
+      .trim()
+      .min(1, "Runner app id cannot be empty")
+      .optional(),
+    yes: z.boolean().optional(),
   })
   .superRefine((value, ctx) => {
     if (value.location && !value.account?.length) {
@@ -145,7 +163,7 @@ export const parseAddEnvironmentCommandOptions = (
   return result.data;
 };
 
-export const getEnvironmentInitialAnswers = (
+const buildBaseEnvironmentInitialAnswers = (
   options: AddEnvironmentCommandOptions,
 ): DeploymentEnvironmentInitialAnswers => {
   const initialAnswers: DeploymentEnvironmentInitialAnswers = {};
@@ -213,6 +231,54 @@ export const getEnvironmentInitialAnswers = (
   if (options.domain) {
     initialAnswers.workspace = {
       domain: options.domain,
+    };
+  }
+
+  return initialAnswers;
+};
+
+export const getEnvironmentInitialAnswers = async (
+  options: AddEnvironmentCommandOptions,
+): Promise<DeploymentEnvironmentInitialAnswers> => {
+  const initialAnswers = buildBaseEnvironmentInitialAnswers(options);
+  const privateKey =
+    options.privateKeyPath === undefined
+      ? undefined
+      : await readFile(options.privateKeyPath, "utf8").catch((cause) => {
+          throw new Error(
+            `Failed to read private key file at "${options.privateKeyPath}".`,
+            { cause },
+          );
+        });
+
+  const runnerAppCredentials =
+    options.runnerAppId === undefined &&
+    options.clientId === undefined &&
+    options.installationId === undefined &&
+    privateKey === undefined
+      ? undefined
+      : {
+          clientId: options.clientId,
+          id: options.runnerAppId,
+          installationId: options.installationId,
+          key: privateKey,
+        };
+
+  if (options.yes || runnerAppCredentials) {
+    initialAnswers.init = {};
+  }
+
+  if (options.yes) {
+    initialAnswers.init = {
+      ...initialAnswers.init,
+      confirm: true,
+    };
+  }
+
+  if (runnerAppCredentials) {
+    initialAnswers.init = {
+      ...initialAnswers.init,
+      runnerAppCredentials,
     };
   }
 
@@ -421,6 +487,30 @@ export const makeAddCommand = (
             "Management team tag",
           ),
         )
+        .addOption(
+          new Option(
+            "-y, --yes",
+            "Confirm environment initialization without prompting",
+          ),
+        )
+        .addOption(
+          new Option("--runner-app-id <runner-app-id>", "GitHub Runner App ID"),
+        )
+        .addOption(
+          new Option("--client-id <client-id>", "GitHub Runner App Client ID"),
+        )
+        .addOption(
+          new Option(
+            "--installation-id <installation-id>",
+            "GitHub Runner App Installation ID",
+          ),
+        )
+        .addOption(
+          new Option(
+            "--private-key-path <private-key-path>",
+            "Path to a local GitHub Runner App private key file",
+          ),
+        )
         .action(async function (options: unknown) {
           const { output } = this.optsWithGlobals<GlobalOptions>();
           const outputMode = resolveOutputMode(env, output);
@@ -438,14 +528,27 @@ export const makeAddCommand = (
                   }),
           )
             .andThen((addEnvironmentOptions) =>
-              requireGitHubAuth().andThen(
-                ({ authorizationService, gitHubService }) =>
-                  addEnvironmentAction(
-                    authorizationService,
-                    gitHubService,
-                    presenter,
-                    getEnvironmentInitialAnswers(addEnvironmentOptions),
-                  ),
+              ResultAsync.fromPromise(
+                getEnvironmentInitialAnswers(addEnvironmentOptions),
+                (cause) =>
+                  cause instanceof Error
+                    ? cause
+                    : new Error(
+                        "Failed to load add environment initial answers",
+                        {
+                          cause,
+                        },
+                      ),
+              ).andThen((initialAnswers) =>
+                requireGitHubAuth().andThen(
+                  ({ authorizationService, gitHubService }) =>
+                    addEnvironmentAction(
+                      authorizationService,
+                      gitHubService,
+                      presenter,
+                      initialAnswers,
+                    ),
+                ),
               ),
             )
             .match(

--- a/apps/cli/src/adapters/commander/commands/add.ts
+++ b/apps/cli/src/adapters/commander/commands/add.ts
@@ -166,75 +166,32 @@ export const parseAddEnvironmentCommandOptions = (
 const buildBaseEnvironmentInitialAnswers = (
   options: AddEnvironmentCommandOptions,
 ): DeploymentEnvironmentInitialAnswers => {
-  const initialAnswers: DeploymentEnvironmentInitialAnswers = {};
-
-  if (
-    options.account?.length ||
-    options.location?.length ||
-    options.name ||
-    options.prefix
-  ) {
-    initialAnswers.env = {};
-  }
-
-  if (options.name) {
-    initialAnswers.env = {
-      ...initialAnswers.env,
-      name: options.name,
-    };
-  }
-
-  if (options.prefix) {
-    initialAnswers.env = {
-      ...initialAnswers.env,
-      prefix: options.prefix,
-    };
-  }
-
-  if (options.account?.length) {
-    initialAnswers.env = {
-      ...initialAnswers.env,
+  const env = {
+    ...(options.name && { name: options.name }),
+    ...(options.prefix && { prefix: options.prefix }),
+    ...(options.account?.length && {
       cloudAccountIds: Array.from(new Set(options.account)),
-    };
-  }
-
-  if (options.location?.length) {
-    initialAnswers.env = {
-      ...initialAnswers.env,
+    }),
+    ...(options.location?.length && {
       locations: Object.fromEntries(
         options.location.map(({ accountId, location }) => [
           accountId,
           location as AzureLocation,
         ]),
       ),
-    };
-  }
+    }),
+  };
 
-  if (options.businessUnit || options.managementTeam) {
-    initialAnswers.tags = {};
-  }
+  const tags = {
+    ...(options.businessUnit && { BusinessUnit: options.businessUnit }),
+    ...(options.managementTeam && { ManagementTeam: options.managementTeam }),
+  };
 
-  if (options.businessUnit) {
-    initialAnswers.tags = {
-      ...initialAnswers.tags,
-      BusinessUnit: options.businessUnit,
-    };
-  }
-
-  if (options.managementTeam) {
-    initialAnswers.tags = {
-      ...initialAnswers.tags,
-      ManagementTeam: options.managementTeam,
-    };
-  }
-
-  if (options.domain) {
-    initialAnswers.workspace = {
-      domain: options.domain,
-    };
-  }
-
-  return initialAnswers;
+  return {
+    ...(Object.keys(env).length > 0 && { env }),
+    ...(Object.keys(tags).length > 0 && { tags }),
+    ...(options.domain && { workspace: { domain: options.domain } }),
+  };
 };
 
 export const getEnvironmentInitialAnswers = async (
@@ -264,25 +221,15 @@ export const getEnvironmentInitialAnswers = async (
           key: privateKey,
         };
 
-  if (options.yes || runnerAppCredentials) {
-    initialAnswers.init = {};
-  }
-
-  if (options.yes) {
-    initialAnswers.init = {
-      ...initialAnswers.init,
-      confirm: true,
-    };
-  }
-
-  if (runnerAppCredentials) {
-    initialAnswers.init = {
-      ...initialAnswers.init,
-      runnerAppCredentials,
-    };
-  }
-
-  return initialAnswers;
+  return {
+    ...initialAnswers,
+    ...((options.yes || runnerAppCredentials) && {
+      init: {
+        ...(options.yes && { confirm: true }),
+        ...(runnerAppCredentials && { runnerAppCredentials }),
+      },
+    }),
+  };
 };
 
 /**

--- a/apps/cli/src/adapters/commander/commands/add.ts
+++ b/apps/cli/src/adapters/commander/commands/add.ts
@@ -1,19 +1,22 @@
 import { getLogger } from "@logtape/logtape";
 import chalk from "chalk";
 /**
- * Add command - Scaffold new components into existing workspaces
+ * Add command - Scaffold new components into existing workspaces.
  *
- * This module implements the `dx add` command which allows developers to scaffold
- * new components into their existing workspace following DevEx guidelines.
- *
- * Currently supported components:
- * - environment: Add a new deployment environment to the project
+ * This module implements the `dx add` command and keeps the CLI-specific flag
+ * parsing/validation close to the Commander adapter. It turns supported flags
+ * into prefilled answers for the plop generator so the command can run with a
+ * mix of non-interactive inputs and guided prompts.
  */
-import { Command } from "commander";
+import { Command, Option } from "commander";
 import { okAsync, ResultAsync } from "neverthrow";
+import { z } from "zod/v4";
 
 import type { CommandPresenter } from "../../../domain/command-presenter.js";
-import type { Payload as EnvironmentPayload } from "../../plop/generators/environment/index.js";
+import type {
+  InitialAnswers as DeploymentEnvironmentInitialAnswers,
+  Payload as EnvironmentPayload,
+} from "../../plop/generators/environment/index.js";
 import type { CliEnv } from "../env.js";
 import type { GlobalOptions } from "../global-options.js";
 
@@ -23,9 +26,17 @@ import {
   requestAuthorizationInputSchema,
 } from "../../../domain/authorization.js";
 import { GitHubAuthFactory } from "../../../domain/dependencies.js";
-import { environmentShort } from "../../../domain/environment.js";
+import {
+  environmentSchema,
+  environmentShort,
+} from "../../../domain/environment.js";
 import { type GitHubService } from "../../../domain/github.js";
-import { isAzureLocation, locationShort } from "../../azure/locations.js";
+import {
+  type AzureLocation,
+  isAzureLocation,
+  locationShort,
+} from "../../azure/locations.js";
+import { workspaceSchema } from "../../plop/generators/environment/prompts.js";
 import {
   collectDeploymentEnvironmentPayload,
   getPlopInstance,
@@ -37,6 +48,176 @@ import {
   resolveOutputMode,
 } from "../presenters/index.js";
 import { runAddEnvironmentPreconditions } from "./init.js";
+
+const appendOptionValue = (
+  value: string,
+  previous: string[] = [],
+): string[] => [...previous, value];
+
+const locationOptionSchema = z
+  .string()
+  .trim()
+  .transform((value, ctx) => {
+    const [rawAccountId, ...rawLocationParts] = value.split("=");
+    const accountId = rawAccountId?.trim();
+    const location = rawLocationParts.join("=").trim();
+
+    if (!accountId || rawLocationParts.length === 0 || location.length === 0) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        message: "Location must use the format <subscription-id=region>.",
+      });
+      return z.NEVER;
+    }
+
+    if (!isAzureLocation(location)) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        message: `Unsupported Azure location "${location}".`,
+      });
+      return z.NEVER;
+    }
+
+    return { accountId, location };
+  });
+
+const addEnvironmentCommandOptionsSchema = z
+  .object({
+    account: z
+      .array(z.string().trim().min(1, "Cloud account id cannot be empty"))
+      .optional(),
+    businessUnit: z
+      .string()
+      .trim()
+      .min(1, "Business unit cannot be empty")
+      .optional(),
+    domain: workspaceSchema.shape.domain.optional(),
+    location: z.array(locationOptionSchema).optional(),
+    managementTeam: z
+      .string()
+      .trim()
+      .min(1, "Management team cannot be empty")
+      .optional(),
+    name: environmentSchema.shape.name.optional(),
+    prefix: environmentSchema.shape.prefix.optional(),
+  })
+  .superRefine((value, ctx) => {
+    if (value.location && !value.account?.length) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        message: "Location mappings require at least one --account flag.",
+        path: ["location"],
+      });
+      return;
+    }
+
+    if (value.account && value.location) {
+      const selectedAccounts = new Set(value.account);
+      for (const mapping of value.location) {
+        if (!selectedAccounts.has(mapping.accountId)) {
+          ctx.addIssue({
+            code: z.ZodIssueCode.custom,
+            message: `Location mapping references unknown account "${mapping.accountId}".`,
+            path: ["location"],
+          });
+        }
+      }
+    }
+  });
+
+export type AddEnvironmentCommandOptions = z.infer<
+  typeof addEnvironmentCommandOptionsSchema
+>;
+
+export const parseAddEnvironmentCommandOptions = (
+  input: unknown,
+): AddEnvironmentCommandOptions => {
+  const result = addEnvironmentCommandOptionsSchema.safeParse(input);
+  if (!result.success) {
+    throw new Error(
+      `Invalid add environment command options:\n${z.prettifyError(result.error)}`,
+      {
+        cause: result.error,
+      },
+    );
+  }
+
+  return result.data;
+};
+
+export const getEnvironmentInitialAnswers = (
+  options: AddEnvironmentCommandOptions,
+): DeploymentEnvironmentInitialAnswers => {
+  const initialAnswers: DeploymentEnvironmentInitialAnswers = {};
+
+  if (
+    options.account?.length ||
+    options.location?.length ||
+    options.name ||
+    options.prefix
+  ) {
+    initialAnswers.env = {};
+  }
+
+  if (options.name) {
+    initialAnswers.env = {
+      ...initialAnswers.env,
+      name: options.name,
+    };
+  }
+
+  if (options.prefix) {
+    initialAnswers.env = {
+      ...initialAnswers.env,
+      prefix: options.prefix,
+    };
+  }
+
+  if (options.account?.length) {
+    initialAnswers.env = {
+      ...initialAnswers.env,
+      cloudAccountIds: Array.from(new Set(options.account)),
+    };
+  }
+
+  if (options.location?.length) {
+    initialAnswers.env = {
+      ...initialAnswers.env,
+      locations: Object.fromEntries(
+        options.location.map(({ accountId, location }) => [
+          accountId,
+          location as AzureLocation,
+        ]),
+      ),
+    };
+  }
+
+  if (options.businessUnit || options.managementTeam) {
+    initialAnswers.tags = {};
+  }
+
+  if (options.businessUnit) {
+    initialAnswers.tags = {
+      ...initialAnswers.tags,
+      BusinessUnit: options.businessUnit,
+    };
+  }
+
+  if (options.managementTeam) {
+    initialAnswers.tags = {
+      ...initialAnswers.tags,
+      ManagementTeam: options.managementTeam,
+    };
+  }
+
+  if (options.domain) {
+    initialAnswers.workspace = {
+      domain: options.domain,
+    };
+  }
+
+  return initialAnswers;
+};
 
 /**
  * Authorize a Cloud Account (Azure Subscription, AWS Account, ...), creating a Pull Request for each account that requires authorization.
@@ -159,6 +340,7 @@ const addEnvironmentAction = (
   authorizationService: AuthorizationService,
   gitHubService: GitHubService,
   presenter: CommandPresenter,
+  initialAnswers: DeploymentEnvironmentInitialAnswers = {},
 ): ResultAsync<AddResult, Error> =>
   runAddEnvironmentPreconditions(presenter)
     .andThen(() =>
@@ -173,7 +355,12 @@ const addEnvironmentAction = (
       // The prompt phase must run outside trackStep: in text mode trackStep
       // renders a spinner that occupies the TTY and hides the prompts.
       ResultAsync.fromPromise(
-        collectDeploymentEnvironmentPayload(plop, gitHubService),
+        collectDeploymentEnvironmentPayload(
+          plop,
+          gitHubService,
+          undefined,
+          initialAnswers,
+        ),
         asError("Failed to run the deployment environment generator"),
       ),
     )
@@ -204,17 +391,61 @@ export const makeAddCommand = (
     .addCommand(
       new Command("environment")
         .description("Add a new deployment environment")
-        .action(async function () {
+        .addOption(
+          new Option("--name <name>", "Environment name").choices([
+            "dev",
+            "uat",
+            "prod",
+          ]),
+        )
+        .addOption(
+          new Option(
+            "--account <subscription-id>",
+            "Cloud account subscription id",
+          ).argParser(appendOptionValue),
+        )
+        .addOption(
+          new Option(
+            "--location <subscription-id=region>",
+            "Default Azure location for a selected account",
+          ).argParser(appendOptionValue),
+        )
+        .addOption(new Option("--prefix <prefix>", "Environment prefix"))
+        .addOption(new Option("--domain <domain>", "Workspace domain"))
+        .addOption(
+          new Option("--business-unit <business-unit>", "Business unit tag"),
+        )
+        .addOption(
+          new Option(
+            "--management-team <management-team>",
+            "Management team tag",
+          ),
+        )
+        .action(async function (options: unknown) {
           const { output } = this.optsWithGlobals<GlobalOptions>();
           const outputMode = resolveOutputMode(env, output);
           const presenter = createCommandPresenter(outputMode);
 
-          await requireGitHubAuth()
-            .andThen(({ authorizationService, gitHubService }) =>
-              addEnvironmentAction(
-                authorizationService,
-                gitHubService,
-                presenter,
+          await ResultAsync.fromPromise(
+            Promise.resolve().then(() =>
+              parseAddEnvironmentCommandOptions(options),
+            ),
+            (cause) =>
+              cause instanceof Error
+                ? cause
+                : new Error("Failed to parse add environment command options", {
+                    cause,
+                  }),
+          )
+            .andThen((addEnvironmentOptions) =>
+              requireGitHubAuth().andThen(
+                ({ authorizationService, gitHubService }) =>
+                  addEnvironmentAction(
+                    authorizationService,
+                    gitHubService,
+                    presenter,
+                    getEnvironmentInitialAnswers(addEnvironmentOptions),
+                  ),
               ),
             )
             .match(

--- a/apps/cli/src/adapters/plop/generators/environment/__tests__/prompts.test.ts
+++ b/apps/cli/src/adapters/plop/generators/environment/__tests__/prompts.test.ts
@@ -234,6 +234,7 @@ describe("prompts with prefilled answers", () => {
   });
 });
 
+// eslint-disable-next-line max-lines-per-function
 describe("prompts", () => {
   it("does not prompt again when only a single-account backend must be initialized", async () => {
     const cloudAccount: CloudAccount = {

--- a/apps/cli/src/adapters/plop/generators/environment/__tests__/prompts.test.ts
+++ b/apps/cli/src/adapters/plop/generators/environment/__tests__/prompts.test.ts
@@ -11,6 +11,7 @@ import type { EnvironmentInitStatus } from "../../../../../domain/environment.js
 
 import prompts, {
   formatInitializationDetails,
+  type InitialAnswers,
   workspaceSchema,
 } from "../prompts.js";
 
@@ -124,6 +125,112 @@ describe("formatInitializationDetails", () => {
     const status = notInitializedStatus([]);
 
     expect(formatInitializationDetails(status)).toBe("");
+  });
+});
+
+describe("prompts with prefilled answers", () => {
+  it("uses prefilled base answers without prompting again", async () => {
+    const cloudAccount: CloudAccount = {
+      csp: "azure",
+      defaultLocation: "italynorth",
+      displayName: "DEV-FooBar",
+      id: "sub-123",
+    };
+
+    const cloudAccountRepository: CloudAccountRepository = {
+      list: vi.fn().mockResolvedValue([cloudAccount]),
+    };
+
+    const cloudAccountService: CloudAccountService = {
+      getTerraformBackend: vi.fn().mockResolvedValue({
+        resourceGroupName: "rg-test",
+        storageAccountName: "sttest",
+        subscriptionId: cloudAccount.id,
+        type: "azurerm",
+      }),
+      hasUserPermissionToInitialize: vi.fn().mockResolvedValue(true),
+      initialize: vi.fn().mockResolvedValue(undefined),
+      isInitialized: vi.fn().mockResolvedValue(true),
+      provisionTerraformBackend: vi.fn().mockResolvedValue(undefined),
+    };
+
+    const promptSpy = vi.spyOn(inquirer, "prompt");
+    const locations = {
+      "sub-123": "italynorth",
+    } satisfies Record<string, "italynorth" | "westeurope">;
+
+    promptSpy
+      .mockResolvedValueOnce({
+        env: {
+          cloudAccounts: [cloudAccount],
+          name: "dev",
+          prefix: "dx",
+        },
+        tags: {
+          BusinessUnit: "Platform",
+          CostCenter: "TS000",
+          ManagementTeam: "Engineering",
+        },
+        workspace: {
+          domain: "payments",
+        },
+      })
+      .mockResolvedValueOnce({
+        [cloudAccount.id]: "italynorth",
+      });
+
+    try {
+      const initialAnswers = {
+        env: {
+          cloudAccountIds: [cloudAccount.id],
+          locations,
+          name: "dev",
+          prefix: "dx",
+        },
+        tags: {
+          BusinessUnit: "Platform",
+          ManagementTeam: "Engineering",
+        },
+        workspace: {
+          domain: "payments",
+        },
+      } satisfies InitialAnswers;
+
+      const deps = {
+        cloudAccountRepository,
+        cloudAccountService,
+        github: {
+          owner: "pagopa",
+          repo: "dx",
+        },
+        initialAnswers,
+      };
+
+      const result = await prompts(deps)(inquirer);
+
+      expect(promptSpy).not.toHaveBeenCalled();
+      expect(result).toEqual({
+        env: {
+          cloudAccounts: [cloudAccount],
+          name: "dev",
+          prefix: "dx",
+        },
+        github: {
+          owner: "pagopa",
+          repo: "dx",
+        },
+        tags: {
+          BusinessUnit: "Platform",
+          CostCenter: "TS000",
+          ManagementTeam: "Engineering",
+        },
+        workspace: {
+          domain: "payments",
+        },
+      });
+    } finally {
+      promptSpy.mockRestore();
+    }
   });
 });
 

--- a/apps/cli/src/adapters/plop/generators/environment/__tests__/prompts.test.ts
+++ b/apps/cli/src/adapters/plop/generators/environment/__tests__/prompts.test.ts
@@ -473,3 +473,102 @@ describe("prompts", () => {
     }
   });
 });
+
+describe("prompts with prefilled initialization answers", () => {
+  it("skips initialization prompts when confirmation and runner credentials are prefilled", async () => {
+    const cloudAccount: CloudAccount = {
+      csp: "azure",
+      defaultLocation: "italynorth",
+      displayName: "DEV-FooBar",
+      id: "sub-123",
+    };
+
+    const cloudAccountRepository: CloudAccountRepository = {
+      list: vi.fn().mockResolvedValue([cloudAccount]),
+    };
+
+    const cloudAccountService: CloudAccountService = {
+      getTerraformBackend: vi.fn().mockResolvedValue(undefined),
+      hasUserPermissionToInitialize: vi.fn().mockResolvedValue(true),
+      initialize: vi.fn().mockResolvedValue(undefined),
+      isInitialized: vi.fn().mockResolvedValue(false),
+      provisionTerraformBackend: vi.fn().mockResolvedValue(undefined),
+    };
+
+    const promptSpy = vi.spyOn(inquirer, "prompt");
+    const consoleLogSpy = vi
+      .spyOn(console, "log")
+      .mockImplementation(() => undefined);
+
+    promptSpy
+      .mockResolvedValueOnce({
+        init: true,
+      })
+      .mockResolvedValueOnce({
+        runnerAppCredentials: {
+          clientId: "app-client-id",
+          id: "app-id",
+          installationId: "installation-id",
+          key: "private-key",
+        },
+      });
+
+    try {
+      const locations = {
+        [cloudAccount.id]: "italynorth",
+      } satisfies Record<string, "italynorth" | "westeurope">;
+
+      const initialAnswers = {
+        env: {
+          cloudAccountIds: [cloudAccount.id],
+          locations,
+          name: "dev",
+          prefix: "dx",
+        },
+        init: {
+          confirm: true,
+          runnerAppCredentials: {
+            clientId: "app-client-id",
+            id: "app-id",
+            installationId: "installation-id",
+            key: "private-key",
+          },
+        },
+        tags: {
+          BusinessUnit: "Platform",
+          ManagementTeam: "Engineering",
+        },
+        workspace: {
+          domain: "payments",
+        },
+      } satisfies InitialAnswers;
+
+      const result = await prompts({
+        cloudAccountRepository,
+        cloudAccountService,
+        github: {
+          owner: "pagopa",
+          repo: "dx",
+        },
+        initialAnswers,
+      })(inquirer);
+
+      expect(promptSpy).not.toHaveBeenCalled();
+      expect(result.init).toEqual({
+        cloudAccountsToInitialize: [cloudAccount],
+        runnerAppCredentials: {
+          clientId: "app-client-id",
+          id: "app-id",
+          installationId: "installation-id",
+          key: "private-key",
+        },
+        terraformBackend: {
+          cloudAccount,
+        },
+      });
+    } finally {
+      promptSpy.mockRestore();
+      consoleLogSpy.mockRestore();
+    }
+  });
+});

--- a/apps/cli/src/adapters/plop/generators/environment/__tests__/prompts.test.ts
+++ b/apps/cli/src/adapters/plop/generators/environment/__tests__/prompts.test.ts
@@ -235,6 +235,75 @@ describe("prompts with prefilled answers", () => {
 });
 
 describe("prompts", () => {
+  it("does not prompt again when only a single-account backend must be initialized", async () => {
+    const cloudAccount: CloudAccount = {
+      csp: "azure",
+      defaultLocation: "italynorth",
+      displayName: "DEV-FooBar",
+      id: "sub-123",
+    };
+
+    const cloudAccountRepository: CloudAccountRepository = {
+      list: vi.fn().mockResolvedValue([cloudAccount]),
+    };
+
+    const cloudAccountService: CloudAccountService = {
+      getTerraformBackend: vi.fn().mockResolvedValue(undefined),
+      hasUserPermissionToInitialize: vi.fn().mockResolvedValue(true),
+      initialize: vi.fn().mockResolvedValue(undefined),
+      isInitialized: vi.fn().mockResolvedValue(true),
+      provisionTerraformBackend: vi.fn().mockResolvedValue(undefined),
+    };
+
+    const promptSpy = vi.spyOn(inquirer, "prompt");
+    const consoleLogSpy = vi
+      .spyOn(console, "log")
+      .mockImplementation(() => undefined);
+
+    promptSpy
+      .mockResolvedValueOnce({
+        env: {
+          cloudAccounts: [cloudAccount],
+          name: "dev",
+          prefix: "dx",
+        },
+        tags: {
+          BusinessUnit: "Platform",
+          CostCenter: "TS000",
+          ManagementTeam: "Engineering",
+        },
+        workspace: {
+          domain: "payments",
+        },
+      })
+      .mockResolvedValueOnce({
+        [cloudAccount.id]: "italynorth",
+      })
+      .mockResolvedValueOnce({
+        init: true,
+      })
+      .mockResolvedValueOnce({});
+
+    try {
+      const result = await prompts({
+        cloudAccountRepository,
+        cloudAccountService,
+        github: {
+          owner: "pagopa",
+          repo: "dx",
+        },
+      })(inquirer);
+
+      expect(promptSpy).toHaveBeenCalledTimes(3);
+      expect(result.init?.terraformBackend).toEqual({
+        cloudAccount,
+      });
+    } finally {
+      promptSpy.mockRestore();
+      consoleLogSpy.mockRestore();
+    }
+  });
+
   it("prompts for the GitHub runner app client ID when initialization is required", async () => {
     const cloudAccount: CloudAccount = {
       csp: "azure",

--- a/apps/cli/src/adapters/plop/generators/environment/index.ts
+++ b/apps/cli/src/adapters/plop/generators/environment/index.ts
@@ -15,10 +15,14 @@ import setEqHelper from "../../helpers/eq.js";
 import setResourcePrefixHelper from "../../helpers/resource-prefix.js";
 import setTerraformStateKeyHelper from "../../helpers/terraform-state-key.js";
 import getActions from "./actions.js";
-import getPrompts, { Payload, payloadSchema } from "./prompts.js";
+import getPrompts, {
+  InitialAnswers,
+  Payload,
+  payloadSchema,
+} from "./prompts.js";
 
 export const PLOP_ENVIRONMENT_GENERATOR_NAME = "DX_DeploymentEnvironment";
-export { Payload, payloadSchema };
+export { type InitialAnswers, Payload, payloadSchema };
 
 export default function (
   plop: NodePlopAPI,
@@ -27,6 +31,7 @@ export default function (
   cloudAccountService: CloudAccountService,
   gitHubService: GitHubService,
   github?: GitHubRepo,
+  initialAnswers: InitialAnswers = {},
 ) {
   setEnvShortHelper(plop);
   setResourcePrefixHelper(plop);
@@ -45,6 +50,7 @@ export default function (
       cloudAccountRepository,
       cloudAccountService,
       github,
+      initialAnswers,
     }),
   });
 }

--- a/apps/cli/src/adapters/plop/generators/environment/prompts.ts
+++ b/apps/cli/src/adapters/plop/generators/environment/prompts.ts
@@ -456,7 +456,8 @@ const prompts: (deps: PromptsDependencies) => DynamicPromptsFunction =
       );
     }
 
-    const initInput = await promptModule.prompt(questions);
+    const initInput =
+      questions.length === 0 ? {} : await promptModule.prompt(questions);
 
     if (initInput.runnerAppCredentials) {
       runnerAppCredentials = initInput.runnerAppCredentials;

--- a/apps/cli/src/adapters/plop/generators/environment/prompts.ts
+++ b/apps/cli/src/adapters/plop/generators/environment/prompts.ts
@@ -72,6 +72,11 @@ export const payloadSchema = z.object({
 
 export type Payload = z.infer<typeof payloadSchema>;
 
+/**
+ * Prefilled answers supplied up-front by the caller (e.g. CLI flags), used to
+ * skip the matching prompts. Identifies cloud accounts by id and locations by
+ * account id, since the full domain objects aren't available before resolving.
+ */
 export const initialAnswersSchema = z.object({
   env: z
     .object({
@@ -104,6 +109,12 @@ export const initialAnswersSchema = z.object({
 
 export type InitialAnswers = z.infer<typeof initialAnswersSchema>;
 
+/**
+ * Answers gathered from the interactive base prompts. Mirrors {@link initialAnswersSchema}
+ * but holds the values produced by the prompt session: cloud accounts are full
+ * domain objects (resolved from inquirer choices) rather than ids. Only questions
+ * not already prefilled are asked, so every field is optional here too.
+ */
 const basePromptAnswersSchema = z.object({
   env: z
     .object({

--- a/apps/cli/src/adapters/plop/generators/environment/prompts.ts
+++ b/apps/cli/src/adapters/plop/generators/environment/prompts.ts
@@ -69,116 +69,299 @@ export const payloadSchema = z.object({
 
 export type Payload = z.infer<typeof payloadSchema>;
 
+export const initialAnswersSchema = z.object({
+  env: z
+    .object({
+      cloudAccountIds: z.array(z.string().trim().min(1)).optional(),
+      locations: z
+        .record(z.string().min(1), z.enum(azure.locations))
+        .optional(),
+      name: environmentSchema.shape.name.optional(),
+      prefix: environmentSchema.shape.prefix.optional(),
+    })
+    .optional(),
+  tags: z
+    .object({
+      BusinessUnit: z.string().trim().min(1).optional(),
+      ManagementTeam: z.string().trim().min(1).optional(),
+    })
+    .optional(),
+  workspace: z
+    .object({
+      domain: workspaceSchema.shape.domain.optional(),
+    })
+    .optional(),
+});
+
+export type InitialAnswers = z.infer<typeof initialAnswersSchema>;
+
+const basePromptAnswersSchema = z.object({
+  env: z
+    .object({
+      cloudAccounts: z.array(cloudAccountSchema).optional(),
+      name: environmentSchema.shape.name.optional(),
+      prefix: environmentSchema.shape.prefix.optional(),
+    })
+    .optional(),
+  tags: z
+    .object({
+      BusinessUnit: z.string().trim().min(1).optional(),
+      ManagementTeam: z.string().trim().min(1).optional(),
+    })
+    .optional(),
+  workspace: z
+    .object({
+      domain: workspaceSchema.shape.domain.optional(),
+    })
+    .optional(),
+});
+
 export type PromptsDependencies = {
   cloudAccountRepository: CloudAccountRepository;
   cloudAccountService: CloudAccountService;
   github?: GitHubRepo;
+  initialAnswers?: InitialAnswers;
 };
 
-/* eslint-disable max-lines-per-function */
+type BasePromptAnswers = z.infer<typeof basePromptAnswersSchema>;
+
+const DEFAULT_COST_CENTER = "TS000";
+
+const resolveCloudAccounts = (
+  availableCloudAccounts: CloudAccount[],
+  initialAnswers: InitialAnswers,
+): CloudAccount[] | undefined => {
+  const cloudAccountIds = initialAnswers.env?.cloudAccountIds;
+  if (cloudAccountIds === undefined) {
+    return undefined;
+  }
+
+  return cloudAccountIds.map((cloudAccountId) => {
+    const cloudAccount = availableCloudAccounts.find(
+      (account) => account.id === cloudAccountId,
+    );
+    assert.ok(cloudAccount, `Cloud account "${cloudAccountId}" was not found.`);
+    return { ...cloudAccount };
+  });
+};
+
+const getBaseQuestions = (
+  availableCloudAccounts: CloudAccount[],
+  initialAnswers: InitialAnswers,
+  selectedCloudAccounts: CloudAccount[] | undefined,
+): DistinctQuestion[] => {
+  const questions: DistinctQuestion[] = [];
+
+  if (initialAnswers.env?.name === undefined) {
+    questions.push({
+      choices: [
+        { name: "PROD", value: "prod" },
+        { name: "UAT", value: "uat" },
+        { name: "DEV", value: "dev" },
+      ],
+      default: "prod",
+      message: "Environment name",
+      name: "env.name",
+      type: "list",
+    });
+  }
+
+  if (selectedCloudAccounts === undefined) {
+    questions.push({
+      choices: getCloudAccountChoices(availableCloudAccounts),
+      loop: false,
+      message: "Account(s)",
+      name: "env.cloudAccounts",
+      type: "checkbox",
+      validate: (value) =>
+        Array.isArray(value) && value.length > 0
+          ? true
+          : "Please select a cloud account.",
+    });
+  }
+
+  if (initialAnswers.env?.prefix === undefined) {
+    questions.push({
+      filter: (value: string) => value.trim().toLowerCase(),
+      message: "Prefix (2-4 characters)",
+      name: "env.prefix",
+      type: "input",
+      validate: validatePrompt(environmentSchema.shape.prefix),
+    });
+  }
+
+  if (initialAnswers.workspace?.domain === undefined) {
+    questions.push({
+      filter: (value: string) => value.trim().toLowerCase(),
+      message: "Domain",
+      name: "workspace.domain",
+      type: "input",
+      validate: validatePrompt(workspaceSchema.shape.domain),
+    });
+  }
+
+  if (initialAnswers.tags?.BusinessUnit === undefined) {
+    questions.push({
+      filter: (value) => value.trim(),
+      message: "Business unit",
+      name: "tags.BusinessUnit",
+      validate: (value) =>
+        value.length > 0 ? true : "Business Unit cannot be empty.",
+    });
+  }
+
+  if (initialAnswers.tags?.ManagementTeam === undefined) {
+    questions.push({
+      filter: (value) => value.trim(),
+      message: "Management team",
+      name: "tags.ManagementTeam",
+      validate: (value) =>
+        value.length > 0 ? true : "Management Team cannot be empty.",
+    });
+  }
+
+  return questions;
+};
+
+const getSelectedCloudAccounts = (
+  answers: BasePromptAnswers,
+  initialCloudAccounts: CloudAccount[] | undefined,
+): CloudAccount[] => {
+  const promptedCloudAccounts = answers.env?.cloudAccounts;
+  const selectedCloudAccounts = initialCloudAccounts ?? promptedCloudAccounts;
+
+  assert.ok(
+    Array.isArray(selectedCloudAccounts) && selectedCloudAccounts.length > 0,
+    "Please select a cloud account.",
+  );
+
+  return selectedCloudAccounts.map((cloudAccount) => ({ ...cloudAccount }));
+};
+
+const applyLocations = async (
+  promptModule: typeof inquirer,
+  selectedCloudAccounts: CloudAccount[],
+  initialAnswers: InitialAnswers,
+) => {
+  const predefinedLocations = initialAnswers.env?.locations ?? {};
+  const locationQuestions = selectedCloudAccounts
+    .filter((account) => predefinedLocations[account.id] === undefined)
+    .map((account) => ({
+      choices: getCloudLocationChoices(azure.cloudRegions),
+      default: azure.defaultLocation,
+      message: `Default location for ${account.displayName}`,
+      name: account.id,
+      type: "list",
+    }));
+
+  const promptedLocations =
+    locationQuestions.length === 0
+      ? {}
+      : await promptModule.prompt(locationQuestions);
+
+  selectedCloudAccounts.forEach((account) => {
+    const location =
+      predefinedLocations[account.id] ?? promptedLocations[account.id];
+    if (location !== undefined) {
+      account.defaultLocation = location;
+    }
+  });
+};
+
+const parseInitialAnswers = (
+  input: InitialAnswers | undefined,
+): InitialAnswers => {
+  const result = initialAnswersSchema.safeParse(input ?? {});
+  assert.ok(
+    result.success,
+    "Invalid initial answers for the environment generator.",
+  );
+  return result.data;
+};
+
+const collectBaseAnswers = async (
+  promptModule: typeof inquirer,
+  availableCloudAccounts: CloudAccount[],
+  initialAnswers: InitialAnswers,
+): Promise<{
+  answers: BasePromptAnswers;
+  initialCloudAccounts: CloudAccount[] | undefined;
+}> => {
+  const initialCloudAccounts = resolveCloudAccounts(
+    availableCloudAccounts,
+    initialAnswers,
+  );
+  const baseQuestions = getBaseQuestions(
+    availableCloudAccounts,
+    initialAnswers,
+    initialCloudAccounts,
+  );
+  const promptAnswersResult = basePromptAnswersSchema.safeParse(
+    baseQuestions.length === 0 ? {} : await promptModule.prompt(baseQuestions),
+  );
+  assert.ok(promptAnswersResult.success, "Invalid environment prompt answers.");
+
+  return {
+    answers: promptAnswersResult.data,
+    initialCloudAccounts,
+  };
+};
+
+const buildPayload = ({
+  answers,
+  github,
+  initialAnswers,
+  selectedCloudAccounts,
+}: {
+  answers: BasePromptAnswers;
+  github: GitHubRepo;
+  initialAnswers: InitialAnswers;
+  selectedCloudAccounts: CloudAccount[];
+}): Payload =>
+  payloadSchema.parse({
+    env: {
+      cloudAccounts: selectedCloudAccounts,
+      name: initialAnswers.env?.name ?? answers.env?.name,
+      prefix: initialAnswers.env?.prefix ?? answers.env?.prefix,
+    },
+    github,
+    tags: {
+      BusinessUnit:
+        initialAnswers.tags?.BusinessUnit ?? answers.tags?.BusinessUnit,
+      CostCenter: DEFAULT_COST_CENTER,
+      ManagementTeam:
+        initialAnswers.tags?.ManagementTeam ?? answers.tags?.ManagementTeam,
+    },
+    workspace: {
+      domain: initialAnswers.workspace?.domain ?? answers.workspace?.domain,
+    },
+  });
+
 const prompts: (deps: PromptsDependencies) => DynamicPromptsFunction =
-  (deps) => async (inquirer) => {
+  (deps) => async (promptModule) => {
     const logger = getLogger(["gen", "env"]);
     const github = deps.github ?? (await getGithubRepo());
     assert.ok(github, "This generator only works inside a GitHub repository.");
+    const initialAnswers = parseInitialAnswers(deps.initialAnswers);
     logger.debug("github repo {github}", { github });
-    const answers = await inquirer.prompt([
-      {
-        choices: [
-          { name: "PROD", value: "prod" },
-          { name: "UAT", value: "uat" },
-          { name: "DEV", value: "dev" },
-        ],
-        default: "prod",
-        message: "Environment name",
-        name: "env.name",
-        type: "list",
-      },
-      {
-        choices: [{ name: "Microsoft Azure", value: "azure" }],
-        default: ["azure"],
-        message: "Cloud provider(s)",
-        name: "csp",
-        type: "checkbox",
-        validate: (value) =>
-          Array.isArray(value) && value.length > 0
-            ? true
-            : "Please select at least one cloud provider.",
-      },
-      {
-        choices: async () =>
-          getCloudAccountChoices(await deps.cloudAccountRepository.list()),
-        loop: false,
-        message: "Account(s)",
-        name: "env.cloudAccounts",
-        type: "checkbox",
-        validate: (value) =>
-          Array.isArray(value) && value.length > 0
-            ? true
-            : "Please select a cloud account.",
-      },
-      {
-        filter: (value: string) => value.trim().toLowerCase(),
-        message: "Prefix (2-4 characters)",
-        name: "env.prefix",
-        type: "input",
-        validate: validatePrompt(environmentSchema.shape.prefix),
-      },
-      {
-        filter: (value: string) => value.trim().toLowerCase(),
-        message: "Domain",
-        name: "workspace.domain",
-        type: "input",
-        validate: validatePrompt(workspaceSchema.shape.domain),
-      },
-      {
-        choices: [
-          {
-            name: "TECNOLOGIA E SERVIZI",
-            value: "TS000",
-          },
-        ],
-        default: "TS000 - Tecnologia e Servizi",
-        message: "Cost center",
-        name: "tags.CostCenter",
-        type: "list",
-        validate: (value) =>
-          Array.isArray(value) && value.length > 0
-            ? true
-            : "Please select a Cost Center.",
-      },
-      {
-        filter: (value) => value.trim(),
-        message: "Business unit",
-        name: "tags.BusinessUnit",
-        validate: (value) =>
-          value.length > 0 ? true : "Business Unit cannot be empty.",
-      },
-      {
-        filter: (value) => value.trim(),
-        message: "Management team",
-        name: "tags.ManagementTeam",
-        validate: (value) =>
-          value.length > 0 ? true : "Management Team cannot be empty.",
-      },
-    ]);
-
-    const payload = payloadSchema.parse({ ...answers, github });
-
-    const locations = await inquirer.prompt(
-      payload.env.cloudAccounts.map((account) => ({
-        choices: getCloudLocationChoices(azure.cloudRegions),
-        default: azure.defaultLocation,
-        message: `Default location for ${account.displayName}`,
-        name: account.id,
-        type: "list",
-      })),
+    const availableCloudAccounts = await deps.cloudAccountRepository.list();
+    const { answers, initialCloudAccounts } = await collectBaseAnswers(
+      promptModule,
+      availableCloudAccounts,
+      initialAnswers,
     );
-    payload.env.cloudAccounts.forEach((account) => {
-      const location = locations[account.id];
-      if (location) {
-        account.defaultLocation = location;
-      }
+    const selectedCloudAccounts = getSelectedCloudAccounts(
+      answers,
+      initialCloudAccounts,
+    );
+
+    await applyLocations(promptModule, selectedCloudAccounts, initialAnswers);
+
+    const payload = buildPayload({
+      answers,
+      github,
+      initialAnswers,
+      selectedCloudAccounts,
     });
 
     const initStatus = await getInitializationStatus(
@@ -194,7 +377,7 @@ const prompts: (deps: PromptsDependencies) => DynamicPromptsFunction =
 
     console.log(formatInitializationDetails(initStatus));
 
-    const initConfirm = await inquirer.prompt({
+    const initConfirm = await promptModule.prompt({
       default: true,
       message: `The environment "${payload.env.name}" is not initialized. Proceed with the setup above?`,
       name: "init",
@@ -273,7 +456,7 @@ const prompts: (deps: PromptsDependencies) => DynamicPromptsFunction =
       );
     }
 
-    const initInput = await inquirer.prompt(questions);
+    const initInput = await promptModule.prompt(questions);
 
     if (initInput.runnerAppCredentials) {
       runnerAppCredentials = initInput.runnerAppCredentials;

--- a/apps/cli/src/adapters/plop/generators/environment/prompts.ts
+++ b/apps/cli/src/adapters/plop/generators/environment/prompts.ts
@@ -27,7 +27,10 @@ import {
   GitHubRepo,
   githubRepoSchema,
 } from "../../../../domain/github-repo.js";
-import { githubAppCredentialsSchema } from "../../../../domain/github.js";
+import {
+  type GitHubAppCredentials,
+  githubAppCredentialsSchema,
+} from "../../../../domain/github.js";
 import { getGithubRepo } from "../../../github/github-repo.js";
 import { validatePrompt } from "../../helpers/validate-prompt.js";
 
@@ -78,6 +81,12 @@ export const initialAnswersSchema = z.object({
         .optional(),
       name: environmentSchema.shape.name.optional(),
       prefix: environmentSchema.shape.prefix.optional(),
+    })
+    .optional(),
+  init: z
+    .object({
+      confirm: z.boolean().optional(),
+      runnerAppCredentials: githubAppCredentialsSchema.partial().optional(),
     })
     .optional(),
   tags: z
@@ -279,6 +288,78 @@ const parseInitialAnswers = (
   return result.data;
 };
 
+const getRunnerAppCredentialQuestions = (
+  initialRunnerAppCredentials: Partial<GitHubAppCredentials>,
+): DistinctQuestion[] => {
+  const questions: DistinctQuestion[] = [];
+
+  if (initialRunnerAppCredentials.id === undefined) {
+    questions.push({
+      filter: (value) => value.trim(),
+      message: "GitHub Runner App ID",
+      name: "runnerAppCredentials.id",
+      type: "input",
+      validate: (value) => value.length > 0,
+    });
+  }
+
+  if (initialRunnerAppCredentials.clientId === undefined) {
+    questions.push({
+      filter: (value) => value.trim(),
+      message: "GitHub Runner App Client ID",
+      name: "runnerAppCredentials.clientId",
+      type: "input",
+      validate: (value) => value.length > 0,
+    });
+  }
+
+  if (initialRunnerAppCredentials.installationId === undefined) {
+    questions.push({
+      filter: (value) => value.trim(),
+      message: "GitHub Runner App Installation ID",
+      name: "runnerAppCredentials.installationId",
+      type: "input",
+      validate: (value) => value.length > 0,
+    });
+  }
+
+  if (initialRunnerAppCredentials.key === undefined) {
+    questions.push({
+      filter: (value) => value.trim(),
+      message: "GitHub Runner App Private Key",
+      name: "runnerAppCredentials.key",
+      type: "editor",
+      validate: (value) => value.length > 0,
+    });
+  }
+
+  return questions;
+};
+
+const mergeRunnerAppCredentials = (
+  initialRunnerAppCredentials: Partial<GitHubAppCredentials>,
+  promptedRunnerAppCredentials: Partial<GitHubAppCredentials> | undefined,
+): InitPayload["runnerAppCredentials"] => {
+  const runnerAppCredentials = {
+    clientId:
+      initialRunnerAppCredentials.clientId ??
+      promptedRunnerAppCredentials?.clientId,
+    id: initialRunnerAppCredentials.id ?? promptedRunnerAppCredentials?.id,
+    installationId:
+      initialRunnerAppCredentials.installationId ??
+      promptedRunnerAppCredentials?.installationId,
+    key: initialRunnerAppCredentials.key ?? promptedRunnerAppCredentials?.key,
+  };
+
+  if (
+    Object.values(runnerAppCredentials).every((value) => value === undefined)
+  ) {
+    return undefined;
+  }
+
+  return githubAppCredentialsSchema.parse(runnerAppCredentials);
+};
+
 const collectBaseAnswers = async (
   promptModule: typeof inquirer,
   availableCloudAccounts: CloudAccount[],
@@ -377,14 +458,16 @@ const prompts: (deps: PromptsDependencies) => DynamicPromptsFunction =
 
     console.log(formatInitializationDetails(initStatus));
 
-    const initConfirm = await promptModule.prompt({
-      default: true,
-      message: `The environment "${payload.env.name}" is not initialized. Proceed with the setup above?`,
-      name: "init",
-      type: "confirm",
-    });
+    if (initialAnswers.init?.confirm !== true) {
+      const initConfirm = await promptModule.prompt({
+        default: true,
+        message: `The environment "${payload.env.name}" is not initialized. Proceed with the setup above?`,
+        name: "init",
+        type: "confirm",
+      });
 
-    assert.ok(initConfirm.init, "Can't proceed without initialization");
+      assert.ok(initConfirm.init, "Can't proceed without initialization");
+    }
 
     assert.ok(
       await hasUserPermissionToInitialize(
@@ -421,51 +504,26 @@ const prompts: (deps: PromptsDependencies) => DynamicPromptsFunction =
       (issue) => issue.type === "CLOUD_ACCOUNT_NOT_INITIALIZED",
     );
 
-    let runnerAppCredentials: InitPayload["runnerAppCredentials"];
+    const initialRunnerAppCredentials =
+      initialAnswers.init?.runnerAppCredentials ?? {};
 
     if (cloudAccountsNotInitialized) {
       questions.push(
-        {
-          filter: (value) => value.trim(),
-          message: "GitHub Runner App ID",
-          name: "runnerAppCredentials.id",
-          type: "input",
-          validate: (value) => value.length > 0,
-        },
-        {
-          filter: (value) => value.trim(),
-          message: "GitHub Runner App Client ID",
-          name: "runnerAppCredentials.clientId",
-          type: "input",
-          validate: (value) => value.length > 0,
-        },
-        {
-          filter: (value) => value.trim(),
-          message: "GitHub Runner App Installation ID",
-          name: "runnerAppCredentials.installationId",
-          type: "input",
-          validate: (value) => value.length > 0,
-        },
-        {
-          filter: (value) => value.trim(),
-          message: "GitHub Runner App Private Key",
-          name: "runnerAppCredentials.key",
-          type: "editor",
-          validate: (value) => value.length > 0,
-        },
+        ...getRunnerAppCredentialQuestions(initialRunnerAppCredentials),
       );
     }
 
     const initInput =
       questions.length === 0 ? {} : await promptModule.prompt(questions);
 
-    if (initInput.runnerAppCredentials) {
-      runnerAppCredentials = initInput.runnerAppCredentials;
-    }
-
     if (initInput.terraformBackend) {
       terraformBackend = initInput.terraformBackend;
     }
+
+    const runnerAppCredentials = mergeRunnerAppCredentials(
+      initialRunnerAppCredentials,
+      initInput.runnerAppCredentials,
+    );
 
     payload.init = payloadSchema.shape.init.parse({
       cloudAccountsToInitialize: getCloudAccountToInitialize(initStatus),

--- a/apps/cli/src/adapters/plop/index.ts
+++ b/apps/cli/src/adapters/plop/index.ts
@@ -11,6 +11,7 @@ import { GitHubService, RepositoryNotFoundError } from "../../domain/github.js";
 import { AzureSubscriptionRepository } from "../azure/cloud-account-repository.js";
 import { AzureCloudAccountService } from "../azure/cloud-account-service.js";
 import createDeploymentEnvironmentGenerator, {
+  InitialAnswers as DeploymentEnvironmentInitialAnswers,
   Payload as EnvironmentPayload,
   payloadSchema as environmentPayloadSchema,
   PLOP_ENVIRONMENT_GENERATOR_NAME,
@@ -150,8 +151,14 @@ export const collectDeploymentEnvironmentPayload = async (
   plop: NodePlopAPI,
   gitHubService: GitHubService,
   github?: GitHubRepo,
+  initialAnswers: DeploymentEnvironmentInitialAnswers = {},
 ): Promise<{ generator: PlopGenerator; payload: EnvironmentPayload }> => {
-  setDeploymentEnvironmentGenerator(plop, gitHubService, github);
+  setDeploymentEnvironmentGenerator(
+    plop,
+    gitHubService,
+    github,
+    initialAnswers,
+  );
   const generator = plop.getGenerator(PLOP_ENVIRONMENT_GENERATOR_NAME);
   const answers = await generator.runPrompts();
   const payload = environmentPayloadSchema.parse(answers);
@@ -185,6 +192,7 @@ export const setDeploymentEnvironmentGenerator = (
   plop: NodePlopAPI,
   gitHubService: GitHubService,
   github?: GitHubRepo,
+  initialAnswers: DeploymentEnvironmentInitialAnswers = {},
 ) => {
   const credential = new AzureCliCredential();
   const cloudAccountRepository = new AzureSubscriptionRepository(credential);
@@ -197,5 +205,6 @@ export const setDeploymentEnvironmentGenerator = (
     cloudAccountService,
     gitHubService,
     github,
+    initialAnswers,
   );
 };


### PR DESCRIPTION
Make dx add environment accept the agreed CLI flags and use them as prefilled answers while keeping the conditional initialization prompts interactive.

Add coverage for the new flag contract and the prefilled-answer prompt behavior.

Resolves CES-2134
