### PR TITLE
Fix AWS example security findings

### DIFF
--- a/.nx/version-plans/version-plan-1782725439871.md
+++ b/.nx/version-plans/version-plan-1782725439871.md
@@ -1,0 +1,5 @@
+---
+provider-aws: patch
+---
+
+Fix AWS subnet CIDR example security findings

--- a/providers/aws/examples/resources/dx_available_subnet_cidr/resource.tf
+++ b/providers/aws/examples/resources/dx_available_subnet_cidr/resource.tf
@@ -19,7 +19,7 @@ provider "aws" {
   region = "eu-south-1"
 }
 
-# Create a VPC first
+# trivy:ignore:AVD-AWS-0178 Flow Logs are omitted to keep this provider example focused on CIDR allocation.
 resource "aws_vpc" "example" {
   cidr_block           = "10.0.0.0/16"
   enable_dns_hostnames = true
@@ -41,7 +41,7 @@ resource "aws_subnet" "example" {
   vpc_id                  = aws_vpc.example.id
   cidr_block              = dx_available_subnet_cidr.example.cidr_block
   availability_zone       = "eu-west-1a"
-  map_public_ip_on_launch = true
+  map_public_ip_on_launch = false
 
   tags = {
     Name = "example-subnet"


### PR DESCRIPTION
## Summary

- Disable automatic public IP assignment in the AWS subnet CIDR example.
- Add a local Trivy suppression for omitted VPC Flow Logs so the example stays focused on CIDR allocation.
- Add a patch release plan for `provider-aws`.

## Validation

- Commit pre-commit hooks passed, including Terraform fmt and Trivy validation.
- Focused Trivy scan for `providers/aws/examples/resources/dx_available_subnet_cidr` reports zero misconfigurations.
- `pnpm nx run provider-aws:format` and `pnpm nx run provider-aws:test` require Go and could not complete locally because `go` is not installed in this environment.

Close CES-2184