### PR TITLE
Handle missing git identity in dx init

### DIFF
--- a/.nx/version-plans/version-plan-1783344751762.md
+++ b/.nx/version-plans/version-plan-1783344751762.md
@@ -1,0 +1,5 @@
+---
+'@pagopa/dx-cli': patch
+---
+
+Fallback to a temporary git identity when dx init scaffolds a repository without git user.name or user.email configured.

--- a/apps/cli/src/adapters/commander/commands/__tests__/init-git-identity.test.ts
+++ b/apps/cli/src/adapters/commander/commands/__tests__/init-git-identity.test.ts
@@ -115,10 +115,15 @@ const runInitCommand = async () => {
 
 describe("makeInitCommand git identity fallback", () => {
   let executedGitCommands: string[];
+  let gitConfigValues: Record<"user.email" | "user.name", string | undefined>;
 
   beforeEach(() => {
     vi.clearAllMocks();
     executedGitCommands = [];
+    gitConfigValues = {
+      "user.email": undefined,
+      "user.name": undefined,
+    };
 
     const payload = makePayload();
     const repositoryTerraform = vi.fn(() =>
@@ -133,11 +138,27 @@ describe("makeInitCommand git identity fallback", () => {
         executedGitCommands.push(command);
 
         if (command === "git config --get user.name") {
-          return Promise.resolve({ exitCode: 1, stderr: "", stdout: "" });
+          return Promise.resolve(
+            gitConfigValues["user.name"] === undefined
+              ? { exitCode: 1, stderr: "", stdout: "" }
+              : {
+                  exitCode: 0,
+                  stderr: "",
+                  stdout: gitConfigValues["user.name"],
+                },
+          );
         }
 
         if (command === "git config --get user.email") {
-          return Promise.resolve({ exitCode: 1, stderr: "", stdout: "" });
+          return Promise.resolve(
+            gitConfigValues["user.email"] === undefined
+              ? { exitCode: 1, stderr: "", stdout: "" }
+              : {
+                  exitCode: 0,
+                  stderr: "",
+                  stdout: gitConfigValues["user.email"],
+                },
+          );
         }
 
         return Promise.resolve({ exitCode: 0, stderr: "", stdout: "" });
@@ -165,6 +186,20 @@ describe("makeInitCommand git identity fallback", () => {
   });
 
   it("uses temporary git -c identity overrides when git user config is missing", async () => {
+    await runInitCommand();
+
+    const commitCommand = executedGitCommands.find((command) =>
+      command.includes('commit --no-gpg-sign -m "Scaffold workspace"'),
+    );
+
+    expect(commitCommand).toContain(
+      'git -c user.name=dx-pagopa-bot -c user.email=dx-pagopa-github-bot@pagopa.it commit --no-gpg-sign -m "Scaffold workspace"',
+    );
+  });
+
+  it("uses the default bot identity for both values when only one git config value is present", async () => {
+    gitConfigValues["user.name"] = "User Name";
+
     await runInitCommand();
 
     const commitCommand = executedGitCommands.find((command) =>

--- a/apps/cli/src/adapters/commander/commands/__tests__/init-git-identity.test.ts
+++ b/apps/cli/src/adapters/commander/commands/__tests__/init-git-identity.test.ts
@@ -1,0 +1,178 @@
+/**
+ * Tests the git identity fallback used by the init command when the local git
+ * configuration does not define user.name or user.email.
+ */
+
+import { Command } from "commander";
+import inquirer from "inquirer";
+import { okAsync } from "neverthrow";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { mockDeep } from "vitest-mock-extended";
+
+import type { AuthorizationService } from "../../../../domain/authorization.js";
+import type { CommandPresenter } from "../../../../domain/command-presenter.js";
+import type { GitHubAuthFactory } from "../../../../domain/dependencies.js";
+import type { GitHubService } from "../../../../domain/github.js";
+import type { Payload as MonorepoPayload } from "../../../plop/generators/monorepo/index.js";
+
+import { PullRequest } from "../../../../domain/github.js";
+
+const mocks = vi.hoisted(() => {
+  const reportError = vi.fn();
+  const reportResult = vi.fn();
+  const trackStepMock = vi.fn();
+  const presenter: CommandPresenter = {
+    reportError,
+    reportResult,
+    trackStep: async <T>(name: string, task: () => Promise<T>) => {
+      trackStepMock(name, task);
+      return task();
+    },
+  };
+
+  return {
+    collectMonorepoPayload: vi.fn(),
+    createCommandPresenter: vi.fn(() => presenter),
+    execa$: vi.fn(),
+    getPlopInstance: vi.fn(),
+    reportError,
+    reportResult,
+    resolveOutputMode: vi.fn(
+      (_env: unknown, output: "json" | "text" | undefined) => output ?? "text",
+    ),
+    runMonorepoActions: vi.fn(),
+    tf$: vi.fn(),
+    trackStepMock,
+  };
+});
+
+vi.mock("inquirer");
+vi.mock("ora", () => ({
+  oraPromise: <T>(promise: Promise<T>) => promise,
+}));
+vi.mock("../../../plop/index.js", () => ({
+  collectMonorepoPayload: mocks.collectMonorepoPayload,
+  getPlopInstance: mocks.getPlopInstance,
+  runMonorepoActions: mocks.runMonorepoActions,
+}));
+vi.mock("../../../execa/terraform.js", () => ({ tf$: mocks.tf$ }));
+vi.mock("../../presenters/index.js", () => ({
+  createCommandPresenter: mocks.createCommandPresenter,
+  resolveOutputMode: mocks.resolveOutputMode,
+}));
+vi.mock("execa", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("execa")>();
+
+  return {
+    ...actual,
+    $: mocks.execa$,
+  };
+});
+
+import { makeInitCommand } from "../init.js";
+
+const silentOutput = {
+  writeErr: () => {
+    /* silence stderr in tests */
+  },
+  writeOut: () => {
+    /* silence stdout in tests */
+  },
+};
+
+const makePayload = (
+  overrides: Partial<MonorepoPayload> = {},
+): MonorepoPayload => ({
+  repoDescription: "A test repo",
+  repoName: "test-repo",
+  repoOwner: "pagopa",
+  ...overrides,
+});
+
+const runInitCommand = async () => {
+  const gitHubService = mockDeep<GitHubService>();
+  gitHubService.createPullRequest.mockResolvedValue(
+    new PullRequest("https://github.com/pagopa/test-repo/pull/1"),
+  );
+
+  const requireGitHubAuth: GitHubAuthFactory = () =>
+    okAsync({
+      authorizationService: mockDeep<AuthorizationService>(),
+      gitHubService,
+    });
+
+  const initCommand = makeInitCommand(requireGitHubAuth, { CI: false });
+  initCommand.exitOverride().configureOutput(silentOutput);
+
+  const program = new Command();
+  program
+    .exitOverride()
+    .option("--output <mode>", "Output mode", "json")
+    .addCommand(initCommand);
+
+  await program.parseAsync(["node", "dx", "--output", "json", "init"]);
+};
+
+describe("makeInitCommand git identity fallback", () => {
+  let executedGitCommands: string[];
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    executedGitCommands = [];
+
+    const payload = makePayload();
+    const repositoryTerraform = vi.fn(() =>
+      Promise.resolve({ exitCode: 0, stderr: "", stdout: "" }),
+    );
+    const gitCommands = vi.fn(
+      (strings: TemplateStringsArray, ...values: string[]) => {
+        const command = strings.reduce(
+          (acc, chunk, index) => acc + chunk + (values[index] ?? ""),
+          "",
+        );
+        executedGitCommands.push(command);
+
+        if (command === "git config --get user.name") {
+          return Promise.resolve({ exitCode: 1, stderr: "", stdout: "" });
+        }
+
+        if (command === "git config --get user.email") {
+          return Promise.resolve({ exitCode: 1, stderr: "", stdout: "" });
+        }
+
+        return Promise.resolve({ exitCode: 0, stderr: "", stdout: "" });
+      },
+    );
+
+    mocks.getPlopInstance.mockResolvedValue({});
+    mocks.collectMonorepoPayload.mockResolvedValue({ generator: {}, payload });
+    mocks.runMonorepoActions.mockResolvedValue(payload);
+    mocks.tf$.mockImplementation((...args: unknown[]) =>
+      Array.isArray(args[0])
+        ? Promise.resolve({ stdout: "ok" })
+        : repositoryTerraform,
+    );
+    mocks.execa$.mockImplementation((options?: { shell?: boolean }) =>
+      options?.shell === true ? gitCommands : Promise.resolve({ stdout: "" }),
+    );
+    vi.mocked(inquirer.prompt).mockResolvedValue({ confirm: true });
+    vi.spyOn(process, "chdir").mockImplementation(() => undefined);
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+    process.exitCode = undefined;
+  });
+
+  it("uses temporary git -c identity overrides when git user config is missing", async () => {
+    await runInitCommand();
+
+    const commitCommand = executedGitCommands.find((command) =>
+      command.includes('commit --no-gpg-sign -m "Scaffold workspace"'),
+    );
+
+    expect(commitCommand).toContain(
+      'git -c user.name=dx-pagopa-bot -c user.email=dx-pagopa-github-bot@pagopa.it commit --no-gpg-sign -m "Scaffold workspace"',
+    );
+  });
+});

--- a/apps/cli/src/adapters/commander/commands/init.ts
+++ b/apps/cli/src/adapters/commander/commands/init.ts
@@ -367,6 +367,8 @@ const createRemoteRepositoryWithPresenter =
  * See https://git-scm.com/docs/git-remote#_exit_status
  */
 const GIT_REMOTE_ALREADY_EXISTS_EXIT_CODE = 3;
+const DEFAULT_SCAFFOLD_GIT_USER_EMAIL = "dx-pagopa-github-bot@pagopa.it";
+const DEFAULT_SCAFFOLD_GIT_USER_NAME = "dx-pagopa-bot";
 
 /**
  * Translates a failure of the git remote setup step into an actionable error.
@@ -398,6 +400,49 @@ const initializeGitRepositoryWithPresenter =
     const git$ = $({
       shell: true,
     });
+    const gitRead$ = $({
+      reject: false,
+      shell: true,
+    });
+    const readGitConfigValue = async (
+      key: "user.email" | "user.name",
+    ): Promise<string | undefined> => {
+      const result = await gitRead$`git config --get ${key}`;
+      const value = result.stdout.trim();
+      const stderr = (result.stderr ?? "").trim();
+      const isMissingValue =
+        result.exitCode === 1 && value === "" && stderr === "";
+
+      if (isMissingValue || value === "") {
+        return undefined;
+      }
+
+      if (result.exitCode !== 0) {
+        throw new Error(
+          stderr === "" ? `Failed to read git config ${key}` : stderr,
+          { cause: result },
+        );
+      }
+
+      return value;
+    };
+    const commitScaffold = async () => {
+      const [configuredGitUserName, configuredGitUserEmail] = await Promise.all(
+        [readGitConfigValue("user.name"), readGitConfigValue("user.email")],
+      );
+
+      if (
+        configuredGitUserName !== undefined &&
+        configuredGitUserEmail !== undefined
+      ) {
+        await git$`git commit --no-gpg-sign -m "Scaffold workspace"`;
+        return;
+      }
+
+      // `git -c` applies the fallback identity only to this scaffold commit, so
+      // the generated repository does not persist bot defaults in local config.
+      await git$`git -c user.name=${configuredGitUserName ?? DEFAULT_SCAFFOLD_GIT_USER_NAME} -c user.email=${configuredGitUserEmail ?? DEFAULT_SCAFFOLD_GIT_USER_EMAIL} commit --no-gpg-sign -m "Scaffold workspace"`;
+    };
     // `git remote add` is tracked separately from the push so its documented
     // exit codes (e.g. 3 = remote already exists) surface a specific, actionable
     // message instead of being misreported as a push failure.
@@ -413,7 +458,7 @@ const initializeGitRepositoryWithPresenter =
       // while keeping the scaffolded local files in the working tree for a clean PR diff.
       await git$`git reset origin/main`;
       await git$`git add .`;
-      await git$`git commit --no-gpg-sign -m "Scaffold workspace"`;
+      await commitScaffold();
       await git$`git push -u origin ${branchName}`;
     };
     return trackStep(

--- a/apps/cli/src/adapters/commander/commands/init.ts
+++ b/apps/cli/src/adapters/commander/commands/init.ts
@@ -430,18 +430,17 @@ const initializeGitRepositoryWithPresenter =
       const [configuredGitUserName, configuredGitUserEmail] = await Promise.all(
         [readGitConfigValue("user.name"), readGitConfigValue("user.email")],
       );
-
-      if (
+      const hasConfiguredGitIdentity =
         configuredGitUserName !== undefined &&
-        configuredGitUserEmail !== undefined
-      ) {
-        await git$`git commit --no-gpg-sign -m "Scaffold workspace"`;
-        return;
-      }
+        configuredGitUserEmail !== undefined;
 
-      // `git -c` applies the fallback identity only to this scaffold commit, so
-      // the generated repository does not persist bot defaults in local config.
-      await git$`git -c user.name=${configuredGitUserName ?? DEFAULT_SCAFFOLD_GIT_USER_NAME} -c user.email=${configuredGitUserEmail ?? DEFAULT_SCAFFOLD_GIT_USER_EMAIL} commit --no-gpg-sign -m "Scaffold workspace"`;
+      if (hasConfiguredGitIdentity) {
+        await git$`git commit --no-gpg-sign -m "Scaffold workspace"`;
+      } else {
+        // `git -c` applies the fallback identity only to this scaffold commit, so
+        // the generated repository does not persist bot defaults in local config.
+        await git$`git -c user.name=${DEFAULT_SCAFFOLD_GIT_USER_NAME} -c user.email=${DEFAULT_SCAFFOLD_GIT_USER_EMAIL} commit --no-gpg-sign -m "Scaffold workspace"`;
+      }
     };
     // `git remote add` is tracked separately from the push so its documented
     // exit codes (e.g. 3 = remote already exists) surface a specific, actionable


### PR DESCRIPTION
Use a temporary `git -c user.name/user.email` fallback for the scaffold commit in `dx init`

Resolves CES-2146
