### PR TITLE
Enable Nx Docker release project targets wiring

### DIFF
--- a/apps/dx-metrics-import/package.json
+++ b/apps/dx-metrics-import/package.json
@@ -47,7 +47,10 @@
         }
       },
       "nx-release-publish": {
-        "executor": "nx:run-commands"
+        "executor": "nx:run-commands",
+        "options": {
+          "command": "pnpm --filter @pagopa/nx-docker-release-tools exec dx-docker-release-publish-with-latest --project-root {projectRoot}"
+        }
       }
     },
     "release": {

--- a/apps/dx-metrics-import/package.json
+++ b/apps/dx-metrics-import/package.json
@@ -36,5 +36,24 @@
     "tsx": "catalog:",
     "typescript": "catalog:",
     "vitest": "catalog:"
+  },
+  "nx": {
+    "targets": {
+      "docker:build": {
+        "options": {
+          "env": {
+            "DOCKER_BUILD_PLATFORMS": "linux/arm64"
+          }
+        }
+      },
+      "nx-release-publish": {
+        "executor": "nx:run-commands"
+      }
+    },
+    "release": {
+      "docker": {
+        "repositoryName": "pagopa/dx-metrics-import"
+      }
+    }
   }
 }

--- a/apps/dx-metrics/package.json
+++ b/apps/dx-metrics/package.json
@@ -35,5 +35,24 @@
     "tailwindcss": "^4.2.4",
     "typescript": "catalog:",
     "vitest": "catalog:"
+  },
+  "nx": {
+    "targets": {
+      "docker:build": {
+        "options": {
+          "env": {
+            "DOCKER_BUILD_PLATFORMS": "linux/arm64"
+          }
+        }
+      },
+      "nx-release-publish": {
+        "executor": "nx:run-commands"
+      }
+    },
+    "release": {
+      "docker": {
+        "repositoryName": "pagopa/dx-metrics"
+      }
+    }
   }
 }

--- a/apps/dx-metrics/package.json
+++ b/apps/dx-metrics/package.json
@@ -46,7 +46,10 @@
         }
       },
       "nx-release-publish": {
-        "executor": "nx:run-commands"
+        "executor": "nx:run-commands",
+        "options": {
+          "command": "pnpm --filter @pagopa/nx-docker-release-tools exec dx-docker-release-publish-with-latest --project-root {projectRoot}"
+        }
       }
     },
     "release": {

--- a/apps/mcpserver/Dockerfile
+++ b/apps/mcpserver/Dockerfile
@@ -1,4 +1,4 @@
-FROM public.ecr.aws/docker/library/node:24-alpine@sha256:2bdb65ed1dab192432bc31c95f94155ca5ad7fc1392fb7eb7526ab682fa5bf14 AS base
+FROM --platform=$BUILDPLATFORM public.ecr.aws/docker/library/node:24-alpine@sha256:2bdb65ed1dab192432bc31c95f94155ca5ad7fc1392fb7eb7526ab682fa5bf14 AS base
 # 1. Enable pnpm
 RUN corepack enable
 
@@ -15,7 +15,7 @@ COPY ./packages ./packages
 # 5. Install ALL dependencies for mcpserver and its workspace dependencies
 RUN pnpm install --filter @pagopa/dx-mcpserver...
 # 6. Build the mcpserver app
-RUN pnpm nx build @pagopa/dx-mcpserver
+RUN NX_DAEMON=false pnpm nx build @pagopa/dx-mcpserver
 # 7. Prune development-only dependencies for the final image
 RUN pnpm --filter @pagopa/dx-mcpserver deploy --legacy --prod /app/deploy
 

--- a/apps/mcpserver/package.json
+++ b/apps/mcpserver/package.json
@@ -45,5 +45,17 @@
     "format": "prettier --write .",
     "format:check": "prettier --check .",
     "version": "node ./scripts/generate-server-manifest.js"
+  },
+  "nx": {
+    "targets": {
+      "nx-release-publish": {
+        "executor": "nx:run-commands"
+      }
+    },
+    "release": {
+      "docker": {
+        "repositoryName": "pagopa/dx-mcpserver"
+      }
+    }
   }
 }

--- a/apps/mcpserver/package.json
+++ b/apps/mcpserver/package.json
@@ -49,7 +49,10 @@
   "nx": {
     "targets": {
       "nx-release-publish": {
-        "executor": "nx:run-commands"
+        "executor": "nx:run-commands",
+        "options": {
+          "command": "pnpm --filter @pagopa/nx-docker-release-tools exec dx-docker-release-publish-with-latest --project-root {projectRoot}"
+        }
       }
     },
     "release": {

--- a/containers/self-hosted-runner/project.json
+++ b/containers/self-hosted-runner/project.json
@@ -3,7 +3,10 @@
   "name": "self-hosted-runner",
   "targets": {
     "nx-release-publish": {
-      "executor": "nx:run-commands"
+      "executor": "nx:run-commands",
+      "options": {
+        "command": "pnpm --filter @pagopa/nx-docker-release-tools exec dx-docker-release-publish-with-latest --project-root {projectRoot}"
+      }
     },
     "docker:build": {
       "options": {

--- a/containers/self-hosted-runner/project.json
+++ b/containers/self-hosted-runner/project.json
@@ -2,8 +2,16 @@
   "$schema": "../../node_modules/nx/schemas/project-schema.json",
   "name": "self-hosted-runner",
   "targets": {
+    "nx-release-publish": {
+      "executor": "nx:run-commands"
+    },
     "docker:build": {
       "options": {
+        "cwd": "containers/self-hosted-runner",
+        "args": [
+          "--tag containers-self-hosted-runner",
+          "-f Dockerfile"
+        ],
         "platform": "linux/amd64"
       }
     }

--- a/infra/modules/azure_app_configuration/tests/apps/all_scenarios/project.json
+++ b/infra/modules/azure_app_configuration/tests/apps/all_scenarios/project.json
@@ -5,9 +5,13 @@
   "description": "Simple application for Terraform E2E tests, which exposes endpoints to test connectivity and integration with App Configuration",
   "private": true,
   "targets": {
+    "nx-release-publish": {
+      "executor": "nx:run-commands"
+    },
     "docker:build": {
+      "command": "docker build -f ../Dockerfile {args} .",
       "options": {
-        "platform": "linux/amd64,linux/arm64"
+        "cwd": "infra/modules/azure_app_configuration/tests/apps/all_scenarios/src"
       }
     },
     "docker:run": {

--- a/infra/modules/azure_app_configuration/tests/apps/all_scenarios/project.json
+++ b/infra/modules/azure_app_configuration/tests/apps/all_scenarios/project.json
@@ -6,7 +6,10 @@
   "private": true,
   "targets": {
     "nx-release-publish": {
-      "executor": "nx:run-commands"
+      "executor": "nx:run-commands",
+      "options": {
+        "command": "pnpm --filter @pagopa/nx-docker-release-tools exec dx-docker-release-publish-with-latest --project-root {projectRoot}"
+      }
     },
     "docker:build": {
       "command": "docker build -f ../Dockerfile {args} .",

--- a/infra/modules/azure_cosmos_account/tests/apps/network_access/project.json
+++ b/infra/modules/azure_cosmos_account/tests/apps/network_access/project.json
@@ -5,9 +5,13 @@
   "description": "Simple application for Terraform E2E tests, which exposes a single HTTP endpoint to test connectivity to Cosmos DB",
   "private": true,
   "targets": {
+    "nx-release-publish": {
+      "executor": "nx:run-commands"
+    },
     "docker:build": {
+      "command": "docker build -f ../Dockerfile {args} .",
       "options": {
-        "platform": "linux/amd64,linux/arm64"
+        "cwd": "infra/modules/azure_cosmos_account/tests/apps/network_access/src"
       }
     },
     "docker:run": {

--- a/infra/modules/azure_cosmos_account/tests/apps/network_access/project.json
+++ b/infra/modules/azure_cosmos_account/tests/apps/network_access/project.json
@@ -6,7 +6,10 @@
   "private": true,
   "targets": {
     "nx-release-publish": {
-      "executor": "nx:run-commands"
+      "executor": "nx:run-commands",
+      "options": {
+        "command": "pnpm --filter @pagopa/nx-docker-release-tools exec dx-docker-release-publish-with-latest --project-root {projectRoot}"
+      }
     },
     "docker:build": {
       "command": "docker build -f ../Dockerfile {args} .",

--- a/infra/modules/azure_merge_roles/tests/apps/blob_rbac_probe/project.json
+++ b/infra/modules/azure_merge_roles/tests/apps/blob_rbac_probe/project.json
@@ -6,7 +6,10 @@
   "private": true,
   "targets": {
     "nx-release-publish": {
-      "executor": "nx:run-commands"
+      "executor": "nx:run-commands",
+      "options": {
+        "command": "pnpm --filter @pagopa/nx-docker-release-tools exec dx-docker-release-publish-with-latest --project-root {projectRoot}"
+      }
     },
     "docker:build": {
       "options": {

--- a/infra/modules/azure_merge_roles/tests/apps/blob_rbac_probe/project.json
+++ b/infra/modules/azure_merge_roles/tests/apps/blob_rbac_probe/project.json
@@ -5,9 +5,16 @@
   "description": "Simple application for Terraform E2E tests, exposing a single HTTP endpoint to verify merged Blob RBAC permissions with managed identity",
   "private": true,
   "targets": {
+    "nx-release-publish": {
+      "executor": "nx:run-commands"
+    },
     "docker:build": {
       "options": {
-        "platform": "linux/amd64,linux/arm64"
+        "cwd": "infra/modules/azure_merge_roles/tests/apps/blob_rbac_probe",
+        "args": [
+          "--tag infra-modules-azure_merge_roles-tests-apps-blob_rbac_probe",
+          "-f Dockerfile"
+        ]
       }
     },
     "docker:run": {


### PR DESCRIPTION
Split PR focused only on project-level target wiring.
- configure `nx-release-publish` per project for Docker release targets
- keep foundation behavior generic and reusable
- align target projects with the dedicated Docker publish helper CLI

Resolves CES-2153
Depends on #1856 