### PR TITLE
Move `policy/dev` backend

### DIFF
--- a/infra/policy/dev/main.tf
+++ b/infra/policy/dev/main.tf
@@ -7,8 +7,8 @@ terraform {
   }
 
   backend "azurerm" {
-    resource_group_name  = "terraform-state-rg"
-    storage_account_name = "tfdevdx"
+    resource_group_name  = "dx-d-itn-tfstate-rg-01"
+    storage_account_name = "dxditntfstatest01"
     container_name       = "terraform-state"
     key                  = "dx.policy.dev.italynorth.tfstate"
   }


### PR DESCRIPTION
Now the state file is saved in the same storage account as other dev modules