### PR TITLE
Add automation-cd environment to github_environment_bootstrap

### DIFF
--- a/.nx/version-plans/version-plan-1782118662711.md
+++ b/.nx/version-plans/version-plan-1782118662711.md
@@ -1,0 +1,5 @@
+---
+github_environment_bootstrap: minor
+---
+
+Add automation-cd GitHub environment

--- a/infra/modules/github_environment_bootstrap/README.md
+++ b/infra/modules/github_environment_bootstrap/README.md
@@ -15,6 +15,18 @@ For more information on setting up and managing infrastructure in a monoreposito
 - Integrates with Jira by adding autolink references for specified boards.
 - Allows customization of repository topics and descriptions.
 
+### Supported GitHub Environments
+
+This module creates the following GitHub environments:
+
+- `infra-ci`: For continuous integration of infrastructure code.
+- `infra-cd`: For continuous deployment of infrastructure code (requires manual approval).
+- `automation-cd`: For continuous deployment of automated tasks.
+- `opex-ci`: For continuous integration of operational expenditure code.
+- `opex-cd`: For continuous deployment of operational expenditure code (requires manual approval).
+- `app-ci`: For continuous integration of application code.
+- `app-cd`: For continuous deployment of application code (requires manual approval).
+
 ### Usage Example
 
 ```hcl

--- a/infra/modules/github_environment_bootstrap/README.md
+++ b/infra/modules/github_environment_bootstrap/README.md
@@ -131,6 +131,7 @@ No modules.
 | [github_repository_autolink_reference.jira_board](https://registry.terraform.io/providers/integrations/github/latest/docs/resources/repository_autolink_reference) | resource |
 | [github_repository_environment.app_cd](https://registry.terraform.io/providers/integrations/github/latest/docs/resources/repository_environment) | resource |
 | [github_repository_environment.app_ci](https://registry.terraform.io/providers/integrations/github/latest/docs/resources/repository_environment) | resource |
+| [github_repository_environment.automation_cd](https://registry.terraform.io/providers/integrations/github/latest/docs/resources/repository_environment) | resource |
 | [github_repository_environment.bootstrapper_cd](https://registry.terraform.io/providers/integrations/github/latest/docs/resources/repository_environment) | resource |
 | [github_repository_environment.infra_cd](https://registry.terraform.io/providers/integrations/github/latest/docs/resources/repository_environment) | resource |
 | [github_repository_environment.infra_ci](https://registry.terraform.io/providers/integrations/github/latest/docs/resources/repository_environment) | resource |
@@ -138,6 +139,8 @@ No modules.
 | [github_repository_environment.opex_ci](https://registry.terraform.io/providers/integrations/github/latest/docs/resources/repository_environment) | resource |
 | [github_repository_environment_deployment_policy.app_cd_branch](https://registry.terraform.io/providers/integrations/github/latest/docs/resources/repository_environment_deployment_policy) | resource |
 | [github_repository_environment_deployment_policy.app_cd_tag](https://registry.terraform.io/providers/integrations/github/latest/docs/resources/repository_environment_deployment_policy) | resource |
+| [github_repository_environment_deployment_policy.automation_cd_branch](https://registry.terraform.io/providers/integrations/github/latest/docs/resources/repository_environment_deployment_policy) | resource |
+| [github_repository_environment_deployment_policy.automation_cd_tag](https://registry.terraform.io/providers/integrations/github/latest/docs/resources/repository_environment_deployment_policy) | resource |
 | [github_repository_environment_deployment_policy.bootstrapper_cd_branch](https://registry.terraform.io/providers/integrations/github/latest/docs/resources/repository_environment_deployment_policy) | resource |
 | [github_repository_environment_deployment_policy.bootstrapper_cd_tag](https://registry.terraform.io/providers/integrations/github/latest/docs/resources/repository_environment_deployment_policy) | resource |
 | [github_repository_environment_deployment_policy.infra_cd_branch](https://registry.terraform.io/providers/integrations/github/latest/docs/resources/repository_environment_deployment_policy) | resource |

--- a/infra/modules/github_environment_bootstrap/github_environments_cd.tf
+++ b/infra/modules/github_environment_bootstrap/github_environments_cd.tf
@@ -17,6 +17,17 @@ resource "github_repository_environment" "infra_cd" {
   }
 }
 
+resource "github_repository_environment" "automation_cd" {
+  for_each    = toset(var.repository.environments)
+  environment = "automation-${each.value}-cd"
+  repository  = github_repository.this.name
+
+  deployment_branch_policy {
+    protected_branches     = false
+    custom_branch_policies = true
+  }
+}
+
 resource "github_repository_environment" "app_cd" {
   for_each    = toset(var.repository.environments)
   environment = "app-${each.value}-cd"
@@ -82,6 +93,14 @@ resource "github_repository_environment_deployment_policy" "infra_cd_branch" {
   branch_pattern = each.value.branch
 }
 
+resource "github_repository_environment_deployment_policy" "automation_cd_branch" {
+  for_each = { for k, v in setproduct(var.repository.environments, var.repository.infra_cd_policy_branches) : "${v[0]}-${v[1]}" => { env = v[0], branch = v[1] } }
+
+  repository     = github_repository.this.name
+  environment    = github_repository_environment.automation_cd[each.value.env].environment
+  branch_pattern = each.value.branch
+}
+
 resource "github_repository_environment_deployment_policy" "app_cd_branch" {
   for_each = { for k, v in setproduct(var.repository.environments, var.repository.app_cd_policy_branches) : "${v[0]}-${v[1]}" => { env = v[0], branch = v[1] } }
 
@@ -111,6 +130,14 @@ resource "github_repository_environment_deployment_policy" "infra_cd_tag" {
 
   repository  = github_repository.this.name
   environment = github_repository_environment.infra_cd[each.value.env].environment
+  tag_pattern = each.value.tag
+}
+
+resource "github_repository_environment_deployment_policy" "automation_cd_tag" {
+  for_each = { for k, v in setproduct(var.repository.environments, var.repository.infra_cd_policy_tags) : "${v[0]}-${v[1]}" => { env = v[0], tag = v[1] } }
+
+  repository  = github_repository.this.name
+  environment = github_repository_environment.automation_cd[each.value.env].environment
   tag_pattern = each.value.tag
 }
 


### PR DESCRIPTION
Add the `automation-{env}-cd` GitHub repository environment to the `github_environment_bootstrap` Terraform module, with branch and tag deployment policies matching the existing `infra-cd` pattern.

This environment type is intended for automation workflows (e.g. TLS certificate renewal) that are distinct from `infra`, `app`, and `opex` deployments.

Close CES-2168