### PR TITLE
Resolve CLI presenter from CI env and output flag

### DIFF
--- a/.nx/version-plans/version-plan-1781787929301.md
+++ b/.nx/version-plans/version-plan-1781787929301.md
@@ -1,0 +1,5 @@
+---
+'@pagopa/dx-cli': patch
+---
+
+Resolve the CLI output presenter from the CI environment and the `--output` flag instead of constructing it in every command. In a non-interactive (CI) environment the CLI now emits JSON automatically; otherwise the `--output` flag decides, defaulting to text.

--- a/apps/cli/src/__tests__/index.test.ts
+++ b/apps/cli/src/__tests__/index.test.ts
@@ -1,0 +1,94 @@
+/**
+ * Tests for CLI runtime wiring in the entrypoint.
+ *
+ * Verifies that `runCli` parses the environment once and passes the validated
+ * `CliEnv` to `makeCli`, so commands can resolve their presenter from it.
+ */
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const mocks = vi.hoisted(() => {
+  const parse = vi.fn();
+
+  return {
+    applyCodemodById: vi.fn(),
+    configure: vi.fn(async () => undefined),
+    getConfig: vi.fn(() => ({})),
+    getConsoleSink: vi.fn(() => () => undefined),
+    listCodemods: vi.fn(),
+    makeCli: vi.fn(
+      (...args: [unknown, unknown, unknown, { CI: boolean }, string]) => {
+        void args;
+        return { parse };
+      },
+    ),
+    makePackageJsonReader: vi.fn(() => ({})),
+    makeRepositoryReader: vi.fn(() => ({})),
+    parse,
+  };
+});
+
+vi.mock("@logtape/logtape", () => ({
+  configure: mocks.configure,
+  getConsoleSink: mocks.getConsoleSink,
+}));
+vi.mock("../adapters/codemods/index.js", () => ({ default: {} }));
+vi.mock("../adapters/commander/index.js", () => ({
+  makeCli: mocks.makeCli,
+}));
+vi.mock("../adapters/node/package-json.js", () => ({
+  makePackageJsonReader: mocks.makePackageJsonReader,
+}));
+vi.mock("../adapters/node/repository.js", () => ({
+  makeRepositoryReader: mocks.makeRepositoryReader,
+}));
+vi.mock("../config.js", () => ({ getConfig: mocks.getConfig }));
+vi.mock("../domain/info.js", () => ({
+  getInfo: vi.fn(() => vi.fn()),
+}));
+vi.mock("../use-cases/apply-codemod.js", () => ({
+  applyCodemodById: mocks.applyCodemodById,
+}));
+vi.mock("../use-cases/list-codemods.js", () => ({
+  listCodemods: mocks.listCodemods,
+}));
+
+import { runCli } from "../index.js";
+
+const getEnv = () => mocks.makeCli.mock.calls[0]?.[3];
+
+describe("runCli", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.unstubAllEnvs();
+    // Neutralize any ambient CI value so tests control it explicitly.
+    vi.stubEnv("CI", undefined);
+  });
+
+  afterEach(() => {
+    vi.unstubAllEnvs();
+  });
+
+  it("parses CI=true into the env passed to makeCli", async () => {
+    vi.stubEnv("CI", "true");
+
+    await runCli("0.0.0");
+
+    expect(getEnv()?.CI).toBe(true);
+  });
+
+  it("defaults CI to false when the variable is not set", async () => {
+    vi.stubEnv("CI", undefined);
+
+    await runCli("0.0.0");
+
+    expect(getEnv()?.CI).toBe(false);
+  });
+
+  it("does not model the presenter as a use case", async () => {
+    await runCli("0.0.0");
+
+    expect(mocks.makeCli.mock.calls[0]?.[2]).not.toHaveProperty(
+      "presenterRuntime",
+    );
+  });
+});

--- a/apps/cli/src/adapters/commander/__tests__/global-options.test.ts
+++ b/apps/cli/src/adapters/commander/__tests__/global-options.test.ts
@@ -12,6 +12,7 @@ const makeProgram = (argv: string[]): Command => {
     mock<Dependencies>(),
     mock<Config>(),
     mock<CliDependencies>(),
+    { CI: false },
     "0.0.0",
   );
   program.exitOverride().configureOutput({

--- a/apps/cli/src/adapters/commander/__tests__/index.test.ts
+++ b/apps/cli/src/adapters/commander/__tests__/index.test.ts
@@ -1,0 +1,76 @@
+/**
+ * Tests for makeCli wiring.
+ *
+ * Verifies that the parsed CliEnv is forwarded to every command factory so
+ * each command can resolve its own presenter (CI vs --output) at action time.
+ */
+import { Command } from "commander";
+import { describe, expect, it, vi } from "vitest";
+import { mock } from "vitest-mock-extended";
+
+import type { Config } from "../../../config.js";
+import type { Dependencies } from "../../../domain/dependencies.js";
+import type { CliEnv } from "../env.js";
+
+const commandFactoryMocks = vi.hoisted(() => ({
+  makeAddCommand: vi.fn(() => new Command("add")),
+  makeCodemodCommand: vi.fn(() => new Command("codemod")),
+  makeDoctorCommand: vi.fn(() => new Command("doctor")),
+  makeInfoCommand: vi.fn(() => new Command("info")),
+  makeInitCommand: vi.fn(() => new Command("init")),
+  makeSavemoneyCommand: vi.fn(() => new Command("savemoney")),
+}));
+
+vi.mock("../commands/add.js", () => ({
+  makeAddCommand: commandFactoryMocks.makeAddCommand,
+}));
+vi.mock("../commands/codemod.js", () => ({
+  makeCodemodCommand: commandFactoryMocks.makeCodemodCommand,
+}));
+vi.mock("../commands/doctor.js", () => ({
+  makeDoctorCommand: commandFactoryMocks.makeDoctorCommand,
+}));
+vi.mock("../commands/info.js", () => ({
+  makeInfoCommand: commandFactoryMocks.makeInfoCommand,
+}));
+vi.mock("../commands/init.js", () => ({
+  makeInitCommand: commandFactoryMocks.makeInitCommand,
+}));
+vi.mock("../commands/savemoney.js", () => ({
+  makeSavemoneyCommand: commandFactoryMocks.makeSavemoneyCommand,
+}));
+
+import { type CliDependencies, makeCli } from "../index.js";
+
+describe("makeCli", () => {
+  it("forwards the parsed env to each command factory", () => {
+    const dependencies = mock<Dependencies>();
+    const config = mock<Config>();
+    const cliDependencies = mock<CliDependencies>();
+    const env: CliEnv = { CI: false };
+
+    makeCli(dependencies, config, cliDependencies, env, "0.0.0");
+
+    expect(commandFactoryMocks.makeDoctorCommand).toHaveBeenCalledWith(
+      dependencies,
+      config,
+      env,
+    );
+    expect(commandFactoryMocks.makeCodemodCommand).toHaveBeenCalledWith(
+      cliDependencies,
+      env,
+    );
+    expect(commandFactoryMocks.makeInitCommand).toHaveBeenCalledWith(
+      dependencies.requireGitHubAuth,
+      env,
+    );
+    expect(commandFactoryMocks.makeInfoCommand).toHaveBeenCalledWith(
+      dependencies,
+      env,
+    );
+    expect(commandFactoryMocks.makeAddCommand).toHaveBeenCalledWith(
+      dependencies.requireGitHubAuth,
+      env,
+    );
+  });
+});

--- a/apps/cli/src/adapters/commander/commands/__tests__/add-json.test.ts
+++ b/apps/cli/src/adapters/commander/commands/__tests__/add-json.test.ts
@@ -96,7 +96,7 @@ describe("add environment command json output", () => {
 
     const program = new Command()
       .option("--output <mode>", "Output mode", "json")
-      .addCommand(makeAddCommand(requireGitHubAuth));
+      .addCommand(makeAddCommand(requireGitHubAuth, { CI: false }));
 
     await program.parseAsync([
       "node",

--- a/apps/cli/src/adapters/commander/commands/__tests__/codemod.test.ts
+++ b/apps/cli/src/adapters/commander/commands/__tests__/codemod.test.ts
@@ -37,11 +37,14 @@ const runCodemodCommand = async (
   args: string[],
   overrides: CodemodCommandOverrides = {},
 ) => {
-  const command = makeCodemodCommand({
-    applyCodemodById:
-      overrides.applyCodemodById ?? makeSuccessfulApplyCodemodById(),
-    listCodemods: overrides.listCodemods ?? vi.fn(() => okAsync(codemods)),
-  });
+  const command = makeCodemodCommand(
+    {
+      applyCodemodById:
+        overrides.applyCodemodById ?? makeSuccessfulApplyCodemodById(),
+      listCodemods: overrides.listCodemods ?? vi.fn(() => okAsync(codemods)),
+    },
+    { CI: false },
+  );
   const program = new Command()
     .exitOverride()
     .option("--output <mode>", "Output mode", "text")

--- a/apps/cli/src/adapters/commander/commands/__tests__/doctor.test.ts
+++ b/apps/cli/src/adapters/commander/commands/__tests__/doctor.test.ts
@@ -62,7 +62,9 @@ const captureStdout = (): string[] => {
 };
 
 const runDoctorCommand = async (output: "json" | "text") => {
-  const command = makeDoctorCommand(makeDependencies(), getConfig());
+  const command = makeDoctorCommand(makeDependencies(), getConfig(), {
+    CI: false,
+  });
   const program = new Command()
     .exitOverride()
     .option("--output <mode>", "Output mode", output)

--- a/apps/cli/src/adapters/commander/commands/__tests__/info.test.ts
+++ b/apps/cli/src/adapters/commander/commands/__tests__/info.test.ts
@@ -52,7 +52,7 @@ const makeDependencies = (): Dependencies => {
 };
 
 const runInfoCommand = async (output: "json" | "text") => {
-  const command = makeInfoCommand(makeDependencies());
+  const command = makeInfoCommand(makeDependencies(), { CI: false });
   const program = new Command()
     .exitOverride()
     .option("--output <mode>", "Output mode", output)

--- a/apps/cli/src/adapters/commander/commands/__tests__/init-command.test.ts
+++ b/apps/cli/src/adapters/commander/commands/__tests__/init-command.test.ts
@@ -53,7 +53,7 @@ describe("makeInitCommand", () => {
       }),
     );
     const requireGitHubAuth: GitHubAuthFactory = requireGitHubAuthSpy;
-    const root = makeRoot(makeInitCommand(requireGitHubAuth));
+    const root = makeRoot(makeInitCommand(requireGitHubAuth, { CI: false }));
 
     await expect(
       root.parseAsync(["init"], { from: "user" }),

--- a/apps/cli/src/adapters/commander/commands/__tests__/init-json.test.ts
+++ b/apps/cli/src/adapters/commander/commands/__tests__/init-json.test.ts
@@ -93,7 +93,7 @@ describe("init command json output", () => {
       });
     const program = new Command()
       .option("--output <mode>", "Output mode", "json")
-      .addCommand(makeInitCommand(requireGitHubAuth));
+      .addCommand(makeInitCommand(requireGitHubAuth, { CI: false }));
     await program.parseAsync(["node", "dx", "--output", "json", "init"]);
 
     expect(parseNdjson(stderr.written)).toEqual([

--- a/apps/cli/src/adapters/commander/commands/__tests__/init.test.ts
+++ b/apps/cli/src/adapters/commander/commands/__tests__/init.test.ts
@@ -10,17 +10,22 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { mockDeep } from "vitest-mock-extended";
 
 import type { AuthorizationService } from "../../../../domain/authorization.js";
+import type { CommandPresenter } from "../../../../domain/command-presenter.js";
 import type { GitHubAuthFactory } from "../../../../domain/dependencies.js";
 import type { GitHubService } from "../../../../domain/github.js";
 import type { Payload as MonorepoPayload } from "../../../plop/generators/monorepo/index.js";
 
 const mocks = vi.hoisted(() => {
-  const presenter = {
-    reportError: vi.fn(),
-    reportResult: vi.fn(),
-    trackStep: vi.fn(async (_name: string, task: () => Promise<unknown>) =>
-      task(),
-    ),
+  const reportError = vi.fn();
+  const reportResult = vi.fn();
+  const trackStepMock = vi.fn();
+  const presenter: CommandPresenter = {
+    reportError,
+    reportResult,
+    trackStep: async <T>(name: string, task: () => Promise<T>) => {
+      trackStepMock(name, task);
+      return task();
+    },
   };
 
   return {
@@ -28,11 +33,17 @@ const mocks = vi.hoisted(() => {
     createCommandPresenter: vi.fn(() => presenter),
     getPlopInstance: vi.fn(),
     presenter,
+    reportError,
+    reportResult,
+    resolveOutputMode: vi.fn(
+      (_env: unknown, output: "json" | "text" | undefined) => output ?? "text",
+    ),
     runMonorepoActions: vi.fn(),
     tf$: vi.fn(async (...args: [TemplateStringsArray, ...unknown[]]) => {
       void args;
       return { stdout: '{"user":{"name":"test@example.com"}}' };
     }),
+    trackStepMock,
   };
 });
 
@@ -48,6 +59,7 @@ vi.mock("../../../plop/index.js", () => ({
 vi.mock("../../../execa/terraform.js", () => ({ tf$: mocks.tf$ }));
 vi.mock("../../presenters/index.js", () => ({
   createCommandPresenter: mocks.createCommandPresenter,
+  resolveOutputMode: mocks.resolveOutputMode,
 }));
 
 import {
@@ -85,7 +97,7 @@ const runInitCommand = async (
       authorizationService: mockDeep<AuthorizationService>(),
       gitHubService,
     });
-  const initCommand = makeInitCommand(requireGitHubAuth);
+  const initCommand = makeInitCommand(requireGitHubAuth, { CI: false });
   initCommand.exitOverride().configureOutput(silentOutput);
 
   const program = new Command();
@@ -263,7 +275,7 @@ describe("makeInitCommand", () => {
         authorizationService: mockDeep<AuthorizationService>(),
         gitHubService: mockDeep<GitHubService>(),
       });
-    const command = makeInitCommand(requireGitHubAuth);
+    const command = makeInitCommand(requireGitHubAuth, { CI: false });
 
     const flags = command.options.flatMap((option) => [
       option.flags,
@@ -283,16 +295,15 @@ describe("makeInitCommand", () => {
   it("uses the command presenter to report json progress and results", async () => {
     await runInitCommand("json");
 
-    expect(mocks.createCommandPresenter).toHaveBeenCalledWith("json");
-    expect(mocks.presenter.trackStep).toHaveBeenCalledWith(
+    expect(mocks.trackStepMock).toHaveBeenCalledWith(
       "Checking Terraform installation...",
       expect.any(Function),
     );
-    expect(mocks.presenter.trackStep).toHaveBeenCalledWith(
+    expect(mocks.trackStepMock).toHaveBeenCalledWith(
       "Checking Corepack installation...",
       expect.any(Function),
     );
-    expect(mocks.presenter.reportResult).toHaveBeenCalledWith(
+    expect(mocks.reportResult).toHaveBeenCalledWith(
       expect.objectContaining({
         gitHubRepoCreationSkipped: true,
         payload,
@@ -306,7 +317,7 @@ describe("makeInitCommand", () => {
 
     await runInitCommand("json");
 
-    expect(mocks.presenter.reportError).toHaveBeenCalledWith(
+    expect(mocks.reportError).toHaveBeenCalledWith(
       expect.objectContaining({
         message: "Failed to run the generator",
       }),
@@ -322,6 +333,6 @@ describe("makeInitCommand", () => {
       code: "commander.error",
       exitCode: 1,
     });
-    expect(mocks.presenter.reportError).not.toHaveBeenCalled();
+    expect(mocks.reportError).not.toHaveBeenCalled();
   });
 });

--- a/apps/cli/src/adapters/commander/commands/add.ts
+++ b/apps/cli/src/adapters/commander/commands/add.ts
@@ -14,6 +14,7 @@ import { okAsync, ResultAsync } from "neverthrow";
 
 import type { CommandPresenter } from "../../../domain/command-presenter.js";
 import type { Payload as EnvironmentPayload } from "../../plop/generators/environment/index.js";
+import type { CliEnv } from "../env.js";
 import type { GlobalOptions } from "../global-options.js";
 
 import {
@@ -31,7 +32,10 @@ import {
   runDeploymentEnvironmentActions,
 } from "../../plop/index.js";
 import { asError, reportCommandError } from "../command-errors.js";
-import { createCommandPresenter } from "../presenters/index.js";
+import {
+  createCommandPresenter,
+  resolveOutputMode,
+} from "../presenters/index.js";
 import { runAddEnvironmentPreconditions } from "./init.js";
 
 /**
@@ -187,7 +191,10 @@ const addEnvironmentAction = (
       ),
     );
 
-export const makeAddCommand = (requireGitHubAuth: GitHubAuthFactory): Command =>
+export const makeAddCommand = (
+  requireGitHubAuth: GitHubAuthFactory,
+  env: CliEnv,
+): Command =>
   new Command()
     .name("add")
     .description("Add a new component to your workspace")
@@ -196,7 +203,8 @@ export const makeAddCommand = (requireGitHubAuth: GitHubAuthFactory): Command =>
         .description("Add a new deployment environment")
         .action(async function () {
           const { output } = this.optsWithGlobals<GlobalOptions>();
-          const presenter = createCommandPresenter(output);
+          const outputMode = resolveOutputMode(env, output);
+          const presenter = createCommandPresenter(outputMode);
 
           await requireGitHubAuth()
             .andThen(({ authorizationService, gitHubService }) =>
@@ -207,8 +215,8 @@ export const makeAddCommand = (requireGitHubAuth: GitHubAuthFactory): Command =>
               ),
             )
             .match(
-              reportSummary(presenter, output),
-              reportCommandError(this, presenter, output),
+              reportSummary(presenter, outputMode),
+              reportCommandError(this, presenter, outputMode),
             );
         }),
     );

--- a/apps/cli/src/adapters/commander/commands/codemod.ts
+++ b/apps/cli/src/adapters/commander/commands/codemod.ts
@@ -3,20 +3,24 @@ import { ResultAsync } from "neverthrow";
 
 import type { ApplyCodemodById } from "../../../use-cases/apply-codemod.js";
 import type { ListCodemods } from "../../../use-cases/list-codemods.js";
+import type { CliEnv } from "../env.js";
+import type { GlobalOptions } from "../global-options.js";
 
 import { asError, reportCommandError } from "../command-errors.js";
-import { GlobalOptions } from "../global-options.js";
-import { createCommandPresenter } from "../presenters/index.js";
+import {
+  createCommandPresenter,
+  resolveOutputMode,
+} from "../presenters/index.js";
 
 export type CodemodCommandDependencies = {
   applyCodemodById: ApplyCodemodById;
   listCodemods: ListCodemods;
 };
 
-export const makeCodemodCommand = ({
-  applyCodemodById,
-  listCodemods,
-}: CodemodCommandDependencies) =>
+export const makeCodemodCommand = (
+  { applyCodemodById, listCodemods }: CodemodCommandDependencies,
+  env: CliEnv,
+) =>
   new Command("codemod")
     .description("Manage and apply migration scripts to the repository")
     .addCommand(
@@ -24,14 +28,15 @@ export const makeCodemodCommand = ({
         .description("List available migration scripts")
         .action(async function () {
           const { output } = this.optsWithGlobals<GlobalOptions>();
-          const presenter = createCommandPresenter(output);
+          const outputMode = resolveOutputMode(env, output);
+          const presenter = createCommandPresenter(outputMode);
 
           await listCodemods()
             .map((codemods) =>
               codemods.map(({ description, id }) => ({ description, id })),
             )
             .andTee((codemods) => presenter.reportResult(codemods))
-            .orTee(reportCommandError(this, presenter, output));
+            .orTee(reportCommandError(this, presenter, outputMode));
         }),
     )
     .addCommand(
@@ -40,7 +45,8 @@ export const makeCodemodCommand = ({
         .description("Apply migration scripts to the repository")
         .action(async function (id) {
           const { output } = this.optsWithGlobals<GlobalOptions>();
-          const presenter = createCommandPresenter(output);
+          const outputMode = resolveOutputMode(env, output);
+          const presenter = createCommandPresenter(outputMode);
 
           await ResultAsync.fromPromise(
             presenter.trackStep(`Applying codemod ${id}...`, () =>
@@ -55,6 +61,6 @@ export const makeCodemodCommand = ({
           )
             .map(() => ({ id }))
             .andTee((result) => presenter.reportResult(result))
-            .orTee(reportCommandError(this, presenter, output));
+            .orTee(reportCommandError(this, presenter, outputMode));
         }),
     );

--- a/apps/cli/src/adapters/commander/commands/doctor.ts
+++ b/apps/cli/src/adapters/commander/commands/doctor.ts
@@ -14,11 +14,15 @@ import type { CommandPresenter } from "../../../domain/command-presenter.js";
 import type { Dependencies } from "../../../domain/dependencies.js";
 import type { DoctorResult } from "../../../domain/doctor.js";
 import type { ValidationCheck } from "../../../domain/validation.js";
+import type { CliEnv } from "../env.js";
+import type { GlobalOptions } from "../global-options.js";
 
 import { Config } from "../../../config.js";
 import { runDoctor } from "../../../domain/doctor.js";
-import { GlobalOptions } from "../global-options.js";
-import { createCommandPresenter } from "../presenters/index.js";
+import {
+  createCommandPresenter,
+  resolveOutputMode,
+} from "../presenters/index.js";
 
 const formatCheck = (check: ValidationCheck): string =>
   check.isValid
@@ -38,6 +42,7 @@ const reportDoctorResult =
 export const makeDoctorCommand = (
   dependencies: Dependencies,
   config: Config,
+  env: CliEnv,
 ): Command =>
   new Command()
     .name("doctor")
@@ -46,11 +51,12 @@ export const makeDoctorCommand = (
     )
     .action(async function () {
       const { output } = this.optsWithGlobals<GlobalOptions>();
-      const presenter = createCommandPresenter(output);
+      const outputMode = resolveOutputMode(env, output);
+      const presenter = createCommandPresenter(outputMode);
 
       const result = await runDoctor(dependencies, config);
 
-      reportDoctorResult(presenter, output)(result);
+      reportDoctorResult(presenter, outputMode)(result);
 
       process.exitCode = result.hasErrors ? 1 : 0;
     });

--- a/apps/cli/src/adapters/commander/commands/info.ts
+++ b/apps/cli/src/adapters/commander/commands/info.ts
@@ -1,18 +1,25 @@
 import { Command } from "commander";
 
 import type { Dependencies } from "../../../domain/dependencies.js";
+import type { CliEnv } from "../env.js";
+import type { GlobalOptions } from "../global-options.js";
 
 import { getInfo } from "../../../domain/info.js";
-import { GlobalOptions } from "../global-options.js";
-import { createCommandPresenter } from "../presenters/index.js";
+import {
+  createCommandPresenter,
+  resolveOutputMode,
+} from "../presenters/index.js";
 
-export const makeInfoCommand = (dependencies: Dependencies): Command =>
+export const makeInfoCommand = (
+  dependencies: Dependencies,
+  env: CliEnv,
+): Command =>
   new Command()
     .name("info")
     .description("Display information about the project")
     .action(async function () {
       const { output } = this.optsWithGlobals<GlobalOptions>();
-      const presenter = createCommandPresenter(output);
+      const presenter = createCommandPresenter(resolveOutputMode(env, output));
       const result = await getInfo(dependencies)();
       presenter.reportResult(result);
     });

--- a/apps/cli/src/adapters/commander/commands/init.ts
+++ b/apps/cli/src/adapters/commander/commands/init.ts
@@ -8,6 +8,7 @@ import * as path from "node:path";
 import { z } from "zod";
 
 import type { CommandPresenter } from "../../../domain/command-presenter.js";
+import type { CliEnv } from "../env.js";
 import type { GlobalOptions } from "../global-options.js";
 
 import { GitHubAuthFactory } from "../../../domain/dependencies.js";
@@ -24,7 +25,10 @@ import {
   runMonorepoActions,
 } from "../../plop/index.js";
 import { asError, reportCommandError } from "../command-errors.js";
-import { createCommandPresenter } from "../presenters/index.js";
+import {
+  createCommandPresenter,
+  resolveOutputMode,
+} from "../presenters/index.js";
 
 type GitHubRepoCreationSkippedResult = {
   gitHubRepoCreationSkipped: true;
@@ -488,6 +492,7 @@ const reportSummary =
 
 export const makeInitCommand = (
   requireGitHubAuth: GitHubAuthFactory,
+  env: CliEnv,
 ): Command =>
   new Command()
     .name("init")
@@ -510,7 +515,8 @@ export const makeInitCommand = (
     )
     .action(async function (options: unknown) {
       const { output } = this.optsWithGlobals<GlobalOptions>();
-      const presenter = createCommandPresenter(output);
+      const outputMode = resolveOutputMode(env, output);
+      const presenter = createCommandPresenter(outputMode);
 
       await ResultAsync.fromPromise(
         Promise.resolve().then(() => parseInitCommandOptions(options)),
@@ -531,7 +537,7 @@ export const makeInitCommand = (
             ),
         )
         .match(
-          reportSummary(presenter, output),
-          reportCommandError(this, presenter, output),
+          reportSummary(presenter, outputMode),
+          reportCommandError(this, presenter, outputMode),
         );
     });

--- a/apps/cli/src/adapters/commander/index.ts
+++ b/apps/cli/src/adapters/commander/index.ts
@@ -1,5 +1,7 @@
 import { Command, Option } from "commander";
 
+import type { CliEnv } from "./env.js";
+
 import { Config } from "../../config.js";
 import { Dependencies } from "../../domain/dependencies.js";
 import { makeAddCommand } from "./commands/add.js";
@@ -12,9 +14,7 @@ import { makeInfoCommand } from "./commands/info.js";
 import { makeInitCommand } from "./commands/init.js";
 import { makeSavemoneyCommand } from "./commands/savemoney.js";
 import { makeSpecCommand } from "./commands/spec.js";
-import { CliEnv } from "./env.js";
 import { extractCliSpec } from "./spec.js";
-
 export type CliDependencies = CodemodCommandDependencies;
 
 export const makeCli = (

--- a/apps/cli/src/adapters/commander/index.ts
+++ b/apps/cli/src/adapters/commander/index.ts
@@ -12,6 +12,7 @@ import { makeInfoCommand } from "./commands/info.js";
 import { makeInitCommand } from "./commands/init.js";
 import { makeSavemoneyCommand } from "./commands/savemoney.js";
 import { makeSpecCommand } from "./commands/spec.js";
+import { CliEnv } from "./env.js";
 import { extractCliSpec } from "./spec.js";
 
 export type CliDependencies = CodemodCommandDependencies;
@@ -20,6 +21,7 @@ export const makeCli = (
   deps: Dependencies,
   config: Config,
   cliDeps: CliDependencies,
+  env: CliEnv,
   version: string,
 ) => {
   const program = new Command();
@@ -42,12 +44,12 @@ export const makeCli = (
         .default("text"),
     );
 
-  program.addCommand(makeDoctorCommand(deps, config));
-  program.addCommand(makeCodemodCommand(cliDeps));
-  program.addCommand(makeInitCommand(deps.requireGitHubAuth));
+  program.addCommand(makeDoctorCommand(deps, config, env));
+  program.addCommand(makeCodemodCommand(cliDeps, env));
+  program.addCommand(makeInitCommand(deps.requireGitHubAuth, env));
   program.addCommand(makeSavemoneyCommand());
-  program.addCommand(makeInfoCommand(deps));
-  program.addCommand(makeAddCommand(deps.requireGitHubAuth));
+  program.addCommand(makeInfoCommand(deps, env));
+  program.addCommand(makeAddCommand(deps.requireGitHubAuth, env));
 
   // spec is registered last so the closure captures the complete command tree.
   program.addCommand(makeSpecCommand(() => extractCliSpec(program, version)));

--- a/apps/cli/src/adapters/commander/presenters/__tests__/index.test.ts
+++ b/apps/cli/src/adapters/commander/presenters/__tests__/index.test.ts
@@ -1,9 +1,14 @@
 /**
- * Tests for isNonInteractive and createCommandPresenter factory.
+ * Tests for isNonInteractive, resolveOutputMode and the createCommandPresenter
+ * factory.
  */
 import { describe, expect, it } from "vitest";
 
-import { createCommandPresenter, isNonInteractive } from "../index.js";
+import {
+  createCommandPresenter,
+  isNonInteractive,
+  resolveOutputMode,
+} from "../index.js";
 import { JsonCommandPresenter } from "../json-command-presenter.js";
 import { TextCommandPresenter } from "../text-command-presenter.js";
 
@@ -14,6 +19,22 @@ describe("isNonInteractive", () => {
 
   it("returns false when CI is false", () => {
     expect(isNonInteractive({ CI: false })).toBe(false);
+  });
+});
+
+describe("resolveOutputMode", () => {
+  it("forces json when running non-interactively, ignoring --output", () => {
+    expect(resolveOutputMode({ CI: true }, "text")).toBe("json");
+    expect(resolveOutputMode({ CI: true }, undefined)).toBe("json");
+  });
+
+  it("follows the --output flag when interactive", () => {
+    expect(resolveOutputMode({ CI: false }, "json")).toBe("json");
+    expect(resolveOutputMode({ CI: false }, "text")).toBe("text");
+  });
+
+  it("defaults to text when nothing is provided", () => {
+    expect(resolveOutputMode({ CI: false }, undefined)).toBe("text");
   });
 });
 

--- a/apps/cli/src/adapters/commander/presenters/index.ts
+++ b/apps/cli/src/adapters/commander/presenters/index.ts
@@ -7,10 +7,12 @@ import type { CommandPresenter } from "../../../domain/command-presenter.js";
  * output format: a user can request JSON output while still answering prompts,
  * and a CI system can set CI=true with text output.
  *
- * createCommandPresenter selects the appropriate CommandPresenter adapter based solely
- * on the requested output format.
+ * createCommandPresenter selects the appropriate CommandPresenter adapter based
+ * solely on the requested output mode, while resolveOutputMode applies the
+ * precedence rules that decide that mode.
  */
 import type { CliEnv } from "../env.js";
+import type { GlobalOptions } from "../global-options.js";
 
 import { JsonCommandPresenter } from "./json-command-presenter.js";
 import { TextCommandPresenter } from "./text-command-presenter.js";
@@ -22,6 +24,24 @@ import { TextCommandPresenter } from "./text-command-presenter.js";
  * following the same convention used by `is-interactive` and `ora`.
  */
 export const isNonInteractive = (env: CliEnv): boolean => env.CI;
+
+/**
+ * Resolves the effective output mode for a command invocation.
+ *
+ * - In a non-interactive environment (CI), output is always "json" so agents
+ *   and pipelines get structured output regardless of the `--output` flag.
+ * - Otherwise the `--output` flag decides.
+ * - When nothing is provided, the mode defaults to "text".
+ */
+export const resolveOutputMode = (
+  env: CliEnv,
+  output: GlobalOptions["output"] | undefined,
+): "json" | "text" => {
+  if (isNonInteractive(env)) {
+    return "json";
+  }
+  return output === "json" ? "json" : "text";
+};
 
 /**
  * Returns the appropriate CommandPresenter adapter for the requested output mode.

--- a/apps/cli/src/adapters/commander/presenters/index.ts
+++ b/apps/cli/src/adapters/commander/presenters/index.ts
@@ -1,15 +1,13 @@
 import type { CommandPresenter } from "../../../domain/command-presenter.js";
 /**
- * Output logger factory.
+ * Output presenter selection.
  *
- * isNonInteractive determines whether the CLI should suppress interactive
- * prompts (e.g. when running in a CI pipeline). This is independent of the
- * output format: a user can request JSON output while still answering prompts,
- * and a CI system can set CI=true with text output.
- *
- * createCommandPresenter selects the appropriate CommandPresenter adapter based
- * solely on the requested output mode, while resolveOutputMode applies the
- * precedence rules that decide that mode.
+ * isNonInteractive reports whether the CLI is running in a non-interactive
+ * (CI) environment. resolveOutputMode applies the precedence rules: a CI
+ * environment forces JSON so agents and pipelines get structured output,
+ * otherwise the `--output` flag decides, defaulting to text.
+ * createCommandPresenter then maps the resolved mode to the matching
+ * CommandPresenter adapter.
  */
 import type { CliEnv } from "../env.js";
 import type { GlobalOptions } from "../global-options.js";

--- a/apps/cli/src/index.ts
+++ b/apps/cli/src/index.ts
@@ -4,6 +4,7 @@ import { errAsync, okAsync, ResultAsync } from "neverthrow";
 import { Octokit } from "octokit";
 
 import codemodRegistry from "./adapters/codemods/index.js";
+import { cliEnvSchema } from "./adapters/commander/env.js";
 import { makeCli } from "./adapters/commander/index.js";
 import { makePackageJsonReader } from "./adapters/node/package-json.js";
 import { makeRepositoryReader } from "./adapters/node/repository.js";
@@ -90,13 +91,14 @@ export const runCli = async (version: string) => {
   };
 
   const config = getConfig();
+  const env = cliEnvSchema.parse(process.env);
 
   const useCases = {
     applyCodemodById: applyCodemodById(codemodRegistry, getInfo(deps)),
     listCodemods: listCodemods(codemodRegistry),
   };
 
-  const program = makeCli(deps, config, useCases, version);
+  const program = makeCli(deps, config, useCases, env, version);
 
   program.parse();
 };


### PR DESCRIPTION
## Problem

Every `dx` command constructed its own `CommandPresenter`, duplicating the selection logic and leaving the CI environment variable unused. There was no single place deciding whether output should be human-readable text or structured JSON.

The output presenter is now resolved through a single helper, `resolveOutputMode(env, output)`:
- In a non-interactive (CI) environment it always selects JSON, so agents and pipelines get structured output.
- Otherwise the `--output` flag decides.
- When nothing is provided it defaults to text.

The parsed `CliEnv` is read once at the entry point and passed through `makeCli` to each command factory. Commands read `--output` via Commander's `optsWithGlobals()` and build their presenter locally from the resolved mode. The presenter is not modeled as a use case, and the previous manual `argv` scanning is gone.