### PR TITLE
Add /jest subpath export to @pagopa/eslint-config

### DIFF
--- a/.nx/version-plans/version-plan-1782213453124.md
+++ b/.nx/version-plans/version-plan-1782213453124.md
@@ -1,0 +1,5 @@
+---
+'@pagopa/eslint-config': minor
+---
+
+Support ESLint 9 alongside ESLint 10

--- a/.nx/version-plans/version-plan-1782215083050.md
+++ b/.nx/version-plans/version-plan-1782215083050.md
@@ -1,0 +1,5 @@
+---
+'@pagopa/eslint-config': minor
+---
+
+Add @pagopa/eslint-config/jest subpath for Jest / React Native consumers

--- a/packages/eslint-config/README.md
+++ b/packages/eslint-config/README.md
@@ -45,3 +45,31 @@ It supports both **ESLint 9** and **ESLint 10**.
      }
    }
    ```
+
+## Test-runner support
+
+The default entry point ships rules for [Vitest](https://vitest.dev/). A separate
+`@pagopa/eslint-config/jest` subpath provides the equivalent rules for
+[Jest](https://jestjs.io/), which is the default test runner for React Native apps.
+
+### Jest (React Native)
+
+Install `eslint-plugin-jest` alongside the regular peer dependencies:
+
+```shell
+pnpm add -D eslint-plugin-jest
+```
+
+Then import the `/jest` subpath:
+
+```js
+import pagopa from "@pagopa/eslint-config/jest";
+
+export default [...pagopa];
+```
+
+> [!NOTE]
+> React Native apps should compose this configuration with
+> [`@react-native/eslint-config`](https://www.npmjs.com/package/@react-native/eslint-config),
+> which contributes the React, React Hooks and React Native rule sets that this package
+> intentionally leaves out.

--- a/packages/eslint-config/README.md
+++ b/packages/eslint-config/README.md
@@ -17,7 +17,7 @@ It supports both **ESLint 9** and **ESLint 10**.
    pnpm add -D -E prettier
    ```
 
-   For ESLint 9 (e.g. React Native apps):
+   For ESLint 9:
 
    ```shell
    pnpm add -D eslint@^9 @eslint/js@^9 @pagopa/eslint-config
@@ -32,7 +32,7 @@ It supports both **ESLint 9** and **ESLint 10**.
    ```js
    import pagopa from "@pagopa/eslint-config";
 
-   export default [...pagopa];
+   export default pagopa;
    ```
 
 3. Add `lint` and `lint:check` scripts in your `package.json`
@@ -52,7 +52,7 @@ The default entry point ships rules for [Vitest](https://vitest.dev/). A separat
 `@pagopa/eslint-config/jest` subpath provides the equivalent rules for
 [Jest](https://jestjs.io/), which is the default test runner for React Native apps.
 
-### Jest (React Native)
+### Jest
 
 Install `eslint-plugin-jest` alongside the regular peer dependencies:
 
@@ -65,11 +65,5 @@ Then import the `/jest` subpath:
 ```js
 import pagopa from "@pagopa/eslint-config/jest";
 
-export default [...pagopa];
+export default pagopa;
 ```
-
-> [!NOTE]
-> React Native apps should compose this configuration with
-> [`@react-native/eslint-config`](https://www.npmjs.com/package/@react-native/eslint-config),
-> which contributes the React, React Hooks and React Native rule sets that this package
-> intentionally leaves out.

--- a/packages/eslint-config/base.js
+++ b/packages/eslint-config/base.js
@@ -1,0 +1,40 @@
+import eslint from "@eslint/js";
+import perfectionist from "eslint-plugin-perfectionist";
+import prettier from "eslint-plugin-prettier/recommended";
+import tseslint from "typescript-eslint";
+
+export const TEST_FILES = [
+  "**/tests/**/*.{js,ts}",
+  "**/__tests__/**/*.{js,ts}",
+  "**/*.{test,spec}.{js,ts}",
+];
+
+export default [
+  eslint.configs.recommended,
+  ...tseslint.configs.strict,
+  ...tseslint.configs.stylistic,
+  prettier,
+  perfectionist.configs["recommended-natural"],
+  {
+    rules: {
+      "@typescript-eslint/no-unused-expressions": "error",
+      "@typescript-eslint/no-unused-vars": ["error", { args: "after-used" }],
+      "arrow-body-style": "error",
+      complexity: "error",
+      eqeqeq: ["error", "smart"],
+      "guard-for-in": "error",
+      "max-lines-per-function": ["error", 200],
+      "no-bitwise": "error",
+      "no-eval": "error",
+      "no-new-wrappers": "error",
+      "no-param-reassign": "error",
+      "no-undef-init": "error",
+      "no-var": "error",
+      "prefer-const": "error",
+      radix: "error",
+    },
+  },
+  {
+    ignores: ["**/generated/*", "**/dist/**", "**/bin/**"],
+  },
+];

--- a/packages/eslint-config/index.js
+++ b/packages/eslint-config/index.js
@@ -1,21 +1,11 @@
-import eslint from "@eslint/js";
 import vitest from "@vitest/eslint-plugin";
-import perfectionist from "eslint-plugin-perfectionist";
-import prettier from "eslint-plugin-prettier/recommended";
-import tseslint from "typescript-eslint";
+
+import base, { TEST_FILES } from "./base.js";
 
 export default [
-  eslint.configs.recommended,
-  ...tseslint.configs.strict,
-  ...tseslint.configs.stylistic,
-  prettier,
-  perfectionist.configs["recommended-natural"],
+  ...base,
   {
-    files: [
-      "**/tests/**/*.{js,ts}",
-      "**/__tests__/**/*.{js,ts}",
-      "**/*.{test,spec}.{js,ts}",
-    ],
+    files: TEST_FILES,
     ...vitest.configs.recommended,
     rules: {
       ...vitest.configs.recommended.rules,
@@ -26,27 +16,5 @@ export default [
       "vitest/prefer-spy-on": "error",
       "vitest/prefer-todo": "error",
     },
-  },
-  {
-    rules: {
-      "@typescript-eslint/no-unused-expressions": "error",
-      "@typescript-eslint/no-unused-vars": ["error", { args: "after-used" }],
-      "arrow-body-style": "error",
-      complexity: "error",
-      eqeqeq: ["error", "smart"],
-      "guard-for-in": "error",
-      "max-lines-per-function": ["error", 200],
-      "no-bitwise": "error",
-      "no-eval": "error",
-      "no-new-wrappers": "error",
-      "no-param-reassign": "error",
-      "no-undef-init": "error",
-      "no-var": "error",
-      "prefer-const": "error",
-      radix: "error",
-    },
-  },
-  {
-    ignores: ["**/generated/*", "**/dist/**", "**/bin/**"],
   },
 ];

--- a/packages/eslint-config/jest.js
+++ b/packages/eslint-config/jest.js
@@ -1,0 +1,20 @@
+import jest from "eslint-plugin-jest";
+
+import base, { TEST_FILES } from "./base.js";
+
+export default [
+  ...base,
+  {
+    files: TEST_FILES,
+    ...jest.configs["flat/recommended"],
+    rules: {
+      ...jest.configs["flat/recommended"].rules,
+      "@typescript-eslint/no-empty-function": "off",
+      "jest/prefer-called-with": "error",
+      "jest/prefer-equality-matcher": "error",
+      "jest/prefer-expect-resolves": "error",
+      "jest/prefer-spy-on": "error",
+      "jest/prefer-todo": "error",
+    },
+  },
+];

--- a/packages/eslint-config/package.json
+++ b/packages/eslint-config/package.json
@@ -3,6 +3,10 @@
   "type": "module",
   "version": "6.1.0",
   "main": "index.js",
+  "exports": {
+    ".": "./index.js",
+    "./jest": "./jest.js"
+  },
   "repository": {
     "type": "git",
     "url": "git+https://github.com/pagopa/dx.git",
@@ -13,7 +17,9 @@
     "format:check": "prettier --check ."
   },
   "files": [
-    "index.js"
+    "base.js",
+    "index.js",
+    "jest.js"
   ],
   "dependencies": {
     "@vitest/eslint-plugin": "^1.6.20",
@@ -26,11 +32,18 @@
   "devDependencies": {
     "@eslint/js": "^10.0.1",
     "eslint": "catalog:",
+    "eslint-plugin-jest": "^29.0.0",
     "prettier": "catalog:"
   },
   "peerDependencies": {
     "@eslint/js": "^9.0.0 || ^10.0.0",
     "eslint": "^9.0.0 || ^10.0.0",
+    "eslint-plugin-jest": "^29.0.0",
     "prettier": ">=3.0.0"
+  },
+  "peerDependenciesMeta": {
+    "eslint-plugin-jest": {
+      "optional": true
+    }
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1204,6 +1204,9 @@ importers:
       eslint:
         specifier: 'catalog:'
         version: 10.6.0(jiti@2.7.0)
+      eslint-plugin-jest:
+        specifier: ^29.0.0
+        version: 29.15.2(@typescript-eslint/eslint-plugin@8.62.0(@typescript-eslint/parser@8.62.0(eslint@10.6.0(jiti@2.7.0))(typescript@5.9.3))(eslint@10.6.0(jiti@2.7.0))(typescript@5.9.3))(eslint@10.6.0(jiti@2.7.0))(typescript@5.9.3)
       prettier:
         specifier: 'catalog:'
         version: 3.8.3
@@ -8615,6 +8618,22 @@ packages:
       eslint: ^2 || ^3 || ^4 || ^5 || ^6 || ^7.2.0 || ^8 || ^9
     peerDependenciesMeta:
       '@typescript-eslint/parser':
+        optional: true
+
+  eslint-plugin-jest@29.15.2:
+    resolution: {integrity: sha512-kEN4r9RZl1xcsb4arGq89LrcVdOUFII/JSCwtTPJyv16mDwmPrcuEQwpxqZHeINvcsd7oK5O/rhdGlxFRaZwvQ==}
+    engines: {node: ^20.12.0 || ^22.0.0 || >=24.0.0}
+    peerDependencies:
+      '@typescript-eslint/eslint-plugin': ^8.0.0
+      eslint: ^8.57.0 || ^9.0.0 || ^10.0.0
+      jest: '*'
+      typescript: '>=4.8.4 <7.0.0'
+    peerDependenciesMeta:
+      '@typescript-eslint/eslint-plugin':
+        optional: true
+      jest:
+        optional: true
+      typescript:
         optional: true
 
   eslint-plugin-jsx-a11y@6.10.2:
@@ -22563,6 +22582,16 @@ snapshots:
     transitivePeerDependencies:
       - eslint-import-resolver-typescript
       - eslint-import-resolver-webpack
+      - supports-color
+
+  eslint-plugin-jest@29.15.2(@typescript-eslint/eslint-plugin@8.62.0(@typescript-eslint/parser@8.62.0(eslint@10.6.0(jiti@2.7.0))(typescript@5.9.3))(eslint@10.6.0(jiti@2.7.0))(typescript@5.9.3))(eslint@10.6.0(jiti@2.7.0))(typescript@5.9.3):
+    dependencies:
+      '@typescript-eslint/utils': 8.62.0(eslint@10.6.0(jiti@2.7.0))(typescript@5.9.3)
+      eslint: 10.6.0(jiti@2.7.0)
+    optionalDependencies:
+      '@typescript-eslint/eslint-plugin': 8.62.0(@typescript-eslint/parser@8.62.0(eslint@10.6.0(jiti@2.7.0))(typescript@5.9.3))(eslint@10.6.0(jiti@2.7.0))(typescript@5.9.3)
+      typescript: 5.9.3
+    transitivePeerDependencies:
       - supports-color
 
   eslint-plugin-jsx-a11y@6.10.2(eslint@9.39.4(jiti@2.7.0)):

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -910,7 +910,7 @@ importers:
         version: 3.4.2(tslib@2.8.1)
       '@microsoft/docusaurus-plugin-application-insights':
         specifier: ^4.0.1
-        version: 4.0.1(@docusaurus/core@3.10.1(@mdx-js/react@3.1.1(@types/react@19.2.17)(react@19.2.7))(@swc/core@1.15.43(@swc/helpers@0.5.21))(debug@4.4.3)(esbuild@0.28.1)(lightningcss@1.32.0)(postcss@8.5.16)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(typescript@5.9.3))(@docusaurus/types@3.10.1(@swc/core@1.15.43(@swc/helpers@0.5.21))(esbuild@0.28.1)(lightningcss@1.32.0)(postcss@8.5.16)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(@docusaurus/utils-validation@3.10.1(@swc/core@1.15.43(@swc/helpers@0.5.21))(esbuild@0.28.1)(lightningcss@1.32.0)(postcss@8.5.16)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+        version: 4.0.1(@docusaurus/core@3.10.1(@mdx-js/react@3.1.1(@types/react@19.2.17)(react@19.2.7))(@swc/core@1.15.43(@swc/helpers@0.5.21))(debug@4.4.3)(esbuild@0.28.1)(lightningcss@1.32.0)(postcss@8.5.16)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(typescript@5.9.3))(@docusaurus/types@3.10.1(@swc/core@1.15.43(@swc/helpers@0.5.21))(clean-css@5.3.3)(esbuild@0.28.1)(html-minifier-terser@7.2.0)(lightningcss@1.32.0)(postcss@8.5.16)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(@docusaurus/utils-validation@3.10.1(@swc/core@1.15.43(@swc/helpers@0.5.21))(esbuild@0.28.1)(lightningcss@1.32.0)(postcss@8.5.16)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
       gray-matter:
         specifier: ^4.0.3
         version: 4.0.3
@@ -17531,7 +17531,7 @@ snapshots:
       '@jest/schemas': 29.6.3
       '@types/istanbul-lib-coverage': 2.0.6
       '@types/istanbul-reports': 3.0.4
-      '@types/node': 22.20.0
+      '@types/node': 26.0.1
       '@types/yargs': 17.0.35
       chalk: 4.1.2
 
@@ -17841,7 +17841,7 @@ snapshots:
       '@nevware21/ts-utils': 0.15.0
       tslib: 2.8.1
 
-  '@microsoft/docusaurus-plugin-application-insights@4.0.1(@docusaurus/core@3.10.1(@mdx-js/react@3.1.1(@types/react@19.2.17)(react@19.2.7))(@swc/core@1.15.43(@swc/helpers@0.5.21))(debug@4.4.3)(esbuild@0.28.1)(lightningcss@1.32.0)(postcss@8.5.16)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(typescript@5.9.3))(@docusaurus/types@3.10.1(@swc/core@1.15.43(@swc/helpers@0.5.21))(esbuild@0.28.1)(lightningcss@1.32.0)(postcss@8.5.16)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(@docusaurus/utils-validation@3.10.1(@swc/core@1.15.43(@swc/helpers@0.5.21))(esbuild@0.28.1)(lightningcss@1.32.0)(postcss@8.5.16)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(react-dom@19.2.7(react@19.2.7))(react@19.2.7)':
+  '@microsoft/docusaurus-plugin-application-insights@4.0.1(@docusaurus/core@3.10.1(@mdx-js/react@3.1.1(@types/react@19.2.17)(react@19.2.7))(@swc/core@1.15.43(@swc/helpers@0.5.21))(debug@4.4.3)(esbuild@0.28.1)(lightningcss@1.32.0)(postcss@8.5.16)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(typescript@5.9.3))(@docusaurus/types@3.10.1(@swc/core@1.15.43(@swc/helpers@0.5.21))(clean-css@5.3.3)(esbuild@0.28.1)(html-minifier-terser@7.2.0)(lightningcss@1.32.0)(postcss@8.5.16)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(@docusaurus/utils-validation@3.10.1(@swc/core@1.15.43(@swc/helpers@0.5.21))(esbuild@0.28.1)(lightningcss@1.32.0)(postcss@8.5.16)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(react-dom@19.2.7(react@19.2.7))(react@19.2.7)':
     dependencies:
       '@docusaurus/core': 3.10.1(@mdx-js/react@3.1.1(@types/react@19.2.17)(react@19.2.7))(@swc/core@1.15.43(@swc/helpers@0.5.21))(debug@4.4.3)(esbuild@0.28.1)(lightningcss@1.32.0)(postcss@8.5.16)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(typescript@5.9.3)
       '@docusaurus/types': 3.10.1(@swc/core@1.15.43(@swc/helpers@0.5.21))(clean-css@5.3.3)(cssnano@6.1.2(postcss@8.5.16))(esbuild@0.28.1)(html-minifier-terser@7.2.0)(lightningcss@1.32.0)(postcss@8.5.16)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
@@ -19745,15 +19745,15 @@ snapshots:
   '@types/body-parser@1.19.6':
     dependencies:
       '@types/connect': 3.4.38
-      '@types/node': 22.20.0
+      '@types/node': 26.0.1
 
   '@types/bonjour@3.5.13':
     dependencies:
-      '@types/node': 22.20.0
+      '@types/node': 26.0.1
 
   '@types/bunyan@1.8.11':
     dependencies:
-      '@types/node': 22.20.0
+      '@types/node': 26.0.1
 
   '@types/chai@5.2.3':
     dependencies:
@@ -19763,11 +19763,11 @@ snapshots:
   '@types/connect-history-api-fallback@1.5.4':
     dependencies:
       '@types/express-serve-static-core': 4.19.8
-      '@types/node': 22.20.0
+      '@types/node': 26.0.1
 
   '@types/connect@3.4.38':
     dependencies:
-      '@types/node': 22.20.0
+      '@types/node': 26.0.1
 
   '@types/d3-array@3.2.2': {}
 
@@ -19894,13 +19894,13 @@ snapshots:
 
   '@types/docker-modem@3.0.6':
     dependencies:
-      '@types/node': 22.20.0
+      '@types/node': 26.0.1
       '@types/ssh2': 1.15.5
 
   '@types/dockerode@4.0.1':
     dependencies:
       '@types/docker-modem': 3.0.6
-      '@types/node': 22.20.0
+      '@types/node': 26.0.1
       '@types/ssh2': 1.15.5
 
   '@types/eslint@9.6.1':
@@ -19923,7 +19923,7 @@ snapshots:
 
   '@types/express-serve-static-core@4.19.8':
     dependencies:
-      '@types/node': 22.20.0
+      '@types/node': 26.0.1
       '@types/qs': 6.15.1
       '@types/range-parser': 1.2.7
       '@types/send': 1.2.1
@@ -19955,7 +19955,7 @@ snapshots:
 
   '@types/http-proxy@1.17.17':
     dependencies:
-      '@types/node': 22.20.0
+      '@types/node': 26.0.1
 
   '@types/inquirer@9.0.10':
     dependencies:
@@ -19987,7 +19987,7 @@ snapshots:
   '@types/liftoff@4.0.3':
     dependencies:
       '@types/fined': 1.1.5
-      '@types/node': 22.20.0
+      '@types/node': 26.0.1
 
   '@types/mdast@4.0.4':
     dependencies:
@@ -20001,7 +20001,7 @@ snapshots:
 
   '@types/mysql@2.15.27':
     dependencies:
-      '@types/node': 22.20.0
+      '@types/node': 26.0.1
 
   '@types/node@17.0.45': {}
 
@@ -20021,17 +20021,17 @@ snapshots:
 
   '@types/pg-pool@2.0.7':
     dependencies:
-      '@types/pg': 8.15.6
+      '@types/pg': 8.20.0
 
   '@types/pg@8.15.6':
     dependencies:
-      '@types/node': 22.20.0
+      '@types/node': 26.0.1
       pg-protocol: 1.15.0
       pg-types: 2.2.0
 
   '@types/pg@8.20.0':
     dependencies:
-      '@types/node': 22.20.0
+      '@types/node': 26.0.1
       pg-protocol: 1.15.0
       pg-types: 2.2.0
 
@@ -20074,18 +20074,18 @@ snapshots:
 
   '@types/sax@1.2.7':
     dependencies:
-      '@types/node': 22.20.0
+      '@types/node': 26.0.1
 
   '@types/semver@7.7.1': {}
 
   '@types/send@0.17.6':
     dependencies:
       '@types/mime': 1.3.5
-      '@types/node': 22.20.0
+      '@types/node': 26.0.1
 
   '@types/send@1.2.1':
     dependencies:
-      '@types/node': 22.20.0
+      '@types/node': 26.0.1
 
   '@types/serve-index@1.9.4':
     dependencies:
@@ -20094,20 +20094,20 @@ snapshots:
   '@types/serve-static@1.15.10':
     dependencies:
       '@types/http-errors': 2.0.5
-      '@types/node': 22.20.0
+      '@types/node': 26.0.1
       '@types/send': 0.17.6
 
   '@types/sockjs@0.3.36':
     dependencies:
-      '@types/node': 22.20.0
+      '@types/node': 26.0.1
 
   '@types/ssh2-streams@0.1.13':
     dependencies:
-      '@types/node': 22.20.0
+      '@types/node': 26.0.1
 
   '@types/ssh2@0.5.52':
     dependencies:
-      '@types/node': 22.20.0
+      '@types/node': 26.0.1
       '@types/ssh2-streams': 0.1.13
 
   '@types/ssh2@1.15.5':
@@ -20118,7 +20118,7 @@ snapshots:
 
   '@types/through@0.0.33':
     dependencies:
-      '@types/node': 22.20.0
+      '@types/node': 26.0.1
 
   '@types/tmp@0.2.6': {}
 
@@ -20135,7 +20135,7 @@ snapshots:
 
   '@types/ws@8.18.1':
     dependencies:
-      '@types/node': 22.20.0
+      '@types/node': 26.0.1
 
   '@types/yargs-parser@21.0.3': {}
 
@@ -22808,7 +22808,7 @@ snapshots:
 
   eval@0.1.8:
     dependencies:
-      '@types/node': 22.20.0
+      '@types/node': 26.0.1
       require-like: 0.1.2
 
   event-target-shim@5.0.1: {}
@@ -24350,7 +24350,7 @@ snapshots:
   jest-util@29.7.0:
     dependencies:
       '@jest/types': 29.6.3
-      '@types/node': 22.20.0
+      '@types/node': 26.0.1
       chalk: 4.1.2
       ci-info: 3.9.0
       graceful-fs: 4.2.11
@@ -24387,13 +24387,13 @@ snapshots:
 
   jest-worker@27.5.1:
     dependencies:
-      '@types/node': 22.20.0
+      '@types/node': 26.0.1
       merge-stream: 2.0.0
       supports-color: 8.1.1
 
   jest-worker@29.7.0:
     dependencies:
-      '@types/node': 22.20.0
+      '@types/node': 26.0.1
       jest-util: 29.7.0
       merge-stream: 2.0.0
       supports-color: 8.1.1
@@ -26651,7 +26651,7 @@ snapshots:
       '@protobufjs/path': 1.1.2
       '@protobufjs/pool': 1.1.0
       '@protobufjs/utf8': 1.1.1
-      '@types/node': 22.20.0
+      '@types/node': 26.0.1
       long: 5.3.2
 
   proxy-addr@2.0.7:


### PR DESCRIPTION
Extract the shared non-test configuration into base.js and add a new
jest.js entry point so React Native applications (and any other
consumer using Jest) can opt into the equivalent recommended-style
rules without the Vitest plugin's false positives. The default import
keeps shipping the Vitest preset, so existing consumers do not need
to migrate.

eslint-plugin-jest is declared as an optional peer dependency so it
is only installed by consumers that actually opt into the new
subpath.

An explicit subpath was preferred over auto-detecting the test runner
at config-load time. Detection would have to inspect the consumer's
installed packages or package.json while the flat config is being
built, which is non-deterministic: a project may legitimately have
both Vitest and Jest present (during a migration, or across different
projects in a monorepo), leaving the choice ambiguous, and the
resulting lint behaviour would silently change with the dependency
tree. A subpath keeps the selection explicit and reproducible — each
eslint.config.js states exactly which preset it wants — and lets the
matching plugin be a clean opt-in peer dependency instead of a
conditional runtime require.

Refs CES-1939, CES-1942

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>
