### PR TITLE
Fix CodeQL Go workspace loading

### DIFF
--- a/go.work
+++ b/go.work
@@ -1,10 +1,13 @@
-go 1.26
+go 1.26.0
 
 use (
 	./infra/modules/azure_app_configuration/tests
 	./infra/modules/azure_app_configuration/tests/apps/all_scenarios/src
 	./infra/modules/azure_cdn/tests
 	./infra/modules/azure_cosmos_account/tests
+	./infra/modules/azure_cosmos_account/tests/apps/network_access/src
+	./infra/modules/azure_merge_roles/tests
+	./infra/modules/azure_merge_roles/tests/apps/blob_rbac_probe/src
 	./infra/modules/github_selfhosted_runner_on_container_app_jobs/tests
 	./providers/aws
 	./providers/aws/tools


### PR DESCRIPTION
## Summary

- Update `go.work` to use the patch-level Go version required by the Go toolchain.
- Add the Go modules CodeQL was discovering outside the workspace so the Go extractor can load all packages consistently.

## Validation

- `go list -mod=readonly ./infra/modules/azure_app_configuration/tests/... ./infra/modules/azure_app_configuration/tests/apps/all_scenarios/src/... ./infra/modules/azure_cdn/tests/... ./infra/modules/azure_cosmos_account/tests/... ./infra/modules/azure_cosmos_account/tests/apps/network_access/src/... ./infra/modules/azure_merge_roles/tests/... ./infra/modules/azure_merge_roles/tests/apps/blob_rbac_probe/src/... ./infra/modules/github_selfhosted_runner_on_container_app_jobs/tests/... ./providers/aws/... ./providers/aws/tools/... ./providers/azure/... ./providers/azure/tools/...`

Close CES-2185