### PR TITLE
Clarify git remote setup errors in init command

### DIFF
--- a/.nx/version-plans/version-plan-1781691244692.md
+++ b/.nx/version-plans/version-plan-1781691244692.md
@@ -1,0 +1,5 @@
+---
+'@pagopa/dx-cli': patch
+---
+
+Surface a clear, actionable error when `git remote add origin` fails during `dx init` (for example when the `origin` remote already exists), instead of misreporting it as a push failure. The underlying git exit code and stderr remain available with --verbose.

--- a/apps/cli/src/adapters/commander/commands/__tests__/init.test.ts
+++ b/apps/cli/src/adapters/commander/commands/__tests__/init.test.ts
@@ -3,6 +3,7 @@
  */
 
 import { Command } from "commander";
+import { ExecaError } from "execa";
 import inquirer from "inquirer";
 import { okAsync } from "neverthrow";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
@@ -53,6 +54,7 @@ import {
   confirmGitHubRepoCreation,
   getMonorepoInitialAnswers,
   makeInitCommand,
+  mapGitRemoteAddError,
   parseInitCommandOptions,
 } from "../init.js";
 
@@ -194,6 +196,46 @@ describe("getMonorepoInitialAnswers", () => {
       repoName: "my-dx-workspace",
       repoOwner: "pagopa",
     });
+  });
+});
+
+describe("mapGitRemoteAddError", () => {
+  const makeExecaError = (exitCode: number): ExecaError => {
+    const error = new ExecaError();
+    error.exitCode = exitCode;
+    return error;
+  };
+
+  it("explains how to recover when the 'origin' remote already exists (exit code 3)", () => {
+    const cause = makeExecaError(3);
+
+    const error = mapGitRemoteAddError(cause);
+
+    expect(error.message).toContain("already exists");
+    expect(error.message).toContain("git remote remove origin");
+    expect(error.cause).toBe(cause);
+  });
+
+  it("falls back to the remote-setup message for other git exit codes", () => {
+    const cause = makeExecaError(1);
+
+    const error = mapGitRemoteAddError(cause);
+
+    expect(error.message).toBe(
+      "Failed to set up the local git repository and its 'origin' remote.",
+    );
+    expect(error.cause).toBe(cause);
+  });
+
+  it("falls back to the remote-setup message for non-Execa errors", () => {
+    const cause = new Error("spawn git ENOENT");
+
+    const error = mapGitRemoteAddError(cause);
+
+    expect(error.message).toBe(
+      "Failed to set up the local git repository and its 'origin' remote.",
+    );
+    expect(error.cause).toBe(cause);
   });
 });
 

--- a/apps/cli/src/adapters/commander/commands/init.ts
+++ b/apps/cli/src/adapters/commander/commands/init.ts
@@ -5,7 +5,7 @@ import { $, ExecaError } from "execa";
 import inquirer from "inquirer";
 import { errAsync, okAsync, ResultAsync } from "neverthrow";
 import * as path from "node:path";
-import { z } from "zod/v4";
+import { z } from "zod";
 
 import type { CommandPresenter } from "../../../domain/command-presenter.js";
 import type { GlobalOptions } from "../global-options.js";
@@ -271,15 +271,53 @@ const createRemoteRepositoryWithPresenter =
       asError("Failed to create GitHub repository."),
     ).map(() => new Repository(repoName, repoOwner));
   };
+/**
+ * Exit code returned by `git remote add` when a remote with the requested name
+ * already exists. `git remote` documents this dedicated status code, so we can
+ * turn it into actionable guidance instead of a generic failure message.
+ *
+ * See https://git-scm.com/docs/git-remote#_exit_status
+ */
+const GIT_REMOTE_ALREADY_EXISTS_EXIT_CODE = 3;
+
+/**
+ * Translates a failure of the git remote setup step into an actionable error.
+ *
+ * When `git remote add origin` exits with code 3 the remote already exists,
+ * which is a recoverable situation: the message tells the user how to fix it.
+ * The original ExecaError is preserved as `cause` so `--verbose` still surfaces
+ * the exit code and git's own stderr.
+ */
+export const mapGitRemoteAddError = (cause: unknown): Error => {
+  if (
+    cause instanceof ExecaError &&
+    cause.exitCode === GIT_REMOTE_ALREADY_EXISTS_EXIT_CODE
+  ) {
+    return new Error(
+      "A git remote named 'origin' already exists. Remove it with `git remote remove origin` and run the command again, or start from a clean directory.",
+      { cause },
+    );
+  }
+  return new Error(
+    "Failed to set up the local git repository and its 'origin' remote.",
+    { cause },
+  );
+};
+
 const initializeGitRepositoryWithPresenter =
   (presenter: CommandPresenter) => (repository: Repository) => {
     const branchName = "features/scaffold-workspace";
     const git$ = $({
       shell: true,
     });
-    const pushToOrigin = async () => {
+    // `git remote add` is tracked separately from the push so its documented
+    // exit codes (e.g. 3 = remote already exists) surface a specific, actionable
+    // message instead of being misreported as a push failure.
+    const configureRemote = async () => {
       await git$`git init`;
       await git$`git remote add origin ${repository.origin}`;
+    };
+    const pushToOrigin = async () => {
       await git$`git fetch origin main`;
       await git$`git checkout -b ${branchName}`;
       // Terraform creates `main` with an initial README commit.
@@ -292,10 +330,19 @@ const initializeGitRepositoryWithPresenter =
     };
     return trackStep(
       presenter,
-      "Pushing code to GitHub...",
-      pushToOrigin,
-      asError("Failed to push code to GitHub."),
-    ).map(() => ({ branchName, repository }));
+      "Configuring the git remote...",
+      configureRemote,
+      mapGitRemoteAddError,
+    )
+      .andThen(() =>
+        trackStep(
+          presenter,
+          "Pushing code to GitHub...",
+          pushToOrigin,
+          asError("Failed to push code to GitHub."),
+        ),
+      )
+      .map(() => ({ branchName, repository }));
   };
 
 const createPullRequestWithPresenter =


### PR DESCRIPTION
During `dx init`, the publish phase mapped **every** git failure to a single `Failed to push code to GitHub.` message. A failure of `git remote add origin` — which `git remote` reports with the documented exit code `3` when the remote already exists — was therefore misattributed to the push step and gave the user no way to recover.

See https://git-scm.com/docs/git-remote#_exit_status

The successful `init` flow is unchanged (same git commands, same order).

Resolves CES-2155
