### PR TITLE
Upgrade actions/upload-artifact to version 7.0.1

### DIFF
--- a/.github/actions/upload-artifact/action.yaml
+++ b/.github/actions/upload-artifact/action.yaml
@@ -22,7 +22,7 @@ runs:
 
   steps:
     - name: Upload Artifact
-      uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7.0.0
+      uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
       with:
         name: ${{ inputs.bundle_name }}
         path: ${{ inputs.file_path }}

--- a/.nx/version-plans/version-plan-1782217546536.md
+++ b/.nx/version-plans/version-plan-1782217546536.md
@@ -1,0 +1,5 @@
+---
+'@pagopa/opex-dashboard-generate-action': patch
+---
+
+Upgrade actions/upload-artifact reference in documentation

--- a/actions/opex-dashboard-generate/README.md
+++ b/actions/opex-dashboard-generate/README.md
@@ -45,7 +45,7 @@ This action is typically used within the [opex-dashboard-deploy workflow](https:
 
 - name: Upload artifacts
   if: steps.generate-action.outputs.has_changes == 'true'
-  uses: actions/upload-artifact@v4
+  uses: 043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
   with:
     name: generated-terraform
     path: ${{ steps.generate-action.outputs.artifacts_path }}


### PR DESCRIPTION
Update the actions/upload-artifact reference in workflows and documentation to version 7.0.1 for improved functionality.

Contribute CES-2173