### PR TITLE
Add DX CLI init skill

### DIFF
--- a/.github/skills/dx-cli/LICENSE.txt
+++ b/.github/skills/dx-cli/LICENSE.txt
@@ -1,0 +1,201 @@
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright 2026 PagoPA
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/.github/skills/dx-cli/SKILL.md
+++ b/.github/skills/dx-cli/SKILL.md
@@ -1,0 +1,60 @@
+---
+name: dx-cli
+description: Run the PagoPA DX CLI to inspect the live command surface with `dx spec` and bootstrap new workspaces with `dx init`. Use when the user asks to create a new DX monorepo, scaffold a repository, publish the scaffold to GitHub, or otherwise run the DX CLI. Always start from `dx spec`, support only `init` for now, and do not run separate precondition or tool-availability checks before invoking the CLI.
+license: Complete terms in LICENSE.txt
+---
+
+# DX CLI Skill
+
+Use this skill when an agent needs to run the PagoPA DX CLI.
+
+## Supported Scope
+
+- Support only `dx init` for now.
+- If the user asks for another `dx` subcommand, stop and explain that this skill currently supports `init` only.
+
+## Core Rules
+
+1. Run `dx spec` first and treat its JSON output as the source of truth for commands, flags, and global options.
+2. Prefer `pnpm dx ...` inside the `pagopa/dx` repository. Prefer `dx ...` when the CLI is already installed in the target environment.
+3. Do not scrape `--help` when `dx spec` is available.
+4. Do not run separate precondition checks such as `terraform -version`, `corepack -v`, `gh auth status`, `az account show`, or repository-existence probes. Invoke the requested DX CLI command directly and let the CLI surface any failures.
+5. Ask only for the missing inputs needed to run `init`, one question at a time. Do not ask about prerequisites.
+6. Prefer explicit flags over interactive prompts. The current CLI has `--publish` but no `--no-publish`, so a fully prompt-free run currently requires the user to want immediate publication.
+7. For agent-friendly automation, prefer `--output json`. In JSON mode, `init` emits progress events on stderr and the final result on stdout.
+
+## Workflow
+
+Follow the detailed [init workflow reference](./references/init-workflow.md).
+
+## Quick Commands
+
+```bash
+# Inspect the live CLI surface first
+pnpm dx spec
+dx spec
+
+# Run init interactively
+pnpm dx init
+dx init
+
+# Run init with all metadata prefilled (the CLI still prompts for publish when --publish is omitted)
+pnpm dx --output json init --name <name> --owner <owner> --description "<description>"
+dx --output json init --name <name> --owner <owner> --description "<description>"
+
+# Run init fully non-interactively with immediate publish
+pnpm dx --output json init --name <name> --owner <owner> --description "<description>" --publish
+dx --output json init --name <name> --owner <owner> --description "<description>" --publish
+```
+
+## Troubleshooting
+
+| Problem                                                                       | Action                                                                                                                     |
+| ----------------------------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------- |
+| `pnpm dx ...` fails because `apps/cli/dist` is missing in the source checkout | Run `pnpm nx run @pagopa/dx-cli:build`, then rerun the same `pnpm dx ...` command.                                         |
+| `dx init` fails because Terraform, Corepack, or auth is missing               | Surface the CLI error as-is. Do not add your own preflight phase on retry unless the user explicitly asks for diagnostics. |
+| The user asks for a `dx` command other than `init`                            | Stop and explain that this skill currently supports `init` only.                                                           |
+
+## References
+
+- [Init workflow](./references/init-workflow.md)

--- a/.github/skills/dx-cli/references/init-workflow.md
+++ b/.github/skills/dx-cli/references/init-workflow.md
@@ -1,0 +1,93 @@
+# `dx init` Workflow
+
+This workflow is intentionally limited to `dx init` and must always start from the live `dx spec` output.
+
+## 1. Read the live CLI spec first
+
+Run one of these commands before doing anything else:
+
+```bash
+# Inside the pagopa/dx repository
+pnpm dx spec
+
+# In an environment where the CLI is already installed
+dx spec
+```
+
+Filter the JSON to the root `globalOptions` plus the `init` command entry instead of scraping `--help`.
+
+The current live `init` surface includes:
+
+| Scope  | Flag                          | Meaning                                                       |
+| ------ | ----------------------------- | ------------------------------------------------------------- |
+| global | `-v, --verbose`               | Enable verbose logging and full error chains                  |
+| global | `--output <mode>`             | Select `text` or `json` output                                |
+| init   | `--name <name>`               | Repository name                                               |
+| init   | `--owner <owner>`             | GitHub organization or user that owns the repository          |
+| init   | `--description <description>` | Repository description                                        |
+| init   | `--publish`                   | Publish the scaffolded repository to GitHub without prompting |
+
+Re-read `dx spec` for every task. Do not trust stale documentation over the live command surface.
+
+## 2. Choose the execution mode
+
+Use the simplest command that matches the user's request:
+
+- Run `dx init` only when the user explicitly wants the interactive experience and the runtime can handle prompts.
+- Prefer `dx --output json init ...` when the user has already provided the inputs or when an agent needs structured progress/output.
+- Add `--publish` only when the user explicitly wants immediate GitHub publication.
+- The current CLI does not expose `--no-publish`, so omitting `--publish` still leads to an interactive confirmation later in the flow.
+
+## 3. Ask only for missing command inputs
+
+When you need more information, ask only for missing `init` inputs:
+
+1. Repository name
+2. GitHub owner
+3. Repository description
+4. Whether to publish immediately
+
+Do **not** ask about Terraform, Corepack, GitHub authentication, Azure authentication, or whether the repository already exists. Those checks belong to the CLI, not to the agent.
+
+If the user does not want immediate publication and the runtime cannot answer interactive prompts, explain that the current CLI surface still prompts for that decision.
+
+## 4. Run the requested command directly
+
+Examples:
+
+```bash
+# Interactive
+dx init
+
+# Prefilled scaffold (the CLI still prompts for publish confirmation later)
+dx --output json init \
+  --name my-monorepo \
+  --owner pagopa \
+  --description "My new PagoPA monorepo"
+
+# Non-interactive scaffold and publish immediately
+dx --output json init \
+  --name my-monorepo \
+  --owner pagopa \
+  --description "My new PagoPA monorepo" \
+  --publish
+```
+
+Inside the `pagopa/dx` source repository, replace `dx` with `pnpm dx`.
+
+## 5. Interpret the result without adding your own preflight logic
+
+When you run `init` with `--output json`:
+
+- progress step events are emitted on stderr
+- the final result is emitted on stdout
+
+If the final result contains `gitHubRepoCreationSkipped: true`, the workspace was scaffolded locally and GitHub publication was skipped intentionally.
+
+If the command fails because prerequisites are missing or authentication is not ready, surface the CLI error clearly. Do not insert extra precondition checks before retrying unless the user explicitly asks for diagnosis.
+
+## 6. Respect the current boundary
+
+- Support only `init`
+- Always run `dx spec` first
+- Never run agent-side precondition checks before invoking the CLI


### PR DESCRIPTION
## Summary
- add a repo-local `dx-cli` skill under `.github/skills/`
- make the skill start from the live `dx spec` output and scope it to `dx init`
- document that agents must invoke the CLI directly instead of running separate precondition checks, including the current `--publish` limitation for fully prompt-free runs

## Notes
- the skill includes a dedicated `init` workflow reference plus an Apache 2.0 `LICENSE.txt`
- `pnpm nx release plan:check` reports that these changes do not touch released projects, so no new version plan file is required