### PR TITLE
Fix `build-workspace` action

### DIFF
--- a/.github/actions/build-workspace/action.yaml
+++ b/.github/actions/build-workspace/action.yaml
@@ -38,7 +38,8 @@ runs:
         if [ "$BUILD_TOOL" == "turbo" ]; then
           WORKSPACE_PATH=$(npx --yes turbo ls --output=json | jq -sr --arg NAME "$WORKSPACE_NAME" '.[].packages.items[] | select(.name == $NAME).path')
         else
-          WORKSPACE_PATH=$(pnpm -F "$WORKSPACE_NAME" list --json | jq -r .[].path)
+          PNPM_PACKAGE_PATH=$(pnpm -F "$WORKSPACE_NAME" list --json | jq -r .[].path)
+          WORKSPACE_PATH=${PNPM_PACKAGE_PATH#$GITHUB_WORKSPACE/}
         fi
         echo "workspace-path=$WORKSPACE_PATH" >> $GITHUB_OUTPUT
       env:

--- a/.github/workflows/_validate-next-bundle.yaml
+++ b/.github/workflows/_validate-next-bundle.yaml
@@ -38,6 +38,7 @@ jobs:
         if: matrix.package-manager == 'pnpm'
         run: |
           pnpm config set --location=project --json packages '["apps/*"]'
+          pnpm config set --location=project --json allowBuilds '{"sharp":true}'
 
       - name: Setup the yarn workspace
         if: matrix.package-manager == 'yarn'
@@ -54,6 +55,7 @@ jobs:
             --agents-md
 
           rm apps/my-app/next.config.*
+          rm -f apps/my-app/pnpm-workspace.yaml
           echo "module.exports = { output: 'standalone' };" > apps/my-app/next.config.js
           "$PACKAGE_MANAGER" install
         env:

--- a/.github/workflows/_validate-next-bundle.yaml
+++ b/.github/workflows/_validate-next-bundle.yaml
@@ -13,14 +13,23 @@ on:
 jobs:
   test-next-bundle:
     runs-on: ubuntu-latest
+    continue-on-error: true
 
     permissions:
       contents: read
 
     strategy:
       matrix:
+        build-tool: ["turbo"]
         package-manager: ["pnpm", "yarn"]
         nextjs-version: ["13", "14", "15", "16"]
+        include:
+          - build-tool: "nx"
+            package-manager: "pnpm"
+            nextjs-version: "15"
+          - build-tool: "nx"
+            package-manager: "pnpm"
+            nextjs-version: "16"
     steps:
       - name: Build the project
         run: |
@@ -38,7 +47,7 @@ jobs:
         if: matrix.package-manager == 'pnpm'
         run: |
           pnpm config set --location=project --json packages '["apps/*"]'
-          pnpm config set --location=project --json allowBuilds '{"sharp":true}'
+          pnpm config set --location=project --json allowBuilds '{"sharp":true,"nx": true}'
 
       - name: Setup the yarn workspace
         if: matrix.package-manager == 'yarn'
@@ -62,6 +71,11 @@ jobs:
           CI: false
           NEXTJS_VERSION: ${{ matrix.nextjs-version }}
           PACKAGE_MANAGER: ${{ matrix.package-manager }}
+
+      - name: Setup Nx
+        if: matrix.build-tool == 'nx'
+        run: |
+          npx nx@latest init --yes
 
       - name: Checkout repository
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2


### PR DESCRIPTION
On `Nx` branch, `get-workspace-path` returned an absolute path instead
of a relative one.

With this change, it is now normalized to always be relative.
