### PR TITLE
Fix Technology Radar link on docs homepage

### DIFF
--- a/.nx/version-plans/version-plan-fix-radar-link.md
+++ b/.nx/version-plans/version-plan-fix-radar-link.md
@@ -1,0 +1,5 @@
+---
+docs: patch
+---
+
+Fix the "Technology Radar" link on the docs homepage, which pointed to the external `pagopa.github.io/technology-radar` site instead of the internal `/radar` page.

--- a/apps/website/docs/index.md
+++ b/apps/website/docs/index.md
@@ -59,8 +59,7 @@ Cloud Service Providers (CSPs), and align with a variety of programming
 languages.
 
 These tools adhere to the principles and boundaries outlined in our
-[Technology Radar](/radar) that
-teams are expected to follow.
+[Technology Radar](/radar) that teams are expected to follow.
 
 Technology Radar recommendations are thoughtfully designed to foster
 consistency, efficiency, and alignment across projects, ensuring a streamlined

--- a/apps/website/docs/index.md
+++ b/apps/website/docs/index.md
@@ -59,7 +59,7 @@ Cloud Service Providers (CSPs), and align with a variety of programming
 languages.
 
 These tools adhere to the principles and boundaries outlined in our
-[Technology Radar](https://pagopa.github.io/technology-radar/index.html) that
+[Technology Radar](/radar) that
 teams are expected to follow.
 
 Technology Radar recommendations are thoughtfully designed to foster
@@ -104,7 +104,7 @@ If you're building APIs, web applications, or services:
 ## What We Provide
 
 **🛤️ Golden Paths** - Opinionated, proven approaches aligned with our
-[Technology Radar](https://pagopa.github.io/technology-radar/)
+[Technology Radar](/radar)
 
 **🔧 Ready-to-Use Tools** - Terraform modules, GitHub Actions, and development
 environments that just work


### PR DESCRIPTION
The "Technology Radar" link on the docs homepage (https://dx.pagopa.it/docs/) pointed to the external `https://pagopa.github.io/technology-radar/` site instead of the site's own `/radar` page (https://dx.pagopa.it/radar).

Updated both occurrences to use the internal `/radar` route.

Includes a version plan for the `docs` package.

Close CES-2209