### PR TITLE
Fix tf_docs regex in pre-commit-config

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -26,7 +26,8 @@ repos:
           - --hook-config=--create-file-if-not-exist=true
           - --args=--hide providers
           - --args=--lockfile=false
-        files: ^infra/(?:.*/)?_?modules/.*
+        files: ^infra/(?:.*/)?_?modules/[^/]+/[^/]+\.tf$
+        exclude: ^infra/(?:.*/)?_?modules/[^/]+/(examples|tests|example)/.*
       - id: terraform_tflint
         args:
           - --args=--disable-rule terraform_required_version


### PR DESCRIPTION
Avoid tf_docs runs in Terraform module's subfolders (e.g. `tests` or `examples`)

Fix [CES-1977](https://pagopa.atlassian.net/browse/CES-1977)

[CES-1977]: https://pagopa.atlassian.net/browse/CES-1977?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ