### PR TITLE
Fix integration test environment configuration

### DIFF
--- a/.nx/version-plans/version-plan-1783325644560.md
+++ b/.nx/version-plans/version-plan-1783325644560.md
@@ -1,0 +1,5 @@
+---
+azure_container_app: patch
+---
+
+Fix naming in integration tests

--- a/infra/modules/azure_container_app/container_app.tf
+++ b/infra/modules/azure_container_app/container_app.tf
@@ -1,5 +1,5 @@
 resource "azurerm_container_app" "this" {
-  name                         = provider::dx::resource_name(merge(local.naming_config, { resource_type = "container_app" }))
+  name                         = provider::dx::resource_name(merge(var.environment, { resource_type = "container_app" }))
   container_app_environment_id = var.container_app_environment_id
   resource_group_name          = var.resource_group_name
   revision_mode                = local.revision_mode

--- a/infra/modules/azure_container_app/locals.tf
+++ b/infra/modules/azure_container_app/locals.tf
@@ -1,13 +1,5 @@
 locals {
   tags = merge(var.tags, { ModuleSource = "DX", ModuleVersion = try(jsondecode(file("${path.module}/package.json")).version, "unknown"), ModuleName = try(jsondecode(file("${path.module}/package.json")).name, "unknown") })
-  naming_config = {
-    prefix          = var.environment.prefix,
-    environment     = var.environment.env_short,
-    location        = var.environment.location
-    domain          = var.environment.domain,
-    name            = var.environment.app_name,
-    instance_number = tonumber(var.environment.instance_number),
-  }
 
   use_cases = {
     default = {

--- a/infra/modules/azure_container_app/tests/integration.tftest.hcl
+++ b/infra/modules/azure_container_app/tests/integration.tftest.hcl
@@ -14,7 +14,7 @@ variables {
     env_short       = "d"
     location        = "italynorth"
     domain          = "int"
-    app_name        = "ca"
+    app_name        = "def"
     instance_number = "01"
   }
 
@@ -101,7 +101,7 @@ run "apply_development" {
   command = apply
 
   variables {
-    environment                  = merge(var.environment, { instance_number = run.setup.instance_numbers.development, app_name = "cadev" })
+    environment                  = merge(var.environment, { instance_number = run.setup.instance_numbers.development, app_name = "dev" })
     tags                         = var.tags
     use_case                     = "development"
     resource_group_name          = run.setup.resource_group_name
@@ -139,7 +139,7 @@ run "apply_with_http_scaler" {
   command = apply
 
   variables {
-    environment                  = merge(var.environment, { instance_number = run.setup.instance_numbers.autoscaler, app_name = "cahttp" })
+    environment                  = merge(var.environment, { instance_number = run.setup.instance_numbers.autoscaler, app_name = "http" })
     tags                         = var.tags
     resource_group_name          = run.setup.resource_group_name
     container_app_environment_id = run.setup.container_app_environment_id

--- a/infra/modules/azure_container_app/tests/setup/main.tf
+++ b/infra/modules/azure_container_app/tests/setup/main.tf
@@ -1,13 +1,4 @@
 locals {
-  naming_config = {
-    prefix          = var.environment.prefix
-    environment     = var.environment.env_short
-    location        = var.environment.location
-    domain          = var.environment.domain
-    name            = var.environment.app_name
-    instance_number = tonumber(var.environment.instance_number)
-  }
-
   existing_resources = {
     prefix          = var.environment.prefix
     environment     = var.environment.env_short
@@ -30,7 +21,7 @@ data "azurerm_log_analytics_workspace" "logs" {
 }
 
 resource "azurerm_resource_group" "sut" {
-  name     = provider::dx::resource_name(merge(local.naming_config, { resource_type = "resource_group" }))
+  name     = provider::dx::resource_name(merge(var.environment, { resource_type = "resource_group" }))
   location = var.environment.location
 
   tags = var.tags
@@ -48,7 +39,7 @@ resource "random_integer" "instance_base" {
 }
 
 resource "azurerm_container_app_environment" "sut" {
-  name                       = provider::dx::resource_name(merge(local.naming_config, { resource_type = "container_app_environment" }))
+  name                       = provider::dx::resource_name(merge(var.environment, { resource_type = "container_app_environment" }))
   resource_group_name        = azurerm_resource_group.sut.name
   location                   = var.environment.location
   log_analytics_workspace_id = data.azurerm_log_analytics_workspace.logs.id


### PR DESCRIPTION
Update the environment configuration to use the correct variables for naming and application settings, ensuring proper integration test setup.