### PR TITLE
Align Azure authorization with repo owner

### DIFF
--- a/.nx/version-plans/version-plan-1782204343110.md
+++ b/.nx/version-plans/version-plan-1782204343110.md
@@ -1,0 +1,5 @@
+---
+'@pagopa/dx-cli': patch
+---
+
+Make Azure authorization follow the selected GitHub owner

--- a/apps/cli/src/adapters/commander/commands/__tests__/add.test.ts
+++ b/apps/cli/src/adapters/commander/commands/__tests__/add.test.ts
@@ -36,7 +36,7 @@ const makeEnvPayload = (
   ...overrides,
 });
 
-describe("authorizeCloudAccounts", () => {
+describe("authorizeCloudAccounts edge cases", () => {
   it("returns empty array when init is undefined (env already initialized)", async () => {
     const authService = mock<AuthorizationService>();
     const envPayload = makeEnvPayload({ init: undefined });
@@ -98,6 +98,36 @@ describe("authorizeCloudAccounts", () => {
     );
   });
 
+  it("forwards the current repository owner to the authorization request", async () => {
+    const authService = mock<AuthorizationService>();
+    authService.requestAuthorization.mockReturnValue(
+      okAsync(new AuthorizationResult("https://example.com/pr/owner-aware")),
+    );
+
+    const account = {
+      csp: "azure" as const,
+      defaultLocation: "italynorth",
+      displayName: "DEV-FooBar",
+      id: "sub-123",
+    };
+
+    const envPayload = makeEnvPayload({
+      github: { owner: "pagopa-dx", repo: "test-repo" },
+      init: { cloudAccountsToInitialize: [account] },
+    });
+
+    const result = await authorizeCloudAccounts(authService)(envPayload);
+
+    expect(result.isOk()).toBe(true);
+    expect(authService.requestAuthorization).toHaveBeenCalledWith(
+      expect.objectContaining({
+        repoOwner: "pagopa-dx",
+      }),
+    );
+  });
+});
+
+describe("authorizeCloudAccounts", () => {
   it("computes correct identity for westeurope location", async () => {
     const authService = mock<AuthorizationService>();
     authService.requestAuthorization.mockReturnValue(

--- a/apps/cli/src/adapters/commander/commands/add.ts
+++ b/apps/cli/src/adapters/commander/commands/add.ts
@@ -75,6 +75,7 @@ export const authorizeCloudAccounts =
           envShort,
           prefix,
           repoName: envPayload.github.repo,
+          repoOwner: envPayload.github.owner,
           subscriptionName: account.displayName,
         });
 

--- a/apps/cli/src/adapters/pagopa-technology/__tests__/authorization.test.ts
+++ b/apps/cli/src/adapters/pagopa-technology/__tests__/authorization.test.ts
@@ -38,6 +38,7 @@ const makeSampleInput = (): RequestAuthorizationInput =>
     envShort: "d",
     prefix: "test",
     repoName: "test-repo",
+    repoOwner: "pagopa",
     subscriptionName: "test-subscription",
   });
 
@@ -108,6 +109,59 @@ describe("PagoPA AuthorizationService", () => {
         body: "This PR adds the bootstrap identity `test-bootstrap-identity-id` to the directory readers and configures AD groups for subscription `test-subscription`.",
         head: "feats/add-test-repo-test-subscription-bootstrap-identity",
         owner: "pagopa",
+        repo: "eng-azure-authorization",
+        title: "Add bootstrap identity and AD groups for test-subscription",
+      });
+    });
+
+    it("should target the authorization repository under the selected owner", async () => {
+      const { authorizationService, gitHubService } = makeEnv();
+      const input = requestAuthorizationInputSchema.parse({
+        bootstrapIdentityId: "test-bootstrap-identity-id",
+        envShort: "d",
+        prefix: "test",
+        repoName: "test-repo",
+        repoOwner: "pagopa-dx",
+        subscriptionName: "test-subscription",
+      });
+      const originalContent = JSON.stringify(
+        { directory_readers: { service_principals_name: [] } },
+        null,
+        2,
+      );
+
+      gitHubService.createBranch.mockResolvedValue(undefined);
+      gitHubService.getFileContent.mockResolvedValue({
+        content: originalContent,
+        sha: "owner-aware-sha-123",
+      });
+      gitHubService.updateFile.mockResolvedValue(undefined);
+      gitHubService.createPullRequest.mockResolvedValue(
+        new PullRequest(
+          "https://github.com/pagopa-dx/eng-azure-authorization/pull/42",
+        ),
+      );
+
+      const result = await authorizationService.requestAuthorization(input);
+
+      expect(result.isOk()).toBe(true);
+      expect(gitHubService.getFileContent).toHaveBeenCalledWith({
+        owner: "pagopa-dx",
+        path: FILE_PATH,
+        ref: "main",
+        repo: "eng-azure-authorization",
+      });
+      expect(gitHubService.createBranch).toHaveBeenCalledWith({
+        branchName: "feats/add-test-repo-test-subscription-bootstrap-identity",
+        fromRef: "main",
+        owner: "pagopa-dx",
+        repo: "eng-azure-authorization",
+      });
+      expect(gitHubService.createPullRequest).toHaveBeenCalledWith({
+        base: "main",
+        body: "This PR adds the bootstrap identity `test-bootstrap-identity-id` to the directory readers and configures AD groups for subscription `test-subscription`.",
+        head: "feats/add-test-repo-test-subscription-bootstrap-identity",
+        owner: "pagopa-dx",
         repo: "eng-azure-authorization",
         title: "Add bootstrap identity and AD groups for test-subscription",
       });

--- a/apps/cli/src/adapters/pagopa-technology/azure-authorization.ts
+++ b/apps/cli/src/adapters/pagopa-technology/azure-authorization.ts
@@ -211,7 +211,6 @@ const ensureIdentity = (
   };
 };
 
-const REPO_OWNER = "pagopa";
 const REPO_NAME = "eng-azure-authorization";
 const BASE_BRANCH = "main";
 
@@ -227,8 +226,10 @@ export const makeAzureAuthorizationService = (
       envShort,
       prefix,
       repoName,
+      repoOwner,
       subscriptionName,
     } = input;
+    const authorizationRepoOwner = repoOwner;
     const filePath = `src/azure-subscriptions/subscriptions/${subscriptionName}/terraform.tfvars.json`;
     const branchName = `feats/add-${repoName}-${subscriptionName}-bootstrap-identity`;
 
@@ -236,14 +237,14 @@ export const makeAzureAuthorizationService = (
       // Step 1: Read file from main to determine if changes are needed
       ResultAsync.fromPromise(
         gitHubService.getFileContent({
-          owner: REPO_OWNER,
+          owner: authorizationRepoOwner,
           path: filePath,
           ref: BASE_BRANCH,
           repo: REPO_NAME,
         }),
         () =>
           new AuthorizationError(
-            `Unable to get ${filePath} in ${REPO_OWNER}/${REPO_NAME}`,
+            `Unable to get ${filePath} in ${authorizationRepoOwner}/${REPO_NAME}`,
           ),
       )
         .orTee((error) => {
@@ -298,12 +299,12 @@ export const makeAzureAuthorizationService = (
               gitHubService.createBranch({
                 branchName,
                 fromRef: BASE_BRANCH,
-                owner: REPO_OWNER,
+                owner: authorizationRepoOwner,
                 repo: REPO_NAME,
               }),
               () =>
                 new AuthorizationError(
-                  `Unable to create branch ${branchName} in ${REPO_OWNER}/${REPO_NAME}`,
+                  `Unable to create branch ${branchName} in ${authorizationRepoOwner}/${REPO_NAME}`,
                 ),
             )
               .orTee((error) => {
@@ -316,14 +317,14 @@ export const makeAzureAuthorizationService = (
                     branch: branchName,
                     content: JSON.stringify(updatedJson, null, 2),
                     message,
-                    owner: REPO_OWNER,
+                    owner: authorizationRepoOwner,
                     path: filePath,
                     repo: REPO_NAME,
                     sha,
                   }),
                   () =>
                     new AuthorizationError(
-                      `Unable to update ${filePath} on branch ${branchName} in ${REPO_OWNER}/${REPO_NAME}`,
+                      `Unable to update ${filePath} on branch ${branchName} in ${authorizationRepoOwner}/${REPO_NAME}`,
                     ),
                 ),
               )
@@ -337,13 +338,13 @@ export const makeAzureAuthorizationService = (
                     base: BASE_BRANCH,
                     body,
                     head: branchName,
-                    owner: REPO_OWNER,
+                    owner: authorizationRepoOwner,
                     repo: REPO_NAME,
                     title,
                   }),
                   () =>
                     new AuthorizationError(
-                      `Unable to create pull request from ${branchName} to ${BASE_BRANCH} in ${REPO_OWNER}/${REPO_NAME}`,
+                      `Unable to create pull request from ${branchName} to ${BASE_BRANCH} in ${authorizationRepoOwner}/${REPO_NAME}`,
                     ),
                 ),
               )

--- a/apps/cli/src/domain/authorization.ts
+++ b/apps/cli/src/domain/authorization.ts
@@ -67,6 +67,7 @@ export const requestAuthorizationInputSchema = z.object({
   envShort: EnvShort,
   prefix: ResourcePrefix,
   repoName: z.string().min(1),
+  repoOwner: z.string().min(1),
   subscriptionName: SubscriptionName,
 });
 

--- a/apps/cli/src/use-cases/__tests__/request-authorization.test.ts
+++ b/apps/cli/src/use-cases/__tests__/request-authorization.test.ts
@@ -21,6 +21,7 @@ const makeSampleInput = (): RequestAuthorizationInput =>
     envShort: "d",
     prefix: "test",
     repoName: "test-repo",
+    repoOwner: "pagopa",
     subscriptionName: "test-subscription",
   });
 


### PR DESCRIPTION
When a repository is initialized under an organization other than `pagopa`, `dx add environment` still opens the Azure authorization pull request against `pagopa/eng-azure-authorization`. This breaks the bootstrap flow for repositories created under `pagopa-dx` or any other supported owner.

This change threads the selected GitHub owner through the authorization request and uses it to target `<owner>/eng-azure-authorization` while keeping the authorization repository name fixed. It also extends the CLI tests to cover non-default owners and adds the required patch version plan for `@pagopa/dx-cli`.

## What changed

- add `repoOwner` to the authorization input contract and pass it from `dx add environment`
- update the Azure authorization adapter to use the propagated owner for file reads, branch creation, file updates, and pull request creation
- add regression coverage for owner-aware command, use-case, and adapter behavior
- add the CLI patch release plan