### PR TITLE
Add Azure Foundry DNS zones

### DIFF
--- a/.nx/version-plans/version-plan-1782811807664.md
+++ b/.nx/version-plans/version-plan-1782811807664.md
@@ -1,0 +1,5 @@
+---
+azure_core_infra: minor
+---
+
+Add Azure Foundry private DNS zones to core infrastructure.

--- a/infra/modules/azure_core_infra/locals.tf
+++ b/infra/modules/azure_core_infra/locals.tf
@@ -35,5 +35,8 @@ locals {
     "apim"                     = "privatelink.azure-api.net"
     "appcs"                    = "privatelink.azconfig.io"
     "redis_managed"            = "privatelink.redis.azure.net"
+    "cognitiveservices"        = "privatelink.cognitiveservices.azure.com"
+    "openai"                   = "privatelink.openai.azure.com"
+    "ai_services"              = "privatelink.services.ai.azure.com"
   }
 }

--- a/infra/modules/azure_core_infra/tests/common.tftest.hcl
+++ b/infra/modules/azure_core_infra/tests/common.tftest.hcl
@@ -66,6 +66,15 @@ run "core_is_correct_plan" {
   }
 
   assert {
+    condition = alltrue([
+      module.dns.private_dns_zones.cognitiveservices.name == "privatelink.cognitiveservices.azure.com",
+      module.dns.private_dns_zones.openai.name == "privatelink.openai.azure.com",
+      module.dns.private_dns_zones.ai_services.name == "privatelink.services.ai.azure.com"
+    ])
+    error_message = "The Azure Foundry Private DNS Zones configuration must be correct"
+  }
+
+  assert {
     condition     = try(azurerm_resource_group.test[0], "NotTestEnv") == "NotTestEnv"
     error_message = "This Environment is not a Test Environment"
   }


### PR DESCRIPTION
## Summary

Add the Azure Foundry private endpoint DNS zones to the core infrastructure module so they are created and linked through the shared private DNS setup.

## Changes

- Add `privatelink.cognitiveservices.azure.com`, `privatelink.openai.azure.com`, and `privatelink.services.ai.azure.com` to `azure_core_infra` private DNS zones.
- Extend the Terraform test plan assertions for the new Foundry zones.
- Add a minor version plan for `azure_core_infra`.