### PR TITLE
Update TLS renewal process documentation

### DIFF
--- a/.nx/version-plans/version-plan-1782117981196.md
+++ b/.nx/version-plans/version-plan-1782117981196.md
@@ -1,0 +1,5 @@
+---
+docs: minor
+---
+
+Update TLS certificate renewal process

--- a/apps/website/docs/azure/networking/creating-tls-cert.md
+++ b/apps/website/docs/azure/networking/creating-tls-cert.md
@@ -10,8 +10,8 @@ challenge over Azure DNS.
 
 See the full workflow reference — including prerequisites, inputs, and setup
 instructions — in the
-**[Generate TLS Certificate](../../pipelines/release-certificate.md)** workflow
-documentation.
+**[Generate Azure TLS Certificate](../../pipelines/release-azure-certificate.md)**
+workflow documentation.
 
 :::
 

--- a/apps/website/docs/azure/networking/creating-tls-cert.md
+++ b/apps/website/docs/azure/networking/creating-tls-cert.md
@@ -2,57 +2,27 @@
 
 ## Overview
 
-Creating and managing a TLS certificate can be a demanding and challenging task
-for developers who want to quickly create a new hostname for their applications.
-This guide provides step-by-step instructions on how to add a new TLS
-certificate and its automatic renewal pipeline using a combination of tools such
-as Terraform, PowerShell and Azure KeyVault.
+A reusable GitHub workflow is available to create and automatically renew TLS
+certificates stored in Azure Key Vault, using Let's Encrypt via the ACME DNS-01
+challenge over Azure DNS.
 
-## How-To Create a new TLS Certificate
+:::tip
 
-:::warning
-
-This section shows how to create an Azure DevOps pipeline via Terraform. The
-DevEx team is working on a simpler, reusable GitHub workflow which will replace
-this soon.
+See the full workflow reference — including prerequisites, inputs, and setup
+instructions — in the
+**[Generate TLS Certificate](../../pipelines/release-certificate.md)** workflow
+documentation.
 
 :::
 
-An Azure DevOps pipeline capable of creating and renewing TLS certificates is
-available as Terraform module
-(`azuredevops_build_definition_tls_cert_federated`) in the repository
-[pagopa/azuredevops-tf-modules](https://github.com/pagopa/azuredevops-tf-modules).
+This workflow should run on a schedule (e.g. every week) to ensure that
+certificates never expire. A `workflow_dispatch` trigger with a `force_renewal`
+input is also recommended to allow manual renewals when needed.
 
-This workflow uses managed identities to access the given KeyVault, checks if
-the given certificate exists or is expiring soon, and if so, requests a new
-certificate from Let's Encrypt using the ACME protocol.
+### Failure Alerting
 
-This pipeline should run on a schedule, for example every week, to ensure that
-certificates will never expire.
-
-However, things may go wrong: for this reason it is essential to add an alert in
-case of pipeline failure. To add the alert:
-
-- navigate to DevOps project setting by clicking on the gear in the bottom-left
-  corner
-- select `Notifications`
-- click on `New subscription`
-- select `A build fails` in `Build` category
-- in `Develiver to`, select `Custom email address` and add the email of the team
-  responsible for the maintenance of the certificate; you could also set a
-  Slack's group email
-- click on `Finish`
-
-:::warning
-
-Due to a bug within the Azure DevOps Terraform provider, the scheduled trigger
-will not work until the first edit of the pipeline is done manually in the Azure
-DevOps portal.
-
-To work around this, once the pipeline is created, navigate to the pipeline in
-the Azure DevOps portal, click on `Edit`, then on the three dots in the
-top-right corner and do a random change (e.g. changing the scheduled trigger
-time) and save the pipeline. Eventually, revert the random change back if
-needed.
-
-:::
+Because this workflow runs on a schedule, failures may go unnoticed. The
+workflow supports optional Slack notifications on failure: set the
+`SLACK_WEBHOOK_URL` secret in your repository's GitHub Actions secrets pointing
+to the desired Slack channel, and the workflow will automatically post an alert
+whenever a scheduled run fails.

--- a/apps/website/docs/pipelines/index.md
+++ b/apps/website/docs/pipelines/index.md
@@ -47,8 +47,9 @@ application deployment, and infrastructure automation.
   and deploy Azure Dashboards from OpenAPI specs
 - **[Azure Login](../azure/iam/azure-login.md)** - Secure authentication to
   Azure
-- **[Generate TLS Certificate](./release-certificate.md)** - Create and
-  automatically renew TLS certificates via Let's Encrypt and Azure Key Vault
+- **[Generate Azure TLS Certificate](./release-azure-certificate.md)** - Create
+  and automatically renew Azure TLS certificates via Let's Encrypt and Azure Key
+  Vault
 
 ### 🛠️ Build & Package
 

--- a/apps/website/docs/pipelines/index.md
+++ b/apps/website/docs/pipelines/index.md
@@ -47,6 +47,8 @@ application deployment, and infrastructure automation.
   and deploy Azure Dashboards from OpenAPI specs
 - **[Azure Login](../azure/iam/azure-login.md)** - Secure authentication to
   Azure
+- **[Generate TLS Certificate](./release-certificate.md)** - Create and
+  automatically renew TLS certificates via Let's Encrypt and Azure Key Vault
 
 ### 🛠️ Build & Package
 

--- a/apps/website/docs/pipelines/release-azure-certificate.md
+++ b/apps/website/docs/pipelines/release-azure-certificate.md
@@ -2,13 +2,13 @@
 sidebar_position: 7
 ---
 
-# Generate TLS Certificate
+# Generate Azure TLS Certificate
 
 :::info Reusable Workflow
 
-| Workflow                     | Version | Source                                                                                                                |
-| ---------------------------- | ------- | --------------------------------------------------------------------------------------------------------------------- |
-| **Generate TLS Certificate** | v1      | [`release-certificate-v1.yaml`](https://github.com/pagopa/dx/blob/main/.github/workflows/release-certificate-v1.yaml) |
+| Workflow                           | Version | Source                                                                                                                |
+| ---------------------------------- | ------- | --------------------------------------------------------------------------------------------------------------------- |
+| **Generate Azure TLS Certificate** | v1      | [`release-certificate-v1.yaml`](https://github.com/pagopa/dx/blob/main/.github/workflows/release-certificate-v1.yaml) |
 
 :::
 
@@ -76,7 +76,7 @@ permissions:
 jobs:
   renew:
     name: "myapp.example.com"
-    uses: pagopa/dx/.github/workflows/release-certificate-v1.yaml@main
+    uses: pagopa/dx/.github/workflows/release-azure-certificate-v1.yaml@main
     secrets: inherit
     with:
       key_vault_name: "my-keyvault"

--- a/apps/website/docs/pipelines/release-certificate.md
+++ b/apps/website/docs/pipelines/release-certificate.md
@@ -1,0 +1,101 @@
+---
+sidebar_position: 7
+---
+
+# Generate TLS Certificate
+
+:::info Reusable Workflow
+
+| Workflow                     | Version | Source                                                                                                                |
+| ---------------------------- | ------- | --------------------------------------------------------------------------------------------------------------------- |
+| **Generate TLS Certificate** | v1      | [`release-certificate-v1.yaml`](https://github.com/pagopa/dx/blob/main/.github/workflows/release-certificate-v1.yaml) |
+
+:::
+
+Reusable workflow that checks whether a TLS certificate stored in Azure Key
+Vault is missing or close to expiration, and if so requests a new one from
+**Let's Encrypt** via the ACME DNS-01 challenge using Azure DNS. The check and
+renewal are handled by the underlying
+[`renew-tls-certificate`](https://github.com/pagopa/dx/tree/main/actions/renew-tls-certificate)
+composite action.
+
+## How It Works
+
+1. **Check**: Downloads the current certificate from Key Vault (if present) and
+   verifies that it does not expire within 30 days. If the certificate is
+   missing, expired, or `force_renewal` is `true`, the renewal flow is
+   triggered.
+2. **Renew**: Logs in to Azure, generates a fresh RSA-2048 CSR, runs the ACME
+   client to complete the DNS-01 challenge against Azure DNS, converts the
+   resulting certificate chain to PFX, and uploads it back to Key Vault.
+
+## Prerequisites
+
+Let's Encrypt account credentials are managed at the organization level. You
+need to add them as repository secrets before using this workflow:
+
+- `LETS_ENCRYPT_PRIVATE_KEY_JSON` — Let's Encrypt account private key in JWK
+  JSON format (copy from organization secrets)
+- `LETS_ENCRYPT_REGISTRATION_JSON` — Let's Encrypt account registration info in
+  JSON format (copy from organization secrets)
+
+## Inputs
+
+| Name                      | Required | Default      | Description                                                                     |
+| ------------------------- | -------- | ------------ | ------------------------------------------------------------------------------- |
+| `key_vault_name`          | Yes      | —            | Name of the Azure Key Vault storing the certificate                             |
+| `csr_common_name`         | Yes      | —            | Common Name (CN) for the Certificate Signing Request (e.g. `myapp.example.com`) |
+| `dns_zone`                | Yes      | —            | Azure DNS Zone used for the ACME DNS-01 challenge (e.g. `example.com`)          |
+| `dns_zone_resource_group` | Yes      | —            | Resource Group that contains the DNS Zone                                       |
+| `force_renewal`           | No       | `false`      | Force renewal even if the certificate is not close to expiration                |
+| `environment`             | No       | `infra-prod` | GitHub Environment prefix; the workflow runs in `{environment}-cd`              |
+
+## Usage
+
+Call the workflow from your repository using `workflow_call`. Schedule it to run
+periodically (e.g. weekly) to ensure certificates never expire.
+
+```yaml
+name: Renew TLS Certificate
+
+on:
+  workflow_dispatch:
+    inputs:
+      force_renewal:
+        description: "Force certificate renewal"
+        required: false
+        default: "false"
+        type: boolean
+  schedule:
+    - cron: "0 8 * * 1" # Every Monday at 08:00 UTC
+
+permissions:
+  contents: read
+  id-token: write
+
+jobs:
+  renew:
+    name: "myapp.example.com"
+    uses: pagopa/dx/.github/workflows/release-certificate-v1.yaml@main
+    secrets: inherit
+    with:
+      key_vault_name: "my-keyvault"
+      csr_common_name: "myapp.example.com"
+      dns_zone: "example.com"
+      dns_zone_resource_group: "my-dns-rg"
+      force_renewal: ${{ inputs.force_renewal || false }}
+      environment: "automation-prod"
+```
+
+### Force a Renewal Manually
+
+You can trigger the workflow manually from the GitHub Actions UI using
+`workflow_dispatch` and set `force_renewal` to `true` to bypass the expiry
+check. This is useful when troubleshooting or recovering from a failed renewal.
+
+## Failure Alerting
+
+Because this workflow runs on a schedule, failures may go unnoticed. The
+workflow supports optional Slack notifications: when a scheduled run fails, it
+automatically posts an alert to a Slack channel if the `SLACK_WEBHOOK_URL`
+secret is configured as a repository secret pointing to the desired channel.


### PR DESCRIPTION
This pull request updates and simplifies the documentation for managing TLS certificate creation and renewal in Azure, focusing on the introduction of a reusable GitHub Actions workflow that automates the process with Let's Encrypt and Azure Key Vault. The changes deprecate the previous Azure DevOps/Terraform pipeline documentation in favor of the new workflow, and provide clear instructions for setup, usage, and alerting.

Close CES-2111