### PR TITLE
Support ESLint 9 alongside ESLint 10

### DIFF
--- a/.nx/version-plans/version-plan-1782213453124.md
+++ b/.nx/version-plans/version-plan-1782213453124.md
@@ -1,0 +1,5 @@
+---
+'@pagopa/eslint-config': minor
+---
+
+Support ESLint 9 alongside ESLint 10

--- a/packages/eslint-config/README.md
+++ b/packages/eslint-config/README.md
@@ -2,12 +2,25 @@
 
 This package provides PagoPA's `eslint.config.js` as an extensible shared config.
 
+It supports both **ESLint 9** and **ESLint 10**.
+
 ## Usage
 
-1. Install `eslint` and `@pagopa/eslint-config` and its peer dependencies: `eslint` and `prettier`
+1. Install `@pagopa/eslint-config` together with its peer dependencies.
+
+   The required peers are `eslint`, `@eslint/js` (matching the same major as `eslint`), and `prettier`.
+
+   For ESLint 10:
 
    ```shell
-   pnpm add -D eslint @pagopa/eslint-config eslint
+   pnpm add -D eslint@^10 @eslint/js@^10 @pagopa/eslint-config
+   pnpm add -D -E prettier
+   ```
+
+   For ESLint 9 (e.g. React Native apps):
+
+   ```shell
+   pnpm add -D eslint@^9 @eslint/js@^9 @pagopa/eslint-config
    pnpm add -D -E prettier
    ```
 

--- a/packages/eslint-config/package.json
+++ b/packages/eslint-config/package.json
@@ -16,7 +16,6 @@
     "index.js"
   ],
   "dependencies": {
-    "@eslint/js": "^10.0.1",
     "@vitest/eslint-plugin": "^1.6.13",
     "eslint-config-prettier": "^10.1.5",
     "eslint-plugin-perfectionist": "^5.7.0",
@@ -25,11 +24,13 @@
     "typescript-eslint": "^8.59.1"
   },
   "devDependencies": {
+    "@eslint/js": "^10.0.1",
     "eslint": "catalog:",
     "prettier": "catalog:"
   },
   "peerDependencies": {
-    "eslint": "^10.0.0",
+    "@eslint/js": "^9.0.0 || ^10.0.0",
+    "eslint": "^9.0.0 || ^10.0.0",
     "prettier": ">=3.0.0"
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1130,9 +1130,6 @@ importers:
 
   packages/eslint-config:
     dependencies:
-      '@eslint/js':
-        specifier: ^10.0.1
-        version: 10.0.1(eslint@10.3.0(jiti@2.7.0))
       '@vitest/eslint-plugin':
         specifier: ^1.6.13
         version: 1.6.13(@typescript-eslint/eslint-plugin@8.59.1(@typescript-eslint/parser@8.59.1(eslint@10.3.0(jiti@2.7.0))(typescript@5.9.3))(eslint@10.3.0(jiti@2.7.0))(typescript@5.9.3))(eslint@10.3.0(jiti@2.7.0))(typescript@5.9.3)(vitest@4.1.8)
@@ -1152,6 +1149,9 @@ importers:
         specifier: ^8.59.1
         version: 8.59.1(eslint@10.3.0(jiti@2.7.0))(typescript@5.9.3)
     devDependencies:
+      '@eslint/js':
+        specifier: ^10.0.1
+        version: 10.0.1(eslint@10.3.0(jiti@2.7.0))
       eslint:
         specifier: 'catalog:'
         version: 10.3.0(jiti@2.7.0)


### PR DESCRIPTION
Widen the eslint and @eslint/js peer ranges to ^9.0.0 || ^10.0.0 so
React Native applications (which are pinned to ESLint 9) can use this
shared config. @eslint/js moves from a regular dependency to a peer
dependency so the consumer's ESLint major dictates the matching
@eslint/js major.

Refs CES-1940

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>
