### PR TITLE
Cache entire .nx folder to fix Unrecognized Cache Artifacts warning

### DIFF
--- a/.github/workflows/validate-v2.yaml
+++ b/.github/workflows/validate-v2.yaml
@@ -97,7 +97,9 @@ jobs:
       - name: Cache Nx
         uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
         with:
-          path: .nx
+          path: |
+            .nx
+            !.nx/workspace-data/d
           key: ${{ runner.os }}-nx-cache-${{ github.workflow }}-${{ github.event.pull_request.number || github.ref_name }}-${{ github.sha }}
           restore-keys: |
             ${{ runner.os }}-nx-cache-${{ github.workflow }}-${{ github.event.pull_request.number || github.ref_name }}-

--- a/.github/workflows/validate-v2.yaml
+++ b/.github/workflows/validate-v2.yaml
@@ -98,7 +98,8 @@ jobs:
         uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
         with:
           path: |
-            .nx
+            .nx/cache
+            .nx/workspace-data
             !.nx/workspace-data/d
           key: ${{ runner.os }}-nx-cache-${{ github.workflow }}-${{ github.event.pull_request.number || github.ref_name }}-${{ github.sha }}
           restore-keys: |

--- a/.github/workflows/validate-v2.yaml
+++ b/.github/workflows/validate-v2.yaml
@@ -97,7 +97,7 @@ jobs:
       - name: Cache Nx
         uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
         with:
-          path: .nx/cache
+          path: .nx
           key: ${{ runner.os }}-nx-cache-${{ github.workflow }}-${{ github.event.pull_request.number || github.ref_name }}-${{ github.sha }}
           restore-keys: |
             ${{ runner.os }}-nx-cache-${{ github.workflow }}-${{ github.event.pull_request.number || github.ref_name }}-
@@ -107,8 +107,6 @@ jobs:
         uses: nrwl/nx-set-shas@afb73a62d26e41464e9254689e1fd6122ee683c1 # v5.0.1
 
       - name: Run code quality checks on affected projects
-        env:
-          NX_REJECT_UNKNOWN_LOCAL_CACHE: 0
         run: pnpm validate
 
   get-environments:

--- a/.github/workflows/validate-v2.yaml
+++ b/.github/workflows/validate-v2.yaml
@@ -107,6 +107,8 @@ jobs:
         uses: nrwl/nx-set-shas@afb73a62d26e41464e9254689e1fd6122ee683c1 # v5.0.1
 
       - name: Run code quality checks on affected projects
+        env:
+          NX_REJECT_UNKNOWN_LOCAL_CACHE: 0
         run: pnpm validate
 
   get-environments:


### PR DESCRIPTION
## Problem

On every PR run the `validate / Static Review` job emits:

```
NX   Unrecognized Cache Artifacts

Nx found unrecognized artifacts in the cache directory and will not be able to use them.
Nx can only restore artifacts it has metadata about.
```

Nx skips the cache entirely as a result, causing all affected projects to be rebuilt from scratch on every push.

## Root cause

Since Nx 20, the new **database cache** stores task metadata in a SQLite database under `.nx/workspace-data`, separate from the artifact files stored in `.nx/cache`. The workflow only saved and restored `.nx/cache`, so on every restore the database was absent.

When Nx starts, it finds artifact files on disk (`.nx/cache`) but has no corresponding database records in `.nx/workspace-data`. It therefore cannot verify those artifacts and emits the warning, refusing to use them.

## Why `NX_REJECT_UNKNOWN_LOCAL_CACHE=0` does not help

This environment variable was the escape hatch for the old **legacy file system cache** (Nx ≤ 19). As of Nx 20, the variable is a documented no-op — the new database cache ignores it entirely. Reference: [deprecation docs](https://nx.dev/docs/reference/deprecated/legacy-cache), [upstream issue nrwl/nx#28914](https://github.com/nrwl/nx/issues/28914).

## Change

Cache the entire `.nx` directory instead of just `.nx/cache`, excluding `.nx/workspace-data/d`.

- **`.nx/cache`** — task artifact files (already cached, kept)
- **`.nx/workspace-data`** — SQLite metadata database (was missing, now included)
- **`.nx/workspace-data/d`** — excluded: contains only Nx daemon runtime files (`daemon.log`, `server-process.json` with a stale PID from the previous runner). Restoring them on a fresh CI runner serves no purpose and could cause Nx to attempt a connection to a dead daemon process.

## Threat model

The Nx cache security model is designed to prevent **cache poisoning** on shared, writable network drives: an attacker with write access could overwrite an artifact for a known task hash and have another machine silently pick it up. Caching the metadata database alongside the artifacts does not change this picture in a GitHub Actions context because:

- **Immutable entries**: GitHub Actions cache entries cannot be overwritten once saved for a given key.
- **Scoped access**: cache entries are scoped to the repository and branch; they are inaccessible from outside.
- **Ephemeral runners**: each job runs on a fresh VM; no persistent disk state survives between jobs.
- **No enumeration**: the GitHub Actions cache API does not allow listing all keys and fetching arbitrary artifacts, which is a prerequisite for the poisoning attack.