### PR TITLE
Add Slack failure notification to TLS certificate renewal workflow

### DIFF
--- a/.github/workflows/release-certificate-v1.yaml
+++ b/.github/workflows/release-certificate-v1.yaml
@@ -35,9 +35,6 @@ jobs:
     name: Create or Renew Certificate
     runs-on: ubuntu-latest
     environment: ${{ inputs.environment }}-cd
-    env:
-      SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
-
     steps:
       - name: Renew TLS Certificate
         uses: pagopa/dx/actions/renew-tls-certificate@main
@@ -54,7 +51,7 @@ jobs:
           lets_encrypt_registration_json: ${{ secrets.LETS_ENCRYPT_REGISTRATION_JSON }}
 
       - name: Notify Slack on failure
-        if: failure() && github.event_name == 'schedule' && env.SLACK_WEBHOOK_URL != ''
+        if: failure() && github.event_name == 'schedule' && secrets.SLACK_WEBHOOK_URL != ''
         uses: pagopa/dx/.github/actions/slack-notification@main
         with:
           id: "TLS Certificate Renewal"

--- a/.github/workflows/release-certificate-v1.yaml
+++ b/.github/workflows/release-certificate-v1.yaml
@@ -35,6 +35,8 @@ jobs:
     name: Create or Renew Certificate
     runs-on: ubuntu-latest
     environment: ${{ inputs.environment }}-cd
+    env:
+      SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
 
     steps:
       - name: Renew TLS Certificate
@@ -50,3 +52,12 @@ jobs:
           arm_tenant_id: ${{ secrets.ARM_TENANT_ID }}
           lets_encrypt_private_key_json: ${{ secrets.LETS_ENCRYPT_PRIVATE_KEY_JSON }}
           lets_encrypt_registration_json: ${{ secrets.LETS_ENCRYPT_REGISTRATION_JSON }}
+
+      - name: Notify Slack on failure
+        if: failure() && github.event_name == 'schedule' && env.SLACK_WEBHOOK_URL != ''
+        uses: pagopa/dx/.github/actions/slack-notification@main
+        with:
+          id: "TLS Certificate Renewal"
+          title: "*TLS Certificate Renewal Failure*"
+          text: "Certificate '${{ inputs.csr_common_name }}' renewal process failed. Please check the <${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}|workflow run> for details."
+          slack_webhook_url: ${{ secrets.SLACK_WEBHOOK_URL }}


### PR DESCRIPTION
Add optional Slack failure notification to the `release-certificate-v1` reusable workflow. When a scheduled run fails, the workflow posts an alert to Slack if the `SLACK_WEBHOOK_URL` repository secret is configured.

The notification is only sent on `schedule` events, avoiding noise on manual runs.

Close CES-2166