### PR TITLE
Refine renew TLS test validation

### DIFF
--- a/.github/workflows/_validate-renew-tls-certificate-e2e.yaml
+++ b/.github/workflows/_validate-renew-tls-certificate-e2e.yaml
@@ -2,10 +2,6 @@ name: Renew TLS certificate end-to-end test
 
 on:
   workflow_dispatch:
-  pull_request:
-    paths:
-      - "actions/renew-tls-certificate/**"
-      - ".github/workflows/_validate-renew-tls-certificate-e2e.yaml"
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}

--- a/actions/renew-tls-certificate/le_renew_ssl_certificate_python_requirements.txt
+++ b/actions/renew-tls-certificate/le_renew_ssl_certificate_python_requirements.txt
@@ -307,9 +307,9 @@ msal-extensions==1.3.1 \
     --hash=sha256:96d3de4d034504e969ac5e85bae8106c8373b5c6568e4c8fa7af2eca9dbe6bca \
     --hash=sha256:c5b0fd10f65ef62b5f1d62f4251d51cbcaf003fcedae8c91b040a488614be1a4
     # via azure-identity
-pycparser==3.0 \
-    --hash=sha256:600f49d217304a5902ac3c37e1281c9fe94e4d0489de643a9504c5cdfdfc6b29 \
-    --hash=sha256:b727414169a36b7d524c1c3e31839a521725078d7b2ff038656844266160a992
+pycparser==2.23 \
+    --hash=sha256:78816d4f24add8f10a06d6f05b4d424ad9e96cfebf68a4ddc99c65c0720d00c2 \
+    --hash=sha256:e5c6e8d3fbad53479cab09ac03729e0a9faf2bee3db8208a550daf5af81a5934
     # via cffi
 PyJWT[crypto]==2.13.0 \
     --hash=sha256:41571c89ca91598c79e8ef18a2d07367d4810fbbd6f637794879baf1b7703423 \

--- a/actions/renew-tls-certificate/package.json
+++ b/actions/renew-tls-certificate/package.json
@@ -15,23 +15,30 @@
     "key-vault"
   ],
   "scripts": {
-    "test:integration": "bash test.sh",
+    "shellcheck": "shellcheck *.sh",
+    "test": "bash test.sh",
     "test:e2e": "bash test-e2e.sh"
   },
   "nx": {
     "targets": {
+      "shellcheck": {
+        "executor": "nx:run-commands",
+        "options": {
+          "command": "pnpm run shellcheck",
+          "cwd": "actions/renew-tls-certificate"
+        }
+      },
+      "test": {
+        "executor": "nx:run-commands",
+        "options": {
+          "command": "pnpm run test",
+          "cwd": "actions/renew-tls-certificate"
+        }
+      },
       "test:e2e": {
         "executor": "nx:run-commands",
         "cache": false,
         "dependsOn": [],
-        "inputs": [
-          "{projectRoot}/action.yaml",
-          "{projectRoot}/le_*.py",
-          "{projectRoot}/test_smoke_imports.py",
-          "{projectRoot}/test_validate_csr.py",
-          "{projectRoot}/le_renew_ssl_certificate_python_requirements.txt",
-          "{projectRoot}/test-e2e.sh"
-        ],
         "options": {
           "command": "pnpm run test:e2e",
           "cwd": "actions/renew-tls-certificate"

--- a/actions/renew-tls-certificate/test-e2e.sh
+++ b/actions/renew-tls-certificate/test-e2e.sh
@@ -4,9 +4,29 @@
 set -euo pipefail
 
 ACTION_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-PYTHON_BIN="${PYTHON_BIN:-python3}"
 WORK_DIR="$(mktemp -d)"
 VENV_DIR="$WORK_DIR/venv"
+
+resolve_python_bin() {
+  if [ -n "${PYTHON_BIN:-}" ]; then
+    printf '%s\n' "$PYTHON_BIN"
+    return 0
+  fi
+
+  for candidate in python3.12 python3.11 python3.10 python3; do
+    if command -v "$candidate" >/dev/null 2>&1; then
+      if "$candidate" -c 'import sys; raise SystemExit(0 if sys.version_info >= (3, 10) else 1)'; then
+        printf '%s\n' "$candidate"
+        return 0
+      fi
+    fi
+  done
+
+  echo "A Python interpreter >= 3.10 is required. Set PYTHON_BIN to a supported interpreter." >&2
+  return 1
+}
+
+PYTHON_BIN="$(resolve_python_bin)"
 
 : "${ARM_SUBSCRIPTION_ID:?ARM_SUBSCRIPTION_ID is required}"
 : "${DNS_ZONE:?DNS_ZONE is required}"

--- a/actions/renew-tls-certificate/test.sh
+++ b/actions/renew-tls-certificate/test.sh
@@ -4,9 +4,29 @@
 set -euo pipefail
 
 ACTION_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-PYTHON_BIN="${PYTHON_BIN:-python3}"
 WORK_DIR="$(mktemp -d)"
 VENV_DIR="$WORK_DIR/venv"
+
+resolve_python_bin() {
+  if [ -n "${PYTHON_BIN:-}" ]; then
+    printf '%s\n' "$PYTHON_BIN"
+    return 0
+  fi
+
+  for candidate in python3.12 python3.11 python3.10 python3; do
+    if command -v "$candidate" >/dev/null 2>&1; then
+      if "$candidate" -c 'import sys; raise SystemExit(0 if sys.version_info >= (3, 10) else 1)'; then
+        printf '%s\n' "$candidate"
+        return 0
+      fi
+    fi
+  done
+
+  echo "A Python interpreter >= 3.10 is required. Set PYTHON_BIN to a supported interpreter." >&2
+  return 1
+}
+
+PYTHON_BIN="$(resolve_python_bin)"
 
 # Keep this test deterministic: it never calls Azure DNS, Key Vault, or ACME.
 cleanup() {

--- a/actions/renew-tls-certificate/test_smoke_imports.py
+++ b/actions/renew-tls-certificate/test_smoke_imports.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-"""Smoke-test renew TLS certificate imports and pinned dependency versions."""
+"""Smoke-test renew TLS certificate imports and key module defaults."""
 
 import cryptography
 import jwt
@@ -10,8 +10,8 @@ import le_renew_ssl_certificate_generate_csr
 
 
 def main():
-    assert cryptography.__version__ == "48.0.1"
-    assert jwt.__version__ == "2.13.0"
+    assert cryptography.__version__
+    assert jwt.__version__
     assert le_create_acme_test_account.DEFAULT_DIRECTORY_URL.startswith("https://")
     assert le_renew_ssl_certificate_acme_tiny.DEFAULT_DIRECTORY_URL.startswith("https://")
     assert le_renew_ssl_certificate_generate_csr.__name__ == "le_renew_ssl_certificate_generate_csr"


### PR DESCRIPTION
This follow-up tightens the review fixes for the renew TLS certificate test work so the regular validation path stays useful and the live end-to-end path stays explicit.

Touched points:
- keep the live Key Vault and Let's Encrypt workflow manual-only, instead of running it automatically on pull requests against shared dev resources
- wire the deterministic smoke test into the standard Nx `test` target so normal validation covers the action without requiring the live environment
- add an Nx `shellcheck` target for the action scripts so they participate in the existing validation flow
- simplify the custom Nx target configuration by relying on workspace defaults where they already fit, instead of keeping redundant local inputs and overrides
- remove brittle smoke assertions tied to exact dependency versions and keep the check focused on importability and module defaults
- fix the hashed Python requirements by replacing the non-existent `pycparser==3.0` pin with the published `2.23` release
- make both test entrypoints fail with a clear message when no Python interpreter >= 3.10 is available, matching the requirements file constraints

Depends on #1874
