### PR TITLE
Bump Terraform setup action to v4.0.1

### DIFF
--- a/.github/actions/terraform-setup/action.yaml
+++ b/.github/actions/terraform-setup/action.yaml
@@ -22,7 +22,7 @@ runs:
       with:
         override_version: ${{ inputs.terraform_version }}
 
-    - uses: hashicorp/setup-terraform@5e8dbf3c6d9deaf4193ca7a8fb23f2ac83bb6c85 # v4.0.0
+    - uses: hashicorp/setup-terraform@dfe3c3f87815947d99a8997f908cb6525fc44e9e # v4.0.1
       name: Setup Terraform
       with:
         terraform_version: ${{ inputs.terraform_version || steps.get-version.outputs.terraform_version }}


### PR DESCRIPTION
Upgrade the Terraform setup action to the latest version for improved functionality and performance.

Contribute CES-2173