### PR TITLE
Fix validate-v2 actions references pointing to feature branch

### DIFF
--- a/.github/workflows/validate-v2.yaml
+++ b/.github/workflows/validate-v2.yaml
@@ -183,7 +183,7 @@ jobs:
           filter: tree:0
 
       - name: Cloud Login
-        uses: pagopa/dx/actions/csp-login@feats/tfplan-in-validate
+        uses: pagopa/dx/actions/csp-login@main
 
       - name: Setup Node.js
         uses: pagopa/dx/.github/actions/node-setup@main
@@ -281,7 +281,7 @@ jobs:
           merge-multiple: true
 
       - name: Post Code Review Report
-        uses: pagopa/dx/actions/run-dx-task@feats/tfplan-in-validate
+        uses: pagopa/dx/actions/run-dx-task@main
         env:
           GITHUB_TOKEN: ${{ github.token }}
         with:


### PR DESCRIPTION
* Updated the `Cloud Login` step to use `pagopa/dx/actions/csp-login@main` instead of a feature branch.
* Updated the `Post Code Review Report` step to use `pagopa/dx/actions/run-dx-task@main` instead of a feature branch.