### PR TITLE
Add SaveMoney pricing toggle

### DIFF
--- a/.nx/version-plans/version-plan-1780067373606.md
+++ b/.nx/version-plans/version-plan-1780067373606.md
@@ -1,0 +1,9 @@
+---
+"@pagopa/dx-savemoney": minor
+---
+
+- Add monthly cost estimation for custom findings: VM, Managed Disk, Public IP, and empty App Service Plan resources now show their estimated monthly cost when flagged as suspected unused.
+- Pricing data is fetched from the Azure Retail Prices API (no authentication required) and cached locally for 24 hours.
+- Lint report shows the resource cost once per resource header `(cost at risk: € X.XX/mo)`, not next to each individual finding.
+- Summary trailer now shows two separate totals: `Estimated monthly cost at risk (custom)` and `Estimated monthly savings (advisor)`.
+- Add `--no-pricing` CLI flag to disable custom cost-at-risk pricing lookups.

--- a/.nx/version-plans/version-plan-1780067373607.md
+++ b/.nx/version-plans/version-plan-1780067373607.md
@@ -1,0 +1,5 @@
+---
+"@pagopa/dx-cli": patch
+---
+
+- Add `--no-pricing` flag to the `savemoney` command to disable custom cost-at-risk pricing lookups.

--- a/.nx/version-plans/version-plan-1780067373607.md
+++ b/.nx/version-plans/version-plan-1780067373607.md
@@ -2,4 +2,4 @@
 "@pagopa/dx-cli": patch
 ---
 
-- Add `--no-pricing` flag to the `savemoney` command to disable custom cost-at-risk pricing lookups.
+- Add `--no-pricing` flag to the `savemoney` command so users can skip custom cost-at-risk pricing lookups when they need a faster offline run or want to avoid external Retail Prices API calls.

--- a/apps/cli/src/adapters/commander/commands/__tests__/savemoney.test.ts
+++ b/apps/cli/src/adapters/commander/commands/__tests__/savemoney.test.ts
@@ -13,7 +13,9 @@ import {
   makeSavemoneyCommand,
   parseSourceOption,
   parseTagsOption,
+  resolveNumberOption,
   resolveSourcesOption,
+  resolveStringOption,
 } from "../savemoney.js";
 
 describe("parseSourceOption", () => {
@@ -96,6 +98,30 @@ describe("resolveSourcesOption", () => {
 
   it("uses the explicit single source", () => {
     expect(resolveSourcesOption("advisor", ["custom"])).toEqual(["advisor"]);
+  });
+});
+
+describe("resolveStringOption", () => {
+  it("uses config value when option comes from a Commander default", () => {
+    expect(resolveStringOption("italynorth", "westeurope", "default")).toBe(
+      "westeurope",
+    );
+  });
+
+  it("uses CLI value when the user provided the option", () => {
+    expect(resolveStringOption("italynorth", "westeurope", "cli")).toBe(
+      "italynorth",
+    );
+  });
+});
+
+describe("resolveNumberOption", () => {
+  it("uses config value when option comes from a Commander default", () => {
+    expect(resolveNumberOption("30", 60, "default")).toBe(60);
+  });
+
+  it("uses CLI value when the user provided the option", () => {
+    expect(resolveNumberOption("45", 60, "cli")).toBe(45);
   });
 });
 

--- a/apps/cli/src/adapters/commander/commands/__tests__/savemoney.test.ts
+++ b/apps/cli/src/adapters/commander/commands/__tests__/savemoney.test.ts
@@ -13,9 +13,7 @@ import {
   makeSavemoneyCommand,
   parseSourceOption,
   parseTagsOption,
-  resolveNumberOption,
   resolveSourcesOption,
-  resolveStringOption,
 } from "../savemoney.js";
 
 describe("parseSourceOption", () => {
@@ -98,30 +96,6 @@ describe("resolveSourcesOption", () => {
 
   it("uses the explicit single source", () => {
     expect(resolveSourcesOption("advisor", ["custom"])).toEqual(["advisor"]);
-  });
-});
-
-describe("resolveStringOption", () => {
-  it("uses config value when option comes from a Commander default", () => {
-    expect(resolveStringOption("italynorth", "westeurope", "default")).toBe(
-      "westeurope",
-    );
-  });
-
-  it("uses CLI value when the user provided the option", () => {
-    expect(resolveStringOption("italynorth", "westeurope", "cli")).toBe(
-      "italynorth",
-    );
-  });
-});
-
-describe("resolveNumberOption", () => {
-  it("uses config value when option comes from a Commander default", () => {
-    expect(resolveNumberOption("30", 60, "default")).toBe(60);
-  });
-
-  it("uses CLI value when the user provided the option", () => {
-    expect(resolveNumberOption("45", 60, "cli")).toBe(45);
   });
 });
 

--- a/apps/cli/src/adapters/commander/commands/__tests__/savemoney.test.ts
+++ b/apps/cli/src/adapters/commander/commands/__tests__/savemoney.test.ts
@@ -13,6 +13,7 @@ import {
   makeSavemoneyCommand,
   parseSourceOption,
   parseTagsOption,
+  resolveSourcesOption,
 } from "../savemoney.js";
 
 describe("parseSourceOption", () => {
@@ -74,6 +75,30 @@ describe("parseTagsOption", () => {
   });
 });
 
+describe("resolveSourcesOption", () => {
+  it("uses config sources when --source is omitted", () => {
+    expect(resolveSourcesOption(undefined, ["custom"])).toEqual(["custom"]);
+  });
+
+  it("uses both sources when --source is omitted and config has no sources", () => {
+    expect(resolveSourcesOption(undefined, undefined)).toEqual([
+      "advisor",
+      "custom",
+    ]);
+  });
+
+  it("lets explicit --source all override a narrowed config", () => {
+    expect(resolveSourcesOption("all", ["custom"])).toEqual([
+      "advisor",
+      "custom",
+    ]);
+  });
+
+  it("uses the explicit single source", () => {
+    expect(resolveSourcesOption("advisor", ["custom"])).toEqual(["advisor"]);
+  });
+});
+
 describe("makeSavemoneyCommand", () => {
   it("documents that --tags does not filter subscription-level Advisor findings", () => {
     const command = makeSavemoneyCommand();
@@ -84,5 +109,16 @@ describe("makeSavemoneyCommand", () => {
     expect(tagsOption?.description).toContain(
       "Advisor subscription-level findings remain global.",
     );
+  });
+
+  it("keeps --no-pricing as the only pricing override", () => {
+    const command = makeSavemoneyCommand();
+    const pricingOptions = command.options.filter((option) =>
+      option.flags.includes("pricing"),
+    );
+
+    expect(pricingOptions.map((option) => option.flags)).toEqual([
+      "--no-pricing",
+    ]);
   });
 });

--- a/apps/cli/src/adapters/commander/commands/savemoney.ts
+++ b/apps/cli/src/adapters/commander/commands/savemoney.ts
@@ -54,11 +54,18 @@ export const makeSavemoneyCommand = () =>
         const finalConfig: AzureConfig = {
           ...config,
           filterTags,
-          preferredLocation: options.location || config.preferredLocation,
+          preferredLocation: resolveStringOption(
+            options.location,
+            config.preferredLocation,
+            this.getOptionValueSource("location"),
+          ),
           ...(options.pricing === false ? { pricing: { enabled: false } } : {}),
           sources: resolveSourcesOption(options.source, config.sources),
-          timespanDays:
-            Number.parseInt(options.days, 10) || config.timespanDays,
+          timespanDays: resolveNumberOption(
+            options.days,
+            config.timespanDays,
+            this.getOptionValueSource("days"),
+          ),
           verbose: verbose ?? false,
         };
 
@@ -123,6 +130,18 @@ export function parseTagsOption(
   return result;
 }
 
+export function resolveNumberOption(
+  option: string | undefined,
+  configValue: number,
+  source: string | undefined,
+): number {
+  if (source !== "cli") {
+    return configValue;
+  }
+  const parsed = Number.parseInt(option ?? "", 10);
+  return Number.isNaN(parsed) ? configValue : parsed;
+}
+
 /**
  * Resolves the source filter preserving the difference between an omitted
  * option (respect config/defaults) and an explicit `--source all` override.
@@ -135,4 +154,12 @@ export function resolveSourcesOption(
     return configSources ?? ["advisor", "custom"];
   }
   return option === "all" ? ["advisor", "custom"] : [option];
+}
+
+export function resolveStringOption(
+  option: string | undefined,
+  configValue: string,
+  source: string | undefined,
+): string {
+  return source === "cli" && option ? option : configValue;
 }

--- a/apps/cli/src/adapters/commander/commands/savemoney.ts
+++ b/apps/cli/src/adapters/commander/commands/savemoney.ts
@@ -35,9 +35,12 @@ export const makeSavemoneyCommand = () =>
     )
     .option(
       "-s, --source <source>",
-      "Restrict findings to a single source: 'advisor', 'custom', or 'all' (default: all)",
+      "Restrict findings to a single source: 'advisor', 'custom', or 'all' (defaults to config file or all)",
       parseSourceOption,
-      "all",
+    )
+    .option(
+      "--no-pricing",
+      "Disable Azure Retail Prices enrichment (skips custom cost-at-risk estimates)",
     )
     .action(async function (options) {
       const { verbose } = this.optsWithGlobals<GlobalOptions>();
@@ -52,10 +55,8 @@ export const makeSavemoneyCommand = () =>
           ...config,
           filterTags,
           preferredLocation: options.location || config.preferredLocation,
-          sources:
-            options.source === "all"
-              ? (config.sources ?? ["advisor", "custom"])
-              : [options.source as AzureSource],
+          ...(options.pricing === false ? { pricing: { enabled: false } } : {}),
+          sources: resolveSourcesOption(options.source, config.sources),
           timespanDays:
             Number.parseInt(options.days, 10) || config.timespanDays,
           verbose: verbose ?? false,
@@ -83,12 +84,13 @@ export const makeSavemoneyCommand = () =>
     });
 
 const SourceSchema = z.enum(["advisor", "all", "custom"]);
+type SourceOption = z.infer<typeof SourceSchema>;
 
 /**
  * Parses the `--source` option via a zod enum, accepting `all`, `advisor`,
  * or `custom` and rejecting any other value with a Commander-friendly error.
  */
-export function parseSourceOption(value: string): string {
+export function parseSourceOption(value: string): SourceOption {
   const result = SourceSchema.safeParse(value);
   if (!result.success) {
     throw new InvalidArgumentError(
@@ -119,4 +121,18 @@ export function parseTagsOption(
     }
   }
   return result;
+}
+
+/**
+ * Resolves the source filter preserving the difference between an omitted
+ * option (respect config/defaults) and an explicit `--source all` override.
+ */
+export function resolveSourcesOption(
+  option: SourceOption | undefined,
+  configSources: AzureSource[] | undefined,
+): AzureSource[] {
+  if (option === undefined) {
+    return configSources ?? ["advisor", "custom"];
+  }
+  return option === "all" ? ["advisor", "custom"] : [option];
 }

--- a/apps/cli/src/adapters/commander/commands/savemoney.ts
+++ b/apps/cli/src/adapters/commander/commands/savemoney.ts
@@ -50,22 +50,22 @@ export const makeSavemoneyCommand = () =>
 
         // Parse tag filter
         const filterTags = parseTagsOption(options.tags);
+        const cliDays = Number.parseInt(options.days, 10);
 
         const finalConfig: AzureConfig = {
           ...config,
           filterTags,
-          preferredLocation: resolveStringOption(
-            options.location,
-            config.preferredLocation,
-            this.getOptionValueSource("location"),
-          ),
+          preferredLocation:
+            this.getOptionValueSource("location") === "cli"
+              ? options.location
+              : config.preferredLocation,
           ...(options.pricing === false ? { pricing: { enabled: false } } : {}),
           sources: resolveSourcesOption(options.source, config.sources),
-          timespanDays: resolveNumberOption(
-            options.days,
-            config.timespanDays,
-            this.getOptionValueSource("days"),
-          ),
+          timespanDays:
+            this.getOptionValueSource("days") === "cli" &&
+            !Number.isNaN(cliDays)
+              ? cliDays
+              : config.timespanDays,
           verbose: verbose ?? false,
         };
 
@@ -130,18 +130,6 @@ export function parseTagsOption(
   return result;
 }
 
-export function resolveNumberOption(
-  option: string | undefined,
-  configValue: number,
-  source: string | undefined,
-): number {
-  if (source !== "cli") {
-    return configValue;
-  }
-  const parsed = Number.parseInt(option ?? "", 10);
-  return Number.isNaN(parsed) ? configValue : parsed;
-}
-
 /**
  * Resolves the source filter preserving the difference between an omitted
  * option (respect config/defaults) and an explicit `--source all` override.
@@ -154,12 +142,4 @@ export function resolveSourcesOption(
     return configSources ?? ["advisor", "custom"];
   }
   return option === "all" ? ["advisor", "custom"] : [option];
-}
-
-export function resolveStringOption(
-  option: string | undefined,
-  configValue: string,
-  source: string | undefined,
-): string {
-  return source === "cli" && option ? option : configValue;
 }

--- a/packages/savemoney/README.md
+++ b/packages/savemoney/README.md
@@ -103,6 +103,18 @@ The tool analyzes the following Azure resource types with specific detection met
 | **Static Web Apps**     | Metrics                 |  🟢 Low   | No traffic data available, Very low site hits (<100 requests in 30 days), Very low data transfer (<1MB in 30 days)                                          |
 | **Azure Advisor**       | Advisor API             | ⚪ Varies | Reserved Instance and Savings Plan opportunities, right-sizing suggestions, and other Cost recommendations — with estimated monthly savings where available |
 
+#### Pricing Coverage
+
+SaveMoney keeps two monetary signals separate:
+
+- **Retail Prices API** estimates the monthly list-price cost at risk for custom findings on resources with predictable pricing.
+- **Azure Advisor** reports Microsoft-provided savings for Cost recommendations when available.
+
+| Resources                                                                     | Pricing source    | Notes                                                                                          |
+| :---------------------------------------------------------------------------- | :---------------- | :--------------------------------------------------------------------------------------------- |
+| Virtual Machines, Managed Disks, Public IP Addresses, empty App Service Plans | Retail Prices API | Reported as `Estimated monthly cost at risk (custom)`.                                         |
+| Azure Advisor Cost recommendations                                            | Azure Advisor     | Reported separately as `Estimated monthly savings (advisor)` when Advisor returns an estimate. |
+
 #### Generic Checks
 
 All resources are also checked for:


### PR DESCRIPTION
Adds a CLI flag to disable best-effort pricing lookups and keeps explicit source overrides working.

depends-on #1939 
