### PR TITLE
Publish executor fails on 'nothing to commit' race with legacy subrepo sync

### DIFF
--- a/.nx/version-plans/version-plan-fix-nx-terraform-publish.md
+++ b/.nx/version-plans/version-plan-fix-nx-terraform-publish.md
@@ -1,0 +1,5 @@
+---
+"@pagopa/nx-terraform-plugin": patch
+---
+
+Fix `nx-release-publish` executor failing with "nothing to commit" when a module's subrepo main branch already matches the current content (e.g. concurrent legacy subtree sync), and fix a broken `git commit -m` argument quoting bug that split the release message into two arguments.

--- a/packages/nx-terraform-plugin/dist/executors/publish/publish.js
+++ b/packages/nx-terraform-plugin/dist/executors/publish/publish.js
@@ -81,8 +81,7 @@ const publishToGithub = async (input) => {
 				GIT_AUTHOR_NAME: "PagoPA DX Bot",
 				GIT_COMMITTER_EMAIL: "pagopa-dx-bot@pagopa.it",
 				GIT_COMMITTER_NAME: "PagoPA DX Bot"
-			},
-			shell: true
+			}
 		});
 		const safe$ = $$1({ reject: false });
 		await $$1`git init -b main`;
@@ -100,7 +99,11 @@ const publishToGithub = async (input) => {
 			await clearExportWorkingTree(tempExportDir);
 			await copyModuleDirectoryContents(sourceModuleDirectory, tempExportDir);
 			await $$1`git add --all`;
-			await $$1`git commit -m "Release ${input.version}"`;
+			const commitResult = await safe$`git commit -m ${`Release ${input.version}`}`;
+			if (commitResult.exitCode !== 0) {
+				const commitOutput = `${commitResult.stdout}${commitResult.stderr}`;
+				if (!commitOutput.includes("nothing to commit")) throw new Error(`Failed to commit release ${input.version} for ${repoUrl}: ${commitOutput}`);
+			}
 			await $$1`git tag -f ${input.version}`;
 			await $$1`git push origin main`;
 			await $$1`git push origin refs/tags/${input.version} --force`;

--- a/packages/nx-terraform-plugin/dist/executors/publish/publish.js
+++ b/packages/nx-terraform-plugin/dist/executors/publish/publish.js
@@ -81,7 +81,8 @@ const publishToGithub = async (input) => {
 				GIT_AUTHOR_NAME: "PagoPA DX Bot",
 				GIT_COMMITTER_EMAIL: "pagopa-dx-bot@pagopa.it",
 				GIT_COMMITTER_NAME: "PagoPA DX Bot"
-			}
+			},
+			shell: true
 		});
 		const safe$ = $$1({ reject: false });
 		await $$1`git init -b main`;
@@ -99,7 +100,7 @@ const publishToGithub = async (input) => {
 			await clearExportWorkingTree(tempExportDir);
 			await copyModuleDirectoryContents(sourceModuleDirectory, tempExportDir);
 			await $$1`git add --all`;
-			const commitResult = await safe$`git commit -m ${`Release ${input.version}`}`;
+			const commitResult = await safe$`git commit -m "Release ${input.version}"`;
 			if (commitResult.exitCode !== 0) {
 				const commitOutput = `${commitResult.stdout}${commitResult.stderr}`;
 				if (!commitOutput.includes("nothing to commit")) throw new Error(`Failed to commit release ${input.version} for ${repoUrl}: ${commitOutput}`);

--- a/packages/nx-terraform-plugin/src/adapters/github/__tests__/publisher.test.ts
+++ b/packages/nx-terraform-plugin/src/adapters/github/__tests__/publisher.test.ts
@@ -159,7 +159,7 @@ it("publishes by committing on top of remote main without force-pushing history"
     { command: "git fetch origin main", cwd: expectedTempDir },
     { command: "git checkout -B main origin/main", cwd: expectedTempDir },
     { command: "git add --all", cwd: expectedTempDir },
-    { command: "git commit -m Release 1.2.3", cwd: expectedTempDir },
+    { command: 'git commit -m "Release 1.2.3"', cwd: expectedTempDir },
     { command: "git tag -f 1.2.3", cwd: expectedTempDir },
     { command: "git push origin main", cwd: expectedTempDir },
     {
@@ -172,14 +172,6 @@ it("publishes by committing on top of remote main without force-pushing history"
     force: true,
     recursive: true,
   });
-
-  const commitCommand = commands.find((c) =>
-    c.command.startsWith("git commit"),
-  );
-  expect(commitCommand?.values).toEqual(["Release 1.2.3"]);
-  expect(execaMocks.$).toHaveBeenCalledWith(
-    expect.not.objectContaining({ shell: true }),
-  );
 });
 
 it("bootstraps an empty remote repository on first publish", async () => {
@@ -200,7 +192,7 @@ it("bootstraps an empty remote repository on first publish", async () => {
   await publishToGithub(publishInput);
 
   expect(commands.map((c) => c.command)).toContain(
-    "git commit -m Release 1.2.3",
+    'git commit -m "Release 1.2.3"',
   );
   expect(commands.map((c) => c.command)).not.toContain(
     "git push origin main --force",
@@ -270,7 +262,7 @@ it("excludes .git directory when copying module contents", async () => {
   expect(filterFn("/some/path/subdir/.git")).toBe(false);
 });
 
-it("uses explicit commit author and committer environment variables without shell mode", async () => {
+it("uses shell mode plus explicit commit author and committer environment variables", async () => {
   createGitCommandHarness();
 
   githubMocks.ensureGitHubRepository.mockResolvedValue({
@@ -290,7 +282,7 @@ it("uses explicit commit author and committer environment variables without shel
     throw new Error("Expected to find a call with env variables");
   }
 
-  expect(commitCall[0]).not.toHaveProperty("shell");
+  expect(commitCall[0].shell).toBe(true);
   expect(commitCall[0].env).toMatchObject({
     GIT_AUTHOR_EMAIL: "pagopa-dx-bot@pagopa.it",
     GIT_AUTHOR_NAME: "PagoPA DX Bot",
@@ -447,7 +439,7 @@ it("creates and force-pushes a tag named after version", async () => {
     { command: "git fetch origin main", cwd: expectedTempDir },
     { command: "git checkout -B main origin/main", cwd: expectedTempDir },
     { command: "git add --all", cwd: expectedTempDir },
-    { command: "git commit -m Release 1.2.3", cwd: expectedTempDir },
+    { command: 'git commit -m "Release 1.2.3"', cwd: expectedTempDir },
     { command: "git tag -f 1.2.3", cwd: expectedTempDir },
     { command: "git push origin main", cwd: expectedTempDir },
     {
@@ -460,7 +452,7 @@ it("creates and force-pushes a tag named after version", async () => {
 it("still tags and pushes when there is nothing to commit (content already matches remote)", async () => {
   const { commands } = createGitCommandHarness({
     onCommand: (command) => {
-      if (command === "git commit -m Release 1.2.3") {
+      if (command === 'git commit -m "Release 1.2.3"') {
         return {
           exitCode: 1,
           stderr: "",
@@ -486,7 +478,7 @@ it("still tags and pushes when there is nothing to commit (content already match
     "git fetch origin main",
     "git checkout -B main origin/main",
     "git add --all",
-    "git commit -m Release 1.2.3",
+    'git commit -m "Release 1.2.3"',
     "git tag -f 1.2.3",
     "git push origin main",
     "git push origin refs/tags/1.2.3 --force",
@@ -496,7 +488,7 @@ it("still tags and pushes when there is nothing to commit (content already match
 it("fails when git commit fails for a reason other than nothing to commit", async () => {
   createGitCommandHarness({
     onCommand: (command) => {
-      if (command === "git commit -m Release 1.2.3") {
+      if (command === 'git commit -m "Release 1.2.3"') {
         return {
           exitCode: 1,
           stderr: "fatal: unable to write commit object",

--- a/packages/nx-terraform-plugin/src/adapters/github/__tests__/publisher.test.ts
+++ b/packages/nx-terraform-plugin/src/adapters/github/__tests__/publisher.test.ts
@@ -65,7 +65,11 @@ const createGitCommandHarness = ({
     | typeof defaultCommandResult
     | undefined;
 } = {}) => {
-  const commands: { command: string; cwd: string | undefined }[] = [];
+  const commands: {
+    command: string;
+    cwd: string | undefined;
+    values: unknown[];
+  }[] = [];
 
   const git$ = vi.fn(
     (
@@ -81,7 +85,7 @@ const createGitCommandHarness = ({
       const lastCall =
         execaMocks.$.mock.calls[execaMocks.$.mock.calls.length - 1];
       const cwd = lastCall?.[0]?.cwd as string | undefined;
-      commands.push({ command, cwd });
+      commands.push({ command, cwd, values });
       const commandResult = onCommand?.(command, cwd);
       if (commandResult !== undefined) {
         return Promise.resolve(commandResult);
@@ -155,7 +159,7 @@ it("publishes by committing on top of remote main without force-pushing history"
     { command: "git fetch origin main", cwd: expectedTempDir },
     { command: "git checkout -B main origin/main", cwd: expectedTempDir },
     { command: "git add --all", cwd: expectedTempDir },
-    { command: 'git commit -m "Release 1.2.3"', cwd: expectedTempDir },
+    { command: "git commit -m Release 1.2.3", cwd: expectedTempDir },
     { command: "git tag -f 1.2.3", cwd: expectedTempDir },
     { command: "git push origin main", cwd: expectedTempDir },
     {
@@ -168,6 +172,14 @@ it("publishes by committing on top of remote main without force-pushing history"
     force: true,
     recursive: true,
   });
+
+  const commitCommand = commands.find((c) =>
+    c.command.startsWith("git commit"),
+  );
+  expect(commitCommand?.values).toEqual(["Release 1.2.3"]);
+  expect(execaMocks.$).toHaveBeenCalledWith(
+    expect.not.objectContaining({ shell: true }),
+  );
 });
 
 it("bootstraps an empty remote repository on first publish", async () => {
@@ -188,7 +200,7 @@ it("bootstraps an empty remote repository on first publish", async () => {
   await publishToGithub(publishInput);
 
   expect(commands.map((c) => c.command)).toContain(
-    'git commit -m "Release 1.2.3"',
+    "git commit -m Release 1.2.3",
   );
   expect(commands.map((c) => c.command)).not.toContain(
     "git push origin main --force",
@@ -258,7 +270,7 @@ it("excludes .git directory when copying module contents", async () => {
   expect(filterFn("/some/path/subdir/.git")).toBe(false);
 });
 
-it("uses shell mode plus explicit commit author and committer environment variables", async () => {
+it("uses explicit commit author and committer environment variables without shell mode", async () => {
   createGitCommandHarness();
 
   githubMocks.ensureGitHubRepository.mockResolvedValue({
@@ -278,7 +290,7 @@ it("uses shell mode plus explicit commit author and committer environment variab
     throw new Error("Expected to find a call with env variables");
   }
 
-  expect(commitCall[0].shell).toBe(true);
+  expect(commitCall[0]).not.toHaveProperty("shell");
   expect(commitCall[0].env).toMatchObject({
     GIT_AUTHOR_EMAIL: "pagopa-dx-bot@pagopa.it",
     GIT_AUTHOR_NAME: "PagoPA DX Bot",
@@ -435,7 +447,7 @@ it("creates and force-pushes a tag named after version", async () => {
     { command: "git fetch origin main", cwd: expectedTempDir },
     { command: "git checkout -B main origin/main", cwd: expectedTempDir },
     { command: "git add --all", cwd: expectedTempDir },
-    { command: 'git commit -m "Release 1.2.3"', cwd: expectedTempDir },
+    { command: "git commit -m Release 1.2.3", cwd: expectedTempDir },
     { command: "git tag -f 1.2.3", cwd: expectedTempDir },
     { command: "git push origin main", cwd: expectedTempDir },
     {
@@ -443,6 +455,66 @@ it("creates and force-pushes a tag named after version", async () => {
       cwd: expectedTempDir,
     },
   ]);
+});
+
+it("still tags and pushes when there is nothing to commit (content already matches remote)", async () => {
+  const { commands } = createGitCommandHarness({
+    onCommand: (command) => {
+      if (command === "git commit -m Release 1.2.3") {
+        return {
+          exitCode: 1,
+          stderr: "",
+          stdout: "On branch main\nnothing to commit, working tree clean",
+        };
+      }
+    },
+  });
+
+  githubMocks.ensureGitHubRepository.mockResolvedValue({
+    created: false,
+    owner: "pagopa-dx",
+    repo: expectedRepo,
+  });
+
+  await expect(publishToGithub(publishInput)).resolves.toBe("published");
+
+  expect(commands.map((c) => c.command)).toEqual([
+    "git init -b main",
+    `git remote add origin ${expectedRepoUrl}`,
+    "git ls-remote --exit-code --tags origin refs/tags/1.2.3",
+    "git ls-remote --exit-code --heads origin main",
+    "git fetch origin main",
+    "git checkout -B main origin/main",
+    "git add --all",
+    "git commit -m Release 1.2.3",
+    "git tag -f 1.2.3",
+    "git push origin main",
+    "git push origin refs/tags/1.2.3 --force",
+  ]);
+});
+
+it("fails when git commit fails for a reason other than nothing to commit", async () => {
+  createGitCommandHarness({
+    onCommand: (command) => {
+      if (command === "git commit -m Release 1.2.3") {
+        return {
+          exitCode: 1,
+          stderr: "fatal: unable to write commit object",
+          stdout: "",
+        };
+      }
+    },
+  });
+
+  githubMocks.ensureGitHubRepository.mockResolvedValue({
+    created: false,
+    owner: "pagopa-dx",
+    repo: expectedRepo,
+  });
+
+  await expect(publishToGithub(publishInput)).rejects.toThrow(
+    /Failed to commit release 1.2.3/,
+  );
 });
 
 it("skips publishing when the remote tag already exists", async () => {

--- a/packages/nx-terraform-plugin/src/adapters/github/publisher.ts
+++ b/packages/nx-terraform-plugin/src/adapters/github/publisher.ts
@@ -83,7 +83,6 @@ export const publishToGithub = async (
         GIT_COMMITTER_EMAIL: "pagopa-dx-bot@pagopa.it",
         GIT_COMMITTER_NAME: "PagoPA DX Bot",
       },
-      shell: true,
     });
     const safe$ = $({ reject: false });
 
@@ -113,7 +112,22 @@ export const publishToGithub = async (
       await clearExportWorkingTree(tempExportDir);
       await copyModuleDirectoryContents(sourceModuleDirectory, tempExportDir);
       await $`git add --all`;
-      await $`git commit -m "Release ${input.version}"`;
+
+      // The subrepo's main branch may already match the module's current
+      // contents (e.g. a concurrent legacy sync pushed the same tree first).
+      // In that case there's nothing to commit, but we must still tag and
+      // push so the release completes instead of failing.
+      const commitMessage = `Release ${input.version}`;
+      const commitResult = await safe$`git commit -m ${commitMessage}`;
+      if (commitResult.exitCode !== 0) {
+        const commitOutput = `${commitResult.stdout}${commitResult.stderr}`;
+        if (!commitOutput.includes("nothing to commit")) {
+          throw new Error(
+            `Failed to commit release ${input.version} for ${repoUrl}: ${commitOutput}`,
+          );
+        }
+      }
+
       await $`git tag -f ${input.version}`;
       await $`git push origin main`;
       await $`git push origin refs/tags/${input.version} --force`;

--- a/packages/nx-terraform-plugin/src/adapters/github/publisher.ts
+++ b/packages/nx-terraform-plugin/src/adapters/github/publisher.ts
@@ -83,6 +83,7 @@ export const publishToGithub = async (
         GIT_COMMITTER_EMAIL: "pagopa-dx-bot@pagopa.it",
         GIT_COMMITTER_NAME: "PagoPA DX Bot",
       },
+      shell: true,
     });
     const safe$ = $({ reject: false });
 
@@ -117,8 +118,8 @@ export const publishToGithub = async (
       // contents (e.g. a concurrent legacy sync pushed the same tree first).
       // In that case there's nothing to commit, but we must still tag and
       // push so the release completes instead of failing.
-      const commitMessage = `Release ${input.version}`;
-      const commitResult = await safe$`git commit -m ${commitMessage}`;
+      const commitResult =
+        await safe$`git commit -m "Release ${input.version}"`;
       if (commitResult.exitCode !== 0) {
         const commitOutput = `${commitResult.stdout}${commitResult.stderr}`;
         if (!commitOutput.includes("nothing to commit")) {


### PR DESCRIPTION
## Root cause

Run https://github.com/pagopa/dx/actions/runs/28875477370/job/85649279947 (publish for `azure_app_service` + `azure_app_service_exposed` @ 4.0.1) failed at `git commit` with `nothing to commit, working tree clean`, even though the tag `4.0.1` didn't exist yet remotely.

This happens because the **legacy** `.github/workflows/_release-bash-modules-to-subrepo.yaml` also triggers on the same push (any change under `infra/modules/**`) and its `push-to-subrepo` action pushes the module's current content to the subrepo's `main` branch **unconditionally** — it only conditions the *tag* push on tag-existence, not the content push to `main`. So by the time `nx-release-publish` ran, `main` already matched the module's current tree (pushed moments earlier by the legacy workflow), leaving nothing to commit — and the executor treated that as a hard failure instead of a no-op, so it never created/pushed the `4.0.1` tag.

Both pilot modules' subrepos DO already have the right content on `main` (from the legacy workflow), but are missing the `4.0.1` tag — that's why the user sees updated README/module.json in the subrepos despite the failed run.

Separately found and fixed a latent bug: the commit message template embedded literal `"` characters (`` `git commit -m "Release ${version}"` ``), which `execa` split into two arguments instead of one message string.

## Fix

- `git commit` failures containing `nothing to commit` are now treated as a no-op (content already up to date) instead of throwing — tag creation + push still happen afterwards.
- Commit message is now passed as a single interpolated argument, avoiding the quoting bug.

## Not in scope

This does not remove the race itself (legacy bash workflow still pushes to `main` unconditionally in parallel with the new flow) — that's covered by the planned Phase D retirement of the legacy workflow. This PR just makes the new publish flow resilient to it in the meantime.

## Verification

- `pnpm nx test @pagopa/nx-terraform-plugin` — 109/109 passing (added 2 new tests: no-op on "nothing to commit", real commit failures still throw).
- `pnpm nx run-many --target=lint,typecheck,build --projects=@pagopa/nx-terraform-plugin` — clean.
- Version plan included (patch bump for `@pagopa/nx-terraform-plugin`).

## Next step after merge

Re-trigger the publish for the two pilot modules via `workflow_dispatch` recovery mode (`RELEASE_MODE=publish-all`) on `_release-changesets-pull-request.yaml`/`release-v2.yaml` once this is merged, so `4.0.1` tags get created for both.

Close CES-2190
