### PR TITLE
Add automation-cd environment to azure_github_environment_bootstrap

### DIFF
--- a/.nx/version-plans/version-plan-1782118724704.md
+++ b/.nx/version-plans/version-plan-1782118724704.md
@@ -1,0 +1,5 @@
+---
+azure_github_environment_bootstrap: minor
+---
+
+Add support to automation-cd GitHub environment

--- a/infra/modules/azure_github_environment_bootstrap/README.md
+++ b/infra/modules/azure_github_environment_bootstrap/README.md
@@ -508,6 +508,7 @@ This module includes practical examples to help you get started quickly:
 |------|------|
 | [azurerm_federated_identity_credential.github_app_cd](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/federated_identity_credential) | resource |
 | [azurerm_federated_identity_credential.github_app_ci](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/federated_identity_credential) | resource |
+| [azurerm_federated_identity_credential.github_automation_cd](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/federated_identity_credential) | resource |
 | [azurerm_federated_identity_credential.github_infra_cd](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/federated_identity_credential) | resource |
 | [azurerm_federated_identity_credential.github_infra_ci](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/federated_identity_credential) | resource |
 | [azurerm_federated_identity_credential.github_opex_cd](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/federated_identity_credential) | resource |
@@ -547,6 +548,7 @@ This module includes practical examples to help you get started quickly:
 | [azurerm_user_assigned_identity.opex_ci](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/user_assigned_identity) | resource |
 | [github_actions_environment_secret.app_cd](https://registry.terraform.io/providers/integrations/github/latest/docs/resources/actions_environment_secret) | resource |
 | [github_actions_environment_secret.app_ci](https://registry.terraform.io/providers/integrations/github/latest/docs/resources/actions_environment_secret) | resource |
+| [github_actions_environment_secret.automation_cd](https://registry.terraform.io/providers/integrations/github/latest/docs/resources/actions_environment_secret) | resource |
 | [github_actions_environment_secret.infra_cd](https://registry.terraform.io/providers/integrations/github/latest/docs/resources/actions_environment_secret) | resource |
 | [github_actions_environment_secret.infra_ci](https://registry.terraform.io/providers/integrations/github/latest/docs/resources/actions_environment_secret) | resource |
 | [github_actions_environment_secret.opex_cd](https://registry.terraform.io/providers/integrations/github/latest/docs/resources/actions_environment_secret) | resource |

--- a/infra/modules/azure_github_environment_bootstrap/github_environments_secrets_cd.tf
+++ b/infra/modules/azure_github_environment_bootstrap/github_environments_secrets_cd.tf
@@ -9,6 +9,16 @@ resource "github_actions_environment_secret" "infra_cd" {
 }
 
 #trivy:ignore:AVD-GIT-0002
+resource "github_actions_environment_secret" "automation_cd" {
+  for_each = local.automation_cd.secrets
+
+  repository      = var.repository.name
+  environment     = "automation-${local.env_name}-cd"
+  secret_name     = each.key
+  plaintext_value = each.value
+}
+
+#trivy:ignore:AVD-GIT-0002
 resource "github_actions_environment_secret" "app_cd" {
   for_each = local.app_cd.secrets
 

--- a/infra/modules/azure_github_environment_bootstrap/id_infra.tf
+++ b/infra/modules/azure_github_environment_bootstrap/id_infra.tf
@@ -29,3 +29,11 @@ resource "azurerm_federated_identity_credential" "github_infra_cd" {
   parent_id = azurerm_user_assigned_identity.infra_cd.id
   subject   = "repo:pagopa/${var.repository.name}:environment:${format(local.ids.infra_environment_name, "cd")}"
 }
+
+resource "azurerm_federated_identity_credential" "github_automation_cd" {
+  name      = format(local.ids.federated_identity_name, "automation", "cd")
+  audience  = local.ids.audience
+  issuer    = local.ids.issuer
+  parent_id = azurerm_user_assigned_identity.infra_cd.id
+  subject   = "repo:pagopa/${var.repository.name}:environment:${format(local.ids.automation_environment_name, "cd")}"
+}

--- a/infra/modules/azure_github_environment_bootstrap/locals.tf
+++ b/infra/modules/azure_github_environment_bootstrap/locals.tf
@@ -50,9 +50,10 @@ locals {
     }))
 
     # e.g. infra-${local.env_name}-cd
-    infra_environment_name = "infra-${local.env_name}-%s"
-    app_environment_name   = "app-${local.env_name}-%s"
-    opex_environment_name  = "opex-${local.env_name}-%s"
+    infra_environment_name      = "infra-${local.env_name}-%s"
+    automation_environment_name = "automation-${local.env_name}-%s"
+    app_environment_name        = "app-${local.env_name}-%s"
+    opex_environment_name       = "opex-${local.env_name}-%s"
 
     issuer   = "https://token.actions.githubusercontent.com"
     audience = ["api://AzureADTokenExchange"]
@@ -103,6 +104,13 @@ locals {
   }
 
   infra_cd = {
+    secrets = {
+      "ARM_CLIENT_ID"       = azurerm_user_assigned_identity.infra_cd.client_id
+      "ARM_SUBSCRIPTION_ID" = data.azurerm_subscription.current.subscription_id
+    }
+  }
+
+  automation_cd = {
     secrets = {
       "ARM_CLIENT_ID"       = azurerm_user_assigned_identity.infra_cd.client_id
       "ARM_SUBSCRIPTION_ID" = data.azurerm_subscription.current.subscription_id


### PR DESCRIPTION
Add support for the `automation-{env}-cd` GitHub environment in the `azure_github_environment_bootstrap` Terraform module.

This new environment type is intended for automation workflows (e.g. TLS certificate renewal) that need Azure credentials but are distinct from `infra`, `app`, and `opex` environments. The environment shares the `infra_cd` managed identity and exposes `ARM_CLIENT_ID` and `ARM_SUBSCRIPTION_ID` as secrets.

Close CES-2167