### PR TITLE
Align Docker deployment workflows with Nx release tags

### DIFF
--- a/.github/workflows/_release-docker-dx-metrics-import-v1.yaml
+++ b/.github/workflows/_release-docker-dx-metrics-import-v1.yaml
@@ -5,6 +5,10 @@ on:
   push:
     branches:
       - main
+    # Path filters are not evaluated for tag pushes.
+    # Trigger image publication on project release tags as well.
+    tags:
+      - "dx-metrics-import@*"
     paths:
       - "apps/dx-metrics-import/package.json"
       - "packages/dx-metrics-core/**"

--- a/.github/workflows/_release-docker-dx-metrics-import-v1.yaml
+++ b/.github/workflows/_release-docker-dx-metrics-import-v1.yaml
@@ -26,6 +26,20 @@ jobs:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
+      - name: Resolve Docker image name from Nx config
+        id: image_name
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          image_name=$(jq -r '.nx.release.docker.repositoryName // empty' apps/dx-metrics-import/package.json)
+          if [[ -z "$image_name" ]]; then
+            echo "::error::Missing nx.release.docker.repositoryName in apps/dx-metrics-import/package.json"
+            exit 1
+          fi
+
+          echo "image_name=$image_name" >> "$GITHUB_OUTPUT"
+
       - name: Docker Build and Push
         uses: pagopa/dx/actions/docker-build-push@main
         env:
@@ -33,7 +47,7 @@ jobs:
         with:
           dockerfile_path: ./apps/dx-metrics-import/Dockerfile
           dockerfile_context: .
-          docker_image_name: pagopa/dx-metrics-import
+          docker_image_name: ${{ steps.image_name.outputs.image_name }}
           docker_image_description: "Scheduled import job for the DX Metrics portal. Fetches GitHub engineering metrics and writes them to PostgreSQL."
           docker_image_authors: PagoPA
           build_platforms: linux/amd64

--- a/.github/workflows/_release-docker-dx-metrics-v1.yaml
+++ b/.github/workflows/_release-docker-dx-metrics-v1.yaml
@@ -5,6 +5,10 @@ on:
   push:
     branches:
       - main
+    # Path filters are not evaluated for tag pushes.
+    # Trigger production deploys on project release tags as well.
+    tags:
+      - "dx-metrics@*"
     paths:
       - "apps/dx-metrics/package.json"
       - "packages/dx-metrics-core/**"

--- a/.github/workflows/_release-docker-dx-metrics-v1.yaml
+++ b/.github/workflows/_release-docker-dx-metrics-v1.yaml
@@ -16,8 +16,32 @@ permissions:
   attestations: write
 
 jobs:
+  resolve-image-name:
+    name: Resolve Docker Image Name
+    runs-on: ubuntu-latest
+    outputs:
+      image_name: ${{ steps.image_name.outputs.image_name }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - name: Resolve Docker image name from Nx config
+        id: image_name
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          image_name=$(jq -r '.nx.release.docker.repositoryName // empty' apps/dx-metrics/package.json)
+          if [[ -z "$image_name" ]]; then
+            echo "::error::Missing nx.release.docker.repositoryName in apps/dx-metrics/package.json"
+            exit 1
+          fi
+
+          echo "image_name=$image_name" >> "$GITHUB_OUTPUT"
+
   deploy:
     name: Deploy DX Metrics as Container App
+    needs: resolve-image-name
     concurrency:
       group: ${{ github.workflow }}-cd
       # Override this configuration to prevent cancelling a running deploy.
@@ -27,7 +51,7 @@ jobs:
     with:
       dockerfile_path: ./apps/dx-metrics/Dockerfile
       dockerfile_context: .
-      docker_image_name: pagopa/dx-metrics
+      docker_image_name: ${{ needs.resolve-image-name.outputs.image_name }}
       docker_image_description: "DX Metrics is a monitoring and analytics service for the PagoPA Developer Experience (DX) team, providing insights into development experience."
       container_app: dx-p-itn-metrics-portal-ca-01
       resource_group_name: dx-p-itn-common-rg-01

--- a/.github/workflows/_release-docker-e2e-appconfiguration.yaml
+++ b/.github/workflows/_release-docker-e2e-appconfiguration.yaml
@@ -21,13 +21,23 @@ jobs:
       id-token: write
       attestations: write
       packages: write
-    env:
-      IMAGE_NAME: "pagopa/e2e-appconfiguration-all-scenarios"
-      IMAGE_TAG: "latest"
-
     steps:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - name: Resolve Docker image name from Nx config
+        id: image_name
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          image_name=$(jq -r '.release.docker.repositoryName // empty' infra/modules/${{ env.MODULE_NAME }}/tests/apps/all_scenarios/project.json)
+          if [[ -z "$image_name" ]]; then
+            echo "::error::Missing release.docker.repositoryName in infra/modules/${{ env.MODULE_NAME }}/tests/apps/all_scenarios/project.json"
+            exit 1
+          fi
+
+          echo "image_name=$image_name" >> "$GITHUB_OUTPUT"
 
       - name: Docker Build and Push
         id: docker_build
@@ -37,7 +47,7 @@ jobs:
         with:
           dockerfile_path: infra/modules/${{ env.MODULE_NAME }}/tests/apps/all_scenarios/Dockerfile
           dockerfile_context: infra/modules/${{ env.MODULE_NAME }}/tests/apps/all_scenarios/src
-          docker_image_name: ${{ env.IMAGE_NAME }}
+          docker_image_name: ${{ steps.image_name.outputs.image_name }}
           docker_image_description: "Web app which exposes endpoints to access App Configuration. Used for E2E tests of the Azure App Configuration Terraform module."
           docker_image_authors: "PagoPA"
           build_platforms: "linux/amd64,linux/arm64"

--- a/.github/workflows/_release-docker-e2e-appconfiguration.yaml
+++ b/.github/workflows/_release-docker-e2e-appconfiguration.yaml
@@ -6,6 +6,10 @@ on:
   push:
     branches:
       - main
+    # Path filters are not evaluated for tag pushes.
+    # Trigger image publication on project release tags as well.
+    tags:
+      - "app_configuration_tests_all_scenarios@*"
     paths:
       - "infra/modules/azure_app_configuration/tests/apps/all_scenarios/**"
 

--- a/.github/workflows/_release-docker-e2e-azure-merge-roles-blob-rbac.yaml
+++ b/.github/workflows/_release-docker-e2e-azure-merge-roles-blob-rbac.yaml
@@ -6,6 +6,10 @@ on:
   push:
     branches:
       - main
+    # Path filters are not evaluated for tag pushes.
+    # Trigger image publication on project release tags as well.
+    tags:
+      - "azure_merge_roles_tests_blob_rbac_probe@*"
     paths:
       - "infra/modules/azure_merge_roles/tests/apps/blob_rbac_probe/**"
 

--- a/.github/workflows/_release-docker-e2e-azure-merge-roles-blob-rbac.yaml
+++ b/.github/workflows/_release-docker-e2e-azure-merge-roles-blob-rbac.yaml
@@ -18,12 +18,23 @@ jobs:
       id-token: write
       attestations: write
       packages: write
-    env:
-      IMAGE_NAME: "pagopa/e2e-azure-merge-roles-blob-rbac"
-
     steps:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - name: Resolve Docker image name from Nx config
+        id: image_name
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          image_name=$(jq -r '.release.docker.repositoryName // empty' infra/modules/azure_merge_roles/tests/apps/blob_rbac_probe/project.json)
+          if [[ -z "$image_name" ]]; then
+            echo "::error::Missing release.docker.repositoryName in infra/modules/azure_merge_roles/tests/apps/blob_rbac_probe/project.json"
+            exit 1
+          fi
+
+          echo "image_name=$image_name" >> "$GITHUB_OUTPUT"
 
       - name: Docker Build and Push
         id: docker_build
@@ -33,7 +44,7 @@ jobs:
         with:
           dockerfile_path: infra/modules/azure_merge_roles/tests/apps/blob_rbac_probe/Dockerfile
           dockerfile_context: infra/modules/azure_merge_roles/tests/apps/blob_rbac_probe
-          docker_image_name: ${{ env.IMAGE_NAME }}
+          docker_image_name: ${{ steps.image_name.outputs.image_name }}
           docker_image_description: "Web app which exposes data-plane and control-plane
             endpoints to probe Azure Storage RBAC. Used for E2E tests of the
             Azure Merge Roles Terraform module."

--- a/.github/workflows/_release-docker-e2e-cosmos-networkaccess.yaml
+++ b/.github/workflows/_release-docker-e2e-cosmos-networkaccess.yaml
@@ -18,13 +18,23 @@ jobs:
       id-token: write
       attestations: write
       packages: write
-    env:
-      IMAGE_NAME: "pagopa/e2e-cosmos-network-access"
-      IMAGE_TAG: "latest"
-
     steps:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - name: Resolve Docker image name from Nx config
+        id: image_name
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          image_name=$(jq -r '.release.docker.repositoryName // empty' infra/modules/azure_cosmos_account/tests/apps/network_access/project.json)
+          if [[ -z "$image_name" ]]; then
+            echo "::error::Missing release.docker.repositoryName in infra/modules/azure_cosmos_account/tests/apps/network_access/project.json"
+            exit 1
+          fi
+
+          echo "image_name=$image_name" >> "$GITHUB_OUTPUT"
 
       - name: Docker Build and Push
         id: docker_build
@@ -34,7 +44,7 @@ jobs:
         with:
           dockerfile_path: infra/modules/azure_cosmos_account/tests/apps/network_access/Dockerfile
           dockerfile_context: infra/modules/azure_cosmos_account/tests/apps/network_access/src
-          docker_image_name: ${{ env.IMAGE_NAME }}
+          docker_image_name: ${{ steps.image_name.outputs.image_name }}
           docker_image_description: "Web app which exposes a single endpoint to probe Azure Cosmos DB. Used for E2E tests of the Azure Cosmos DB Terraform module."
           docker_image_authors: "PagoPA"
           build_platforms: "linux/amd64,linux/arm64"

--- a/.github/workflows/_release-docker-e2e-cosmos-networkaccess.yaml
+++ b/.github/workflows/_release-docker-e2e-cosmos-networkaccess.yaml
@@ -6,6 +6,10 @@ on:
   push:
     branches:
       - main
+    # Path filters are not evaluated for tag pushes.
+    # Trigger image publication on project release tags as well.
+    tags:
+      - "cosmos_db_tests_network_access@*"
     paths:
       - "infra/modules/azure_cosmos_account/tests/apps/network_access/**"
 

--- a/.github/workflows/_validate-docker-e2e-cosmos-networkaccess.yaml
+++ b/.github/workflows/_validate-docker-e2e-cosmos-networkaccess.yaml
@@ -19,12 +19,24 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
-    env:
-      IMAGE_NAME: "pagopa/e2e-cosmos-network-access"
 
     steps:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - name: Resolve Docker image name from Nx config
+        id: image_name
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          image_name=$(jq -r '.release.docker.repositoryName // empty' infra/modules/azure_cosmos_account/tests/apps/network_access/project.json)
+          if [[ -z "$image_name" ]]; then
+            echo "::error::Missing release.docker.repositoryName in infra/modules/azure_cosmos_account/tests/apps/network_access/project.json"
+            exit 1
+          fi
+
+          echo "image_name=$image_name" >> "$GITHUB_OUTPUT"
 
       - name: Docker Build
         id: docker_build
@@ -34,7 +46,7 @@ jobs:
         with:
           dockerfile_path: infra/modules/azure_cosmos_account/tests/apps/network_access/Dockerfile
           dockerfile_context: infra/modules/azure_cosmos_account/tests/apps/network_access/src
-          docker_image_name: ${{ env.IMAGE_NAME }}
+          docker_image_name: ${{ steps.image_name.outputs.image_name }}
           docker_image_description: "Web app which exposes a single endpoint to probe Azure Cosmos DB. Used for E2E tests of the Azure Cosmos DB Terraform module."
           docker_image_authors: "PagoPA"
           build_platforms: "linux/amd64,linux/arm64"

--- a/.github/workflows/release-azure-containerapp-v1.yaml
+++ b/.github/workflows/release-azure-containerapp-v1.yaml
@@ -35,6 +35,11 @@ on:
         required: false
         default: linux/amd64
         description: Image runtime platform, supports multiple comma-separated values
+      docker_registry:
+        type: string
+        required: false
+        default: ghcr
+        description: Container registry used by docker-build-push (ghcr or ecr)
       container_app:
         type: string
         required: true
@@ -59,6 +64,8 @@ jobs:
   build:
     name: Build Docker Image
     runs-on: ubuntu-latest
+    outputs:
+      registry_uri: ${{ steps.docker_build.outputs.registry_uri }}
     permissions:
       contents: read
       id-token: write
@@ -75,6 +82,7 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
+          registry: ${{ inputs.docker_registry }}
           dockerfile_path: ${{ inputs.dockerfile_path }}
           dockerfile_context: ${{ inputs.dockerfile_context }}
           docker_image_name: ${{ env.IMAGE_NAME }}
@@ -99,6 +107,7 @@ jobs:
       GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       CONTAINER_APP_NAME: ${{ inputs.container_app }}
       RESOURCE_GROUP_NAME: ${{ inputs.resource_group_name }}
+      REGISTRY_URI: ${{ needs.build.outputs.registry_uri }}
 
     steps:
       - name: Checkout
@@ -169,7 +178,7 @@ jobs:
 
           new_revision=$(az containerapp revision copy \
             --name "$CONTAINER_APP_NAME" \
-            --image "ghcr.io/$IMAGE_NAME:sha-$SHORT_SHA" \
+            --image "$REGISTRY_URI/$IMAGE_NAME:sha-$SHORT_SHA" \
             --from-revision "$CURRENT_REVISION" \
             --revision-suffix "$SUFFIX" \
             --query "properties.latestRevisionName" \

--- a/.github/workflows/release-azure-containerapp-v1.yaml
+++ b/.github/workflows/release-azure-containerapp-v1.yaml
@@ -35,11 +35,6 @@ on:
         required: false
         default: linux/amd64
         description: Image runtime platform, supports multiple comma-separated values
-      docker_registry:
-        type: string
-        required: false
-        default: ghcr
-        description: Container registry used by docker-build-push (ghcr or ecr)
       container_app:
         type: string
         required: true
@@ -64,8 +59,6 @@ jobs:
   build:
     name: Build Docker Image
     runs-on: ubuntu-latest
-    outputs:
-      registry_uri: ${{ steps.docker_build.outputs.registry_uri }}
     permissions:
       contents: read
       id-token: write
@@ -82,7 +75,6 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
-          registry: ${{ inputs.docker_registry }}
           dockerfile_path: ${{ inputs.dockerfile_path }}
           dockerfile_context: ${{ inputs.dockerfile_context }}
           docker_image_name: ${{ env.IMAGE_NAME }}
@@ -107,7 +99,6 @@ jobs:
       GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       CONTAINER_APP_NAME: ${{ inputs.container_app }}
       RESOURCE_GROUP_NAME: ${{ inputs.resource_group_name }}
-      REGISTRY_URI: ${{ needs.build.outputs.registry_uri }}
 
     steps:
       - name: Checkout
@@ -178,7 +169,7 @@ jobs:
 
           new_revision=$(az containerapp revision copy \
             --name "$CONTAINER_APP_NAME" \
-            --image "$REGISTRY_URI/$IMAGE_NAME:sha-$SHORT_SHA" \
+            --image "ghcr.io/$IMAGE_NAME:sha-$SHORT_SHA" \
             --from-revision "$CURRENT_REVISION" \
             --revision-suffix "$SUFFIX" \
             --query "properties.latestRevisionName" \

--- a/apps/dx-metrics-import/package.json
+++ b/apps/dx-metrics-import/package.json
@@ -47,7 +47,10 @@
         }
       },
       "nx-release-publish": {
-        "executor": "nx:run-commands"
+        "executor": "nx:run-commands",
+        "options": {
+          "command": "pnpm --filter @pagopa/nx-docker-release-tools exec dx-docker-release-publish-with-latest --project-root {projectRoot}"
+        }
       }
     },
     "release": {

--- a/apps/dx-metrics-import/package.json
+++ b/apps/dx-metrics-import/package.json
@@ -36,5 +36,24 @@
     "tsx": "catalog:",
     "typescript": "catalog:",
     "vitest": "catalog:"
+  },
+  "nx": {
+    "targets": {
+      "docker:build": {
+        "options": {
+          "env": {
+            "DOCKER_BUILD_PLATFORMS": "linux/arm64"
+          }
+        }
+      },
+      "nx-release-publish": {
+        "executor": "nx:run-commands"
+      }
+    },
+    "release": {
+      "docker": {
+        "repositoryName": "pagopa/dx-metrics-import"
+      }
+    }
   }
 }

--- a/apps/dx-metrics/package.json
+++ b/apps/dx-metrics/package.json
@@ -35,5 +35,24 @@
     "tailwindcss": "^4.2.4",
     "typescript": "catalog:",
     "vitest": "catalog:"
+  },
+  "nx": {
+    "targets": {
+      "docker:build": {
+        "options": {
+          "env": {
+            "DOCKER_BUILD_PLATFORMS": "linux/arm64"
+          }
+        }
+      },
+      "nx-release-publish": {
+        "executor": "nx:run-commands"
+      }
+    },
+    "release": {
+      "docker": {
+        "repositoryName": "pagopa/dx-metrics"
+      }
+    }
   }
 }

--- a/apps/dx-metrics/package.json
+++ b/apps/dx-metrics/package.json
@@ -46,7 +46,10 @@
         }
       },
       "nx-release-publish": {
-        "executor": "nx:run-commands"
+        "executor": "nx:run-commands",
+        "options": {
+          "command": "pnpm --filter @pagopa/nx-docker-release-tools exec dx-docker-release-publish-with-latest --project-root {projectRoot}"
+        }
       }
     },
     "release": {

--- a/apps/mcpserver/Dockerfile
+++ b/apps/mcpserver/Dockerfile
@@ -1,4 +1,4 @@
-FROM public.ecr.aws/docker/library/node:24-alpine@sha256:2bdb65ed1dab192432bc31c95f94155ca5ad7fc1392fb7eb7526ab682fa5bf14 AS base
+FROM --platform=$BUILDPLATFORM public.ecr.aws/docker/library/node:24-alpine@sha256:2bdb65ed1dab192432bc31c95f94155ca5ad7fc1392fb7eb7526ab682fa5bf14 AS base
 # 1. Enable pnpm
 RUN corepack enable
 
@@ -15,7 +15,7 @@ COPY ./packages ./packages
 # 5. Install ALL dependencies for mcpserver and its workspace dependencies
 RUN pnpm install --filter @pagopa/dx-mcpserver...
 # 6. Build the mcpserver app
-RUN pnpm nx build @pagopa/dx-mcpserver
+RUN NX_DAEMON=false pnpm nx build @pagopa/dx-mcpserver
 # 7. Prune development-only dependencies for the final image
 RUN pnpm --filter @pagopa/dx-mcpserver deploy --legacy --prod /app/deploy
 

--- a/apps/mcpserver/package.json
+++ b/apps/mcpserver/package.json
@@ -45,5 +45,17 @@
     "format": "prettier --write .",
     "format:check": "prettier --check .",
     "version": "node ./scripts/generate-server-manifest.js"
+  },
+  "nx": {
+    "targets": {
+      "nx-release-publish": {
+        "executor": "nx:run-commands"
+      }
+    },
+    "release": {
+      "docker": {
+        "repositoryName": "pagopa/dx-mcpserver"
+      }
+    }
   }
 }

--- a/apps/mcpserver/package.json
+++ b/apps/mcpserver/package.json
@@ -49,7 +49,10 @@
   "nx": {
     "targets": {
       "nx-release-publish": {
-        "executor": "nx:run-commands"
+        "executor": "nx:run-commands",
+        "options": {
+          "command": "pnpm --filter @pagopa/nx-docker-release-tools exec dx-docker-release-publish-with-latest --project-root {projectRoot}"
+        }
       }
     },
     "release": {

--- a/containers/self-hosted-runner/project.json
+++ b/containers/self-hosted-runner/project.json
@@ -3,7 +3,10 @@
   "name": "self-hosted-runner",
   "targets": {
     "nx-release-publish": {
-      "executor": "nx:run-commands"
+      "executor": "nx:run-commands",
+      "options": {
+        "command": "pnpm --filter @pagopa/nx-docker-release-tools exec dx-docker-release-publish-with-latest --project-root {projectRoot}"
+      }
     },
     "docker:build": {
       "options": {

--- a/containers/self-hosted-runner/project.json
+++ b/containers/self-hosted-runner/project.json
@@ -2,8 +2,16 @@
   "$schema": "../../node_modules/nx/schemas/project-schema.json",
   "name": "self-hosted-runner",
   "targets": {
+    "nx-release-publish": {
+      "executor": "nx:run-commands"
+    },
     "docker:build": {
       "options": {
+        "cwd": "containers/self-hosted-runner",
+        "args": [
+          "--tag containers-self-hosted-runner",
+          "-f Dockerfile"
+        ],
         "platform": "linux/amd64"
       }
     }

--- a/infra/modules/azure_app_configuration/tests/apps/all_scenarios/project.json
+++ b/infra/modules/azure_app_configuration/tests/apps/all_scenarios/project.json
@@ -5,9 +5,13 @@
   "description": "Simple application for Terraform E2E tests, which exposes endpoints to test connectivity and integration with App Configuration",
   "private": true,
   "targets": {
+    "nx-release-publish": {
+      "executor": "nx:run-commands"
+    },
     "docker:build": {
+      "command": "docker build -f ../Dockerfile {args} .",
       "options": {
-        "platform": "linux/amd64,linux/arm64"
+        "cwd": "infra/modules/azure_app_configuration/tests/apps/all_scenarios/src"
       }
     },
     "docker:run": {

--- a/infra/modules/azure_app_configuration/tests/apps/all_scenarios/project.json
+++ b/infra/modules/azure_app_configuration/tests/apps/all_scenarios/project.json
@@ -4,6 +4,11 @@
   "version": "0.0.0",
   "description": "Simple application for Terraform E2E tests, which exposes endpoints to test connectivity and integration with App Configuration",
   "private": true,
+  "release": {
+    "docker": {
+      "repositoryName": "pagopa/e2e-appconfiguration-all-scenarios"
+    }
+  },
   "targets": {
     "nx-release-publish": {
       "executor": "nx:run-commands",

--- a/infra/modules/azure_app_configuration/tests/apps/all_scenarios/project.json
+++ b/infra/modules/azure_app_configuration/tests/apps/all_scenarios/project.json
@@ -6,7 +6,10 @@
   "private": true,
   "targets": {
     "nx-release-publish": {
-      "executor": "nx:run-commands"
+      "executor": "nx:run-commands",
+      "options": {
+        "command": "pnpm --filter @pagopa/nx-docker-release-tools exec dx-docker-release-publish-with-latest --project-root {projectRoot}"
+      }
     },
     "docker:build": {
       "command": "docker build -f ../Dockerfile {args} .",

--- a/infra/modules/azure_cosmos_account/tests/apps/network_access/project.json
+++ b/infra/modules/azure_cosmos_account/tests/apps/network_access/project.json
@@ -5,9 +5,13 @@
   "description": "Simple application for Terraform E2E tests, which exposes a single HTTP endpoint to test connectivity to Cosmos DB",
   "private": true,
   "targets": {
+    "nx-release-publish": {
+      "executor": "nx:run-commands"
+    },
     "docker:build": {
+      "command": "docker build -f ../Dockerfile {args} .",
       "options": {
-        "platform": "linux/amd64,linux/arm64"
+        "cwd": "infra/modules/azure_cosmos_account/tests/apps/network_access/src"
       }
     },
     "docker:run": {

--- a/infra/modules/azure_cosmos_account/tests/apps/network_access/project.json
+++ b/infra/modules/azure_cosmos_account/tests/apps/network_access/project.json
@@ -4,6 +4,11 @@
   "version": "0.1.0",
   "description": "Simple application for Terraform E2E tests, which exposes a single HTTP endpoint to test connectivity to Cosmos DB",
   "private": true,
+  "release": {
+    "docker": {
+      "repositoryName": "pagopa/e2e-cosmos-network-access"
+    }
+  },
   "targets": {
     "nx-release-publish": {
       "executor": "nx:run-commands",

--- a/infra/modules/azure_cosmos_account/tests/apps/network_access/project.json
+++ b/infra/modules/azure_cosmos_account/tests/apps/network_access/project.json
@@ -6,7 +6,10 @@
   "private": true,
   "targets": {
     "nx-release-publish": {
-      "executor": "nx:run-commands"
+      "executor": "nx:run-commands",
+      "options": {
+        "command": "pnpm --filter @pagopa/nx-docker-release-tools exec dx-docker-release-publish-with-latest --project-root {projectRoot}"
+      }
     },
     "docker:build": {
       "command": "docker build -f ../Dockerfile {args} .",

--- a/infra/modules/azure_merge_roles/tests/apps/blob_rbac_probe/project.json
+++ b/infra/modules/azure_merge_roles/tests/apps/blob_rbac_probe/project.json
@@ -6,7 +6,10 @@
   "private": true,
   "targets": {
     "nx-release-publish": {
-      "executor": "nx:run-commands"
+      "executor": "nx:run-commands",
+      "options": {
+        "command": "pnpm --filter @pagopa/nx-docker-release-tools exec dx-docker-release-publish-with-latest --project-root {projectRoot}"
+      }
     },
     "docker:build": {
       "options": {

--- a/infra/modules/azure_merge_roles/tests/apps/blob_rbac_probe/project.json
+++ b/infra/modules/azure_merge_roles/tests/apps/blob_rbac_probe/project.json
@@ -4,6 +4,11 @@
   "version": "0.1.0",
   "description": "Simple application for Terraform E2E tests, exposing a single HTTP endpoint to verify merged Blob RBAC permissions with managed identity",
   "private": true,
+  "release": {
+    "docker": {
+      "repositoryName": "pagopa/e2e-azure-merge-roles-blob-rbac"
+    }
+  },
   "targets": {
     "nx-release-publish": {
       "executor": "nx:run-commands",

--- a/infra/modules/azure_merge_roles/tests/apps/blob_rbac_probe/project.json
+++ b/infra/modules/azure_merge_roles/tests/apps/blob_rbac_probe/project.json
@@ -5,9 +5,16 @@
   "description": "Simple application for Terraform E2E tests, exposing a single HTTP endpoint to verify merged Blob RBAC permissions with managed identity",
   "private": true,
   "targets": {
+    "nx-release-publish": {
+      "executor": "nx:run-commands"
+    },
     "docker:build": {
       "options": {
-        "platform": "linux/amd64,linux/arm64"
+        "cwd": "infra/modules/azure_merge_roles/tests/apps/blob_rbac_probe",
+        "args": [
+          "--tag infra-modules-azure_merge_roles-tests-apps-blob_rbac_probe",
+          "-f Dockerfile"
+        ]
       }
     },
     "docker:run": {


### PR DESCRIPTION
## Summary
- align deployment and publish workflows with Nx Docker project configuration
- resolve Docker image names from project config instead of hardcoded values
- start Docker release workflows on project release tags (`{projectName}@{version}`)
- add missing `release.docker.repositoryName` in E2E project configs

## Scope
Split PR focused on deployment workflow alignment and project config consistency.
Depends on https://github.com/pagopa/dx/pull/1856 #1860 