### PR TITLE
Compare MCP server full-workspace Docker build

### DIFF
--- a/apps/mcpserver/Dockerfile
+++ b/apps/mcpserver/Dockerfile
@@ -15,11 +15,8 @@ COPY . .
 #    the project from sources entirely inside the container.
 RUN pnpm install --filter @pagopa/dx-mcpserver...
 
-# 5. Run the normal Nx build inside Docker.
-RUN pnpm nx build @pagopa/dx-mcpserver
-
-# 6. Materialize a production-only payload through an Nx task so the same
-#    packaging step can be exercised outside Docker as well.
+# 5. Materialize the production-only payload through the Nx task pipeline.
+#    The package target depends on build, so Docker only needs a single Nx call.
 RUN pnpm nx package @pagopa/dx-mcpserver
 
 # --- Final Image ---

--- a/apps/mcpserver/Dockerfile
+++ b/apps/mcpserver/Dockerfile
@@ -1,32 +1,34 @@
 FROM public.ecr.aws/docker/library/node:24-alpine@sha256:2bdb65ed1dab192432bc31c95f94155ca5ad7fc1392fb7eb7526ab682fa5bf14 AS base
+# This PoC keeps the Dockerfile in charge of dependency installation and build
+# so we can measure the caching impact of copying the whole workspace.
 # 1. Enable pnpm
 RUN corepack enable
 
 # 2. Set working directory
 WORKDIR /app
 
-# 3. Copy monorepo configuration files
-COPY ./pnpm-lock.yaml ./pnpm-workspace.yaml ./package.json ./nx.json ./tsconfig.json ./
+# 3. Copy the full workspace on purpose: any touched package can invalidate
+#    the build cache, which is the behavior this PoC wants to expose.
+COPY . .
 
-# 4. Copy source code for apps and packages
-COPY ./apps ./apps
-COPY ./packages ./packages
-
-# 5. Install ALL dependencies for mcpserver and its workspace dependencies
+# 4. Install the app plus every workspace package it consumes so Nx can build
+#    the project from sources entirely inside the container.
 RUN pnpm install --filter @pagopa/dx-mcpserver...
-# 6. Build the mcpserver app
+
+# 5. Run the normal Nx build inside Docker.
 RUN pnpm nx build @pagopa/dx-mcpserver
-# 7. Prune development-only dependencies for the final image
+
+# 6. Materialize a production-only payload for the runtime stage.
 RUN pnpm --filter @pagopa/dx-mcpserver deploy --legacy --prod /app/deploy
 
 # --- Final Image ---
 FROM public.ecr.aws/docker/library/node:24-alpine@sha256:2bdb65ed1dab192432bc31c95f94155ca5ad7fc1392fb7eb7526ab682fa5bf14
 WORKDIR /app
 
-# Copy the AWS Lambda Adapter
+# Copy the AWS Lambda Adapter expected by the Lambda runtime.
 COPY --from=public.ecr.aws/awsguru/aws-lambda-adapter:0.9.1@sha256:46d6625e68cbbdd2efab4a20245977664513f13ffef47915b000d431adcea0b4 /lambda-adapter /opt/extensions/lambda-adapter
 
-# Copy the pruned production-ready files from the build stage
+# Copy the production payload prepared in the build stage.
 COPY --from=base /app/deploy .
 
 EXPOSE 8080

--- a/apps/mcpserver/Dockerfile
+++ b/apps/mcpserver/Dockerfile
@@ -18,8 +18,9 @@ RUN pnpm install --filter @pagopa/dx-mcpserver...
 # 5. Run the normal Nx build inside Docker.
 RUN pnpm nx build @pagopa/dx-mcpserver
 
-# 6. Materialize a production-only payload for the runtime stage.
-RUN pnpm --filter @pagopa/dx-mcpserver deploy --legacy --prod /app/deploy
+# 6. Materialize a production-only payload through an Nx task so the same
+#    packaging step can be exercised outside Docker as well.
+RUN pnpm nx package @pagopa/dx-mcpserver
 
 # --- Final Image ---
 FROM public.ecr.aws/docker/library/node:24-alpine@sha256:2bdb65ed1dab192432bc31c95f94155ca5ad7fc1392fb7eb7526ab682fa5bf14
@@ -28,8 +29,8 @@ WORKDIR /app
 # Copy the AWS Lambda Adapter expected by the Lambda runtime.
 COPY --from=public.ecr.aws/awsguru/aws-lambda-adapter:0.9.1@sha256:46d6625e68cbbdd2efab4a20245977664513f13ffef47915b000d431adcea0b4 /lambda-adapter /opt/extensions/lambda-adapter
 
-# Copy the production payload prepared in the build stage.
-COPY --from=base /app/deploy .
+# Copy the production payload prepared by the app-local packaging step.
+COPY --from=base /app/apps/mcpserver/deploy .
 
 EXPOSE 8080
 CMD ["node", "dist/cli.js"]

--- a/apps/mcpserver/package.json
+++ b/apps/mcpserver/package.json
@@ -21,7 +21,9 @@
   "nx": {
     "targets": {
       "package": {
-        "dependsOn": ["build"],
+        "dependsOn": [
+          "build"
+        ],
         "executor": "nx:run-commands",
         "options": {
           "command": "rm -rf apps/mcpserver/deploy && pnpm --filter @pagopa/dx-mcpserver deploy --legacy --prod apps/mcpserver/deploy"

--- a/apps/mcpserver/package.json
+++ b/apps/mcpserver/package.json
@@ -41,6 +41,7 @@
   },
   "scripts": {
     "start": "tsx src/cli.ts",
+    "package": "pnpm --dir ../.. --filter @pagopa/dx-mcpserver deploy --legacy --prod apps/mcpserver/deploy",
     "format": "prettier --write .",
     "format:check": "prettier --check .",
     "version": "node ./scripts/generate-server-manifest.js"

--- a/apps/mcpserver/package.json
+++ b/apps/mcpserver/package.json
@@ -18,6 +18,17 @@
   "bin": {
     "dx": "./dist/cli.js"
   },
+  "nx": {
+    "targets": {
+      "package": {
+        "dependsOn": ["build"],
+        "executor": "nx:run-commands",
+        "options": {
+          "command": "rm -rf apps/mcpserver/deploy && pnpm --filter @pagopa/dx-mcpserver deploy --legacy --prod apps/mcpserver/deploy"
+        }
+      }
+    }
+  },
   "dependencies": {
     "@aws-sdk/client-bedrock-agent-runtime": "^3.1057.0",
     "@aws-sdk/client-s3": "catalog:aws",
@@ -41,7 +52,6 @@
   },
   "scripts": {
     "start": "tsx src/cli.ts",
-    "package": "pnpm --dir ../.. --filter @pagopa/dx-mcpserver deploy --legacy --prod apps/mcpserver/deploy",
     "format": "prettier --write .",
     "format:check": "prettier --check .",
     "version": "node ./scripts/generate-server-manifest.js"

--- a/nx.json
+++ b/nx.json
@@ -98,9 +98,22 @@
   "plugins": [
     {
       "plugin": "@nx/docker",
-      "exclude": ["apps/*/Dockerfile"],
+      "exclude": [
+        "apps/dx-metrics/Dockerfile",
+        "apps/dx-metrics-import/Dockerfile"
+      ],
       "options": {
-        "buildTarget": "docker:build",
+        "buildTarget": {
+          "name": "docker:build",
+          "cwd": ".",
+          "args": [
+            "--file {projectRoot}/Dockerfile",
+            "--platform linux/arm64"
+          ],
+          "env": {
+            "DOCKER_BUILDKIT": "1"
+          }
+        },
         "runTarget": "docker:run"
       }
     },


### PR DESCRIPTION
Compare the MCP server Docker strategy that copies the whole monorepo and builds inside the image.

Summary
- enable the official @nx/docker target for apps/mcpserver with repo-root context
- keep the Dockerfile inside the app while forcing Docker to use the repo root as build context
- copy the whole workspace and run pnpm install + pnpm nx build inside Docker
- document the cache trade-off directly in the Dockerfile comments

Validation
- docker build produced apps-mcpserver:poc-a
- the final image contains the dist/cli.js entrypoint payload

Notes
- No version plan: PoC branch for Docker strategy evaluation, not intended for release
- Draft because this branch is meant to be compared with the prune-based alternative