### PR TITLE
Bump actions/setup-node to v6.4.0

### DIFF
--- a/.github/actions/node-setup/action.yaml
+++ b/.github/actions/node-setup/action.yaml
@@ -37,7 +37,7 @@ runs:
       id: detect-pm
       uses: pagopa/dx/actions/detect-node-package-manager@main
 
-    - uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6.3.0
+    - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
       with:
         node-version-file: .node-version
         cache: ${{ steps.detect-pm.outputs.package-manager }}

--- a/.nx/version-plans/version-plan-1782217292014.md
+++ b/.nx/version-plans/version-plan-1782217292014.md
@@ -1,0 +1,6 @@
+---
+detect-node-package-manager: patch
+nx-release: patch
+---
+
+Upgrade actions/setup-node reference in documentation

--- a/actions/detect-node-package-manager/README.md
+++ b/actions/detect-node-package-manager/README.md
@@ -69,7 +69,7 @@ steps:
     uses: pagopa/dx/actions/detect-node-package-manager@main
 
   - name: Setup Node.js
-    uses: actions/setup-node@v4
+    uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
     with:
       node-version: "20"
       cache: ${{ steps.detect-pm.outputs.package-manager }}

--- a/actions/nx-release/README.md
+++ b/actions/nx-release/README.md
@@ -123,7 +123,7 @@ jobs:
           fetch-tags: "true"
           token: ${{ steps.app-token.outputs.token }}
 
-      - uses: actions/setup-node@1e60f620b9541d16bece96c5465dc8ee9832be0b # v4.0.3
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version: "20"
 


### PR DESCRIPTION
Update the Node.js setup action to version 6.4.0 across multiple workflows for improved performance and compatibility.

Contribute CES-2173