### PR TITLE
Add links to Trivy report

### DIFF
--- a/.github/workflows/static_analysis.yaml
+++ b/.github/workflows/static_analysis.yaml
@@ -161,6 +161,7 @@ jobs:
             --show-diff-on-failure \
             ${CHECK_ARGS[@]+"${CHECK_ARGS[@]}"} \
             --files 2>&1 | tee /tmp/pre-commit-output.log
+
       - name: Run pre-commit on Modified Files
         if: ${{ inputs.folder == '' && github.event_name == 'pull_request' && inputs.enable_modified_files_detection }}
         id: pre_commit_modified_files
@@ -353,7 +354,12 @@ jobs:
               [.Results[] |
                 .Target as $target |
                 .Misconfigurations[]? |
-                "| " + .Severity + " | " + .AVDID + " | `" + $target + "` | L" + (.CauseMetadata.StartLine | tostring) + " | " + .Title + " |"
+                (if (.PrimaryURL // "") != "" then
+                  "[" + .AVDID + "](" + .PrimaryURL + ")"
+                else
+                  .AVDID
+                end) as $id_cell |
+                "| " + .Severity + " | " + $id_cell + " | `" + $target + "` | L" + (.CauseMetadata.StartLine | tostring) + " | " + .Title + " |"
               ] | .[]' /tmp/trivy-output.json)
 
             echo "$TRIVY_TABLE" >> "$GITHUB_STEP_SUMMARY"


### PR DESCRIPTION
Improve the formatting of Trivy output to include clickable links for AVD IDs and introduce a pre-commit step to detect modified files in pull requests.

Close CES-2160

Depends on #1866