### PR TITLE
Fix release workflow formatting and permissions

### DIFF
--- a/.github/workflows/_release-terraform-apply-bootstrapper.yaml
+++ b/.github/workflows/_release-terraform-apply-bootstrapper.yaml
@@ -6,8 +6,11 @@ on:
       - main
     paths:
       - "infra/bootstrapper/**"
+
 permissions:
   contents: read
+  id-token: write
+
 jobs:
   release:
     strategy:


### PR DESCRIPTION
Add a missing newline and update permissions in the release workflow to ensure proper execution.

Example of broken run: https://github.com/pagopa/dx/actions/runs/28084548383

Close CES-2183