### PR TITLE
Document Nx Docker release project wiring and defaults

### DIFF
--- a/.nx/version-plans/version-plan-1781701252185.md
+++ b/.nx/version-plans/version-plan-1781701252185.md
@@ -1,0 +1,5 @@
+---
+docs: patch
+---
+
+Document docker images release with NX

--- a/apps/website/docs/containers/nx-release-docker.md
+++ b/apps/website/docs/containers/nx-release-docker.md
@@ -1,12 +1,13 @@
 ---
-sidebar_position: 12
+sidebar_position: 2
 ---
 
 # Release Docker images with Nx
 
 This page complements
-[Automate versioning and publishing with Nx](./nx-release.md) and focuses on
-repositories that release Docker images with Nx in the PagoPA organization.
+[Automate versioning and publishing with Nx](../pipelines/nx-release.md) and
+focuses on repositories that release Docker images with Nx in the PagoPA
+organization.
 
 ## When to use this guide
 
@@ -18,7 +19,7 @@ Use this guide if your repository:
 
 ## Prerequisites
 
-- A working Nx release setup (see [Nx Release](./nx-release.md))
+- A working Nx release setup (see [Nx Release](../pipelines/nx-release.md))
 - Docker projects discoverable by Nx (for example via `@nx/docker` plugin)
 - A registry target (for example `ghcr.io`)
 
@@ -173,5 +174,5 @@ Fix:
 
 ## Related documentation
 
-- [Automate versioning and publishing with Nx](./nx-release.md)
+- [Automate versioning and publishing with Nx](../pipelines/nx-release.md)
 - [Version plan guide](../github/pull-requests/version-plan.md)

--- a/apps/website/docs/pipelines/index.md
+++ b/apps/website/docs/pipelines/index.md
@@ -23,7 +23,7 @@ application deployment, and infrastructure automation.
 
 - **[Release with Nx](./nx-release.md)** - Automate versioning and publishing
   for Nx monorepos (recommended)
-- **[Release Docker images with Nx](./nx-release-docker.md)** - Configure and
+- **[Release Docker images with Nx](../containers/nx-release-docker.md)** - Configure and
   troubleshoot Docker image releases in Nx repositories
 - **[Release with Changesets](./release.md)** - Automate versioning and
   publishing with Changesets (legacy)

--- a/apps/website/docs/pipelines/index.md
+++ b/apps/website/docs/pipelines/index.md
@@ -23,6 +23,8 @@ application deployment, and infrastructure automation.
 
 - **[Release with Nx](./nx-release.md)** - Automate versioning and publishing
   for Nx monorepos (recommended)
+- **[Release Docker images with Nx](./nx-release-docker.md)** - Configure and
+  troubleshoot Docker image releases in Nx repositories
 - **[Release with Changesets](./release.md)** - Automate versioning and
   publishing with Changesets (legacy)
 

--- a/apps/website/docs/pipelines/nx-release-docker.md
+++ b/apps/website/docs/pipelines/nx-release-docker.md
@@ -1,0 +1,152 @@
+---
+sidebar_position: 12
+---
+
+# Release Docker images with Nx
+
+This page complements
+[Automate versioning and publishing with Nx](./nx-release.md) and focuses on
+repositories that release Docker images with Nx in the PagoPA organization.
+
+## When to use this guide
+
+Use this guide if your repository:
+
+- uses [Nx Release](https://nx.dev/features/manage-releases) with version plans
+- publishes one or more Docker images
+- uses the DX release workflow based on `release-v2.yaml`
+
+## Prerequisites
+
+- A working Nx release setup (see [Nx Release](./nx-release.md))
+- Docker projects discoverable by Nx (for example via `@nx/docker` plugin)
+- A registry target (for example `ghcr.io`)
+
+For GitHub Container Registry (GHCR), ensure your workflow job includes:
+
+```yaml
+permissions:
+  contents: write
+  id-token: write
+  pull-requests: write
+  packages: write
+```
+
+## Recommended nx.json Docker configuration
+
+Add Docker configuration under `release`:
+
+```json
+{
+  "release": {
+    "versionPlans": true,
+    "projectsRelationship": "independent",
+    "docker": {
+      "registryUrl": "ghcr.io",
+      "versionSchemes": {
+        "production": "{versionActionsVersion}"
+      }
+    }
+  }
+}
+```
+
+### Why `{versionActionsVersion}`
+
+Using `{versionActionsVersion}` aligns Docker image tags with the version
+calculated by Nx version actions, keeping package and image releases coherent.
+
+## Project-level Docker repository name
+
+Define `release.docker.repositoryName` for each Docker project.
+
+If your project uses `package.json`:
+
+```json
+{
+  "nx": {
+    "release": {
+      "docker": {
+        "repositoryName": "pagopa/my-service"
+      }
+    }
+  }
+}
+```
+
+If your project uses `project.json`:
+
+```json
+{
+  "release": {
+    "docker": {
+      "repositoryName": "pagopa/my-service"
+    }
+  }
+}
+```
+
+## Local validation flow
+
+Before pushing release changes, run:
+
+```bash
+pnpm nx release plan
+pnpm nx release --dry-run
+```
+
+For a specific Docker project, also validate build target resolution:
+
+```bash
+pnpm nx run my-project:docker:build
+```
+
+## Troubleshooting
+
+### `invalid reference format` with a trailing colon
+
+Example:
+
+```text
+docker tag apps-my-service ghcr.io/pagopa/my-service:
+```
+
+Cause:
+
+- Docker version resolves to an empty value
+- common when `versionSchemes.production` uses `{versionActionsVersion}` and no
+  effective version value is produced for that project in your local run
+
+Fix:
+
+1. Ensure the project is covered by a version plan
+2. Re-run `pnpm nx release --dry-run` to verify version resolution
+3. Re-run the release workflow locally
+
+### `Could not find tmp/<projectRoot>/.docker-version`
+
+Cause:
+
+- Docker publish step runs without a successful Docker version/tag step
+
+Fix:
+
+1. Ensure release version step executed for the project
+2. Ensure Docker versioning was not skipped due to prior errors
+
+### `lstat ... no such file or directory` during Docker build
+
+Cause:
+
+- custom `cwd` plus root-relative Dockerfile argument mismatch
+
+Fix:
+
+1. If using custom `cwd`, set Dockerfile path coherently (for example
+   `-f Dockerfile` when Dockerfile is inside that `cwd`)
+2. Re-run project Docker build target directly
+
+## Related documentation
+
+- [Automate versioning and publishing with Nx](./nx-release.md)
+- [Version plan guide](../github/pull-requests/version-plan.md)

--- a/apps/website/docs/pipelines/nx-release-docker.md
+++ b/apps/website/docs/pipelines/nx-release-docker.md
@@ -56,18 +56,34 @@ Add Docker configuration under `release`:
 Using `{versionActionsVersion}` aligns Docker image tags with the version
 calculated by Nx version actions, keeping package and image releases coherent.
 
-## Project-level Docker repository name
+## Project-level Docker release configuration
 
-Define `release.docker.repositoryName` for each Docker project.
+Define Docker release metadata for each Docker project:
+
+- `release.docker.repositoryName` (required)
+- `release.docker.registryUrl` (optional override)
+
+If `release.docker.registryUrl` is not set at project level, Nx uses
+`release.docker.registryUrl` from workspace `nx.json` (default `ghcr.io` in DX
+setup).
 
 If your project uses `package.json`:
 
 ```json
 {
   "nx": {
+    "targets": {
+      "nx-release-publish": {
+        "executor": "nx:run-commands",
+        "options": {
+          "command": "pnpm --filter @pagopa/nx-docker-release-tools exec dx-docker-release-publish-with-latest --project-root {projectRoot}"
+        }
+      }
+    },
     "release": {
       "docker": {
-        "repositoryName": "pagopa/my-service"
+        "repositoryName": "pagopa/my-service",
+        "registryUrl": "ghcr.io"
       }
     }
   }
@@ -78,9 +94,18 @@ If your project uses `project.json`:
 
 ```json
 {
+  "targets": {
+    "nx-release-publish": {
+      "executor": "nx:run-commands",
+      "options": {
+        "command": "pnpm --filter @pagopa/nx-docker-release-tools exec dx-docker-release-publish-with-latest --project-root {projectRoot}"
+      }
+    }
+  },
   "release": {
     "docker": {
-      "repositoryName": "pagopa/my-service"
+      "repositoryName": "pagopa/my-service",
+      "registryUrl": "ghcr.io"
     }
   }
 }

--- a/apps/website/docs/pipelines/nx-release.md
+++ b/apps/website/docs/pipelines/nx-release.md
@@ -17,6 +17,14 @@ A reusable GitHub workflow that automates package versioning and publishing for
 [Nx](https://nx.dev) monorepos using
 [Nx Release](https://nx.dev/features/manage-releases) with version plans.
 
+:::tip Publishing Docker images too?
+
+If your Nx repository also publishes Docker images, see
+[Release Docker images with Nx](./nx-release-docker.md) for setup and
+troubleshooting guidance.
+
+:::
+
 ## Features
 
 - ⚠️ Can show a pull request warning when changes need a version plan but none
@@ -290,6 +298,7 @@ Trigger `workflow_dispatch` manually. The action scans all past merged
 
 ## Related Documentation
 
+- [Release Docker images with Nx](./nx-release-docker.md)
 - [Nx Release Documentation](https://nx.dev/features/manage-releases)
 - [Nx Release Plan](https://nx.dev/docs/guides/nx-release/file-based-versioning-version-plans)
 - [Nx Commands](https://nx.dev/docs/reference/nx-commands)

--- a/apps/website/docs/pipelines/nx-release.md
+++ b/apps/website/docs/pipelines/nx-release.md
@@ -20,7 +20,7 @@ A reusable GitHub workflow that automates package versioning and publishing for
 :::tip Publishing Docker images too?
 
 If your Nx repository also publishes Docker images, see
-[Release Docker images with Nx](./nx-release-docker.md) for setup and
+[Release Docker images with Nx](../containers/nx-release-docker.md) for setup and
 troubleshooting guidance.
 
 :::
@@ -298,7 +298,7 @@ Trigger `workflow_dispatch` manually. The action scans all past merged
 
 ## Related Documentation
 
-- [Release Docker images with Nx](./nx-release-docker.md)
+- [Release Docker images with Nx](../containers/nx-release-docker.md)
 - [Nx Release Documentation](https://nx.dev/features/manage-releases)
 - [Nx Release Plan](https://nx.dev/docs/guides/nx-release/file-based-versioning-version-plans)
 - [Nx Commands](https://nx.dev/docs/reference/nx-commands)

--- a/apps/website/sidebars.ts
+++ b/apps/website/sidebars.ts
@@ -243,6 +243,7 @@ const sidebars: SidebarsConfig = {
         { id: "containers/index", label: "Why Containers", type: "doc" },
         "dev-containers/index",
         "containers/docker-image-build",
+        "containers/nx-release-docker",
       ],
       label: "Containers",
       type: "category",


### PR DESCRIPTION
Split PR focused only on documentation updates.
- document explicit `nx-release-publish` command usage
- document project-level registry override and fallback to global `ghcr.io`
- clarify Docker release flow for Nx projects in DX docs

Resolves CES-2154
Depends on https://github.com/pagopa/dx/pull/1856