### PR TITLE
Add AEPDF to repository Jira board IDs

### DIFF
--- a/infra/bootstrapper/_modules/aws/tfmodules.lock.json
+++ b/infra/bootstrapper/_modules/aws/tfmodules.lock.json
@@ -1,9 +1,9 @@
 {
   "bootstrap": {
-    "hash": "19d6aa4cc067f2afe19007d9fc88964baff25b9e293db879b9aa78841620d3a8",
-    "version": "0.0.6",
+    "hash": "01b0bfa12e88caf00047a45cfeedce59939f918cb6da850938326e78c0c1729b",
+    "version": "0.0.7",
     "name": "aws_github_environment_bootstrap",
-    "source": "https://registry.terraform.io/modules/pagopa-dx/aws-github-environment-bootstrap/aws/0.0.6"
+    "source": "https://registry.terraform.io/modules/pagopa-dx/aws-github-environment-bootstrap/aws/0.0.7"
   },
   "bootstrap.github_runner": {
     "hash": "ff21571098f150f74ceab8b82a7af1bfc753a3bf3b75707493bf53a5d45fcd91",

--- a/infra/bootstrapper/_modules/azure/tfmodules.lock.json
+++ b/infra/bootstrapper/_modules/azure/tfmodules.lock.json
@@ -6,10 +6,10 @@
     "source": "https://registry.terraform.io/modules/pagopa-dx/azure-github-environment-bootstrap/azurerm/4.1.0"
   },
   "bootstrap.github_runner": {
-    "hash": "38a201fffe67a0529700255961c00bfb42f11a41f0095eea6d466fe4ba7e05e9",
-    "version": "1.3.3",
+    "hash": "9e7ad257adb3eb09a4c5113dbca7a4642481388627a9aea45c3e27a58edac11f",
+    "version": "1.3.4",
     "name": "github_selfhosted_runner_on_container_app_jobs",
-    "source": "https://registry.terraform.io/modules/pagopa-dx/github-selfhosted-runner-on-container-app-jobs/azurerm/1.3.3"
+    "source": "https://registry.terraform.io/modules/pagopa-dx/github-selfhosted-runner-on-container-app-jobs/azurerm/1.3.4"
   },
   "core_values": {
     "hash": "8b9a3151a0e9ec1015b23f137107cd966629384e0cd954c69be07891ff198b1b",

--- a/infra/core/dev/tfmodules.lock.json
+++ b/infra/core/dev/tfmodules.lock.json
@@ -6,63 +6,63 @@
     "source": "https://registry.terraform.io/modules/pagopa-dx/aws-core-infra/aws/0.0.5"
   },
   "azure": {
-    "hash": "db29c1286dc319239efaafe8f775b6f12ba02c65686ff269d836385a055681ca",
-    "version": "4.3.0",
+    "hash": "c43b87dc615bf5dc433bafcf6fe0091388d73bc802212dab41609525d0dcaf44",
+    "version": "4.4.0",
     "name": "azure_core_infra",
-    "source": "https://registry.terraform.io/modules/pagopa-dx/azure-core-infra/azurerm/4.3.0"
+    "source": "https://registry.terraform.io/modules/pagopa-dx/azure-core-infra/azurerm/4.4.0"
   },
   "azure.custom_roles.dx_app_cd_resource_group_deploy": {
-    "hash": "32687e53abb8bcb58f39687703a09dd210da24595996f017fa238c43c3145cb9",
-    "version": "0.1.2",
+    "hash": "58fa698754e138b1753f1e142cf5d4428e3f368449d6f0c9e638767912110871",
+    "version": "0.1.3",
     "name": "azure_merge_roles",
-    "source": "https://registry.terraform.io/modules/pagopa-dx/azure-merge-roles/azurerm/0.1.2"
+    "source": "https://registry.terraform.io/modules/pagopa-dx/azure-merge-roles/azurerm/0.1.3"
   },
   "azure.custom_roles.dx_app_ci_resource_group_reader": {
-    "hash": "32687e53abb8bcb58f39687703a09dd210da24595996f017fa238c43c3145cb9",
-    "version": "0.1.2",
+    "hash": "58fa698754e138b1753f1e142cf5d4428e3f368449d6f0c9e638767912110871",
+    "version": "0.1.3",
     "name": "azure_merge_roles",
-    "source": "https://registry.terraform.io/modules/pagopa-dx/azure-merge-roles/azurerm/0.1.2"
+    "source": "https://registry.terraform.io/modules/pagopa-dx/azure-merge-roles/azurerm/0.1.3"
   },
   "azure.custom_roles.dx_function_durable_storage": {
-    "hash": "32687e53abb8bcb58f39687703a09dd210da24595996f017fa238c43c3145cb9",
-    "version": "0.1.2",
+    "hash": "58fa698754e138b1753f1e142cf5d4428e3f368449d6f0c9e638767912110871",
+    "version": "0.1.3",
     "name": "azure_merge_roles",
-    "source": "https://registry.terraform.io/modules/pagopa-dx/azure-merge-roles/azurerm/0.1.2"
+    "source": "https://registry.terraform.io/modules/pagopa-dx/azure-merge-roles/azurerm/0.1.3"
   },
   "azure.custom_roles.dx_function_host_storage": {
-    "hash": "32687e53abb8bcb58f39687703a09dd210da24595996f017fa238c43c3145cb9",
-    "version": "0.1.2",
+    "hash": "58fa698754e138b1753f1e142cf5d4428e3f368449d6f0c9e638767912110871",
+    "version": "0.1.3",
     "name": "azure_merge_roles",
-    "source": "https://registry.terraform.io/modules/pagopa-dx/azure-merge-roles/azurerm/0.1.2"
+    "source": "https://registry.terraform.io/modules/pagopa-dx/azure-merge-roles/azurerm/0.1.3"
   },
   "azure.custom_roles.dx_infra_cd_private_networking": {
-    "hash": "32687e53abb8bcb58f39687703a09dd210da24595996f017fa238c43c3145cb9",
-    "version": "0.1.2",
+    "hash": "58fa698754e138b1753f1e142cf5d4428e3f368449d6f0c9e638767912110871",
+    "version": "0.1.3",
     "name": "azure_merge_roles",
-    "source": "https://registry.terraform.io/modules/pagopa-dx/azure-merge-roles/azurerm/0.1.2"
+    "source": "https://registry.terraform.io/modules/pagopa-dx/azure-merge-roles/azurerm/0.1.3"
   },
   "azure.custom_roles.dx_infra_cd_resource_group_deploy": {
-    "hash": "32687e53abb8bcb58f39687703a09dd210da24595996f017fa238c43c3145cb9",
-    "version": "0.1.2",
+    "hash": "58fa698754e138b1753f1e142cf5d4428e3f368449d6f0c9e638767912110871",
+    "version": "0.1.3",
     "name": "azure_merge_roles",
-    "source": "https://registry.terraform.io/modules/pagopa-dx/azure-merge-roles/azurerm/0.1.2"
+    "source": "https://registry.terraform.io/modules/pagopa-dx/azure-merge-roles/azurerm/0.1.3"
   },
   "azure.custom_roles.dx_infra_cd_subscription_admin": {
-    "hash": "32687e53abb8bcb58f39687703a09dd210da24595996f017fa238c43c3145cb9",
-    "version": "0.1.2",
+    "hash": "58fa698754e138b1753f1e142cf5d4428e3f368449d6f0c9e638767912110871",
+    "version": "0.1.3",
     "name": "azure_merge_roles",
-    "source": "https://registry.terraform.io/modules/pagopa-dx/azure-merge-roles/azurerm/0.1.2"
+    "source": "https://registry.terraform.io/modules/pagopa-dx/azure-merge-roles/azurerm/0.1.3"
   },
   "azure.custom_roles.dx_infra_ci_resource_group_reader": {
-    "hash": "32687e53abb8bcb58f39687703a09dd210da24595996f017fa238c43c3145cb9",
-    "version": "0.1.2",
+    "hash": "58fa698754e138b1753f1e142cf5d4428e3f368449d6f0c9e638767912110871",
+    "version": "0.1.3",
     "name": "azure_merge_roles",
-    "source": "https://registry.terraform.io/modules/pagopa-dx/azure-merge-roles/azurerm/0.1.2"
+    "source": "https://registry.terraform.io/modules/pagopa-dx/azure-merge-roles/azurerm/0.1.3"
   },
   "azure.custom_roles.dx_infra_ci_subscription_reader": {
-    "hash": "32687e53abb8bcb58f39687703a09dd210da24595996f017fa238c43c3145cb9",
-    "version": "0.1.2",
+    "hash": "58fa698754e138b1753f1e142cf5d4428e3f368449d6f0c9e638767912110871",
+    "version": "0.1.3",
     "name": "azure_merge_roles",
-    "source": "https://registry.terraform.io/modules/pagopa-dx/azure-merge-roles/azurerm/0.1.2"
+    "source": "https://registry.terraform.io/modules/pagopa-dx/azure-merge-roles/azurerm/0.1.3"
   }
 }

--- a/infra/core/prod/tfmodules.lock.json
+++ b/infra/core/prod/tfmodules.lock.json
@@ -1,9 +1,9 @@
 {
   "azure": {
-    "hash": "db29c1286dc319239efaafe8f775b6f12ba02c65686ff269d836385a055681ca",
-    "version": "4.3.0",
+    "hash": "c43b87dc615bf5dc433bafcf6fe0091388d73bc802212dab41609525d0dcaf44",
+    "version": "4.4.0",
     "name": "azure_core_infra",
-    "source": "https://registry.terraform.io/modules/pagopa-dx/azure-core-infra/azurerm/4.3.0"
+    "source": "https://registry.terraform.io/modules/pagopa-dx/azure-core-infra/azurerm/4.4.0"
   },
   "aws": {
     "hash": "02fc245d89d345cb8cc012bc2c4eeca51b6ecca1b436f030b1bc2aec0c2d8746",
@@ -12,57 +12,57 @@
     "source": "https://registry.terraform.io/modules/pagopa-dx/aws-core-infra/aws/0.0.5"
   },
   "azure.custom_roles.dx_app_cd_resource_group_deploy": {
-    "hash": "32687e53abb8bcb58f39687703a09dd210da24595996f017fa238c43c3145cb9",
-    "version": "0.1.2",
+    "hash": "58fa698754e138b1753f1e142cf5d4428e3f368449d6f0c9e638767912110871",
+    "version": "0.1.3",
     "name": "azure_merge_roles",
-    "source": "https://registry.terraform.io/modules/pagopa-dx/azure-merge-roles/azurerm/0.1.2"
+    "source": "https://registry.terraform.io/modules/pagopa-dx/azure-merge-roles/azurerm/0.1.3"
   },
   "azure.custom_roles.dx_app_ci_resource_group_reader": {
-    "hash": "32687e53abb8bcb58f39687703a09dd210da24595996f017fa238c43c3145cb9",
-    "version": "0.1.2",
+    "hash": "58fa698754e138b1753f1e142cf5d4428e3f368449d6f0c9e638767912110871",
+    "version": "0.1.3",
     "name": "azure_merge_roles",
-    "source": "https://registry.terraform.io/modules/pagopa-dx/azure-merge-roles/azurerm/0.1.2"
+    "source": "https://registry.terraform.io/modules/pagopa-dx/azure-merge-roles/azurerm/0.1.3"
   },
   "azure.custom_roles.dx_function_durable_storage": {
-    "hash": "32687e53abb8bcb58f39687703a09dd210da24595996f017fa238c43c3145cb9",
-    "version": "0.1.2",
+    "hash": "58fa698754e138b1753f1e142cf5d4428e3f368449d6f0c9e638767912110871",
+    "version": "0.1.3",
     "name": "azure_merge_roles",
-    "source": "https://registry.terraform.io/modules/pagopa-dx/azure-merge-roles/azurerm/0.1.2"
+    "source": "https://registry.terraform.io/modules/pagopa-dx/azure-merge-roles/azurerm/0.1.3"
   },
   "azure.custom_roles.dx_function_host_storage": {
-    "hash": "32687e53abb8bcb58f39687703a09dd210da24595996f017fa238c43c3145cb9",
-    "version": "0.1.2",
+    "hash": "58fa698754e138b1753f1e142cf5d4428e3f368449d6f0c9e638767912110871",
+    "version": "0.1.3",
     "name": "azure_merge_roles",
-    "source": "https://registry.terraform.io/modules/pagopa-dx/azure-merge-roles/azurerm/0.1.2"
+    "source": "https://registry.terraform.io/modules/pagopa-dx/azure-merge-roles/azurerm/0.1.3"
   },
   "azure.custom_roles.dx_infra_cd_private_networking": {
-    "hash": "32687e53abb8bcb58f39687703a09dd210da24595996f017fa238c43c3145cb9",
-    "version": "0.1.2",
+    "hash": "58fa698754e138b1753f1e142cf5d4428e3f368449d6f0c9e638767912110871",
+    "version": "0.1.3",
     "name": "azure_merge_roles",
-    "source": "https://registry.terraform.io/modules/pagopa-dx/azure-merge-roles/azurerm/0.1.2"
+    "source": "https://registry.terraform.io/modules/pagopa-dx/azure-merge-roles/azurerm/0.1.3"
   },
   "azure.custom_roles.dx_infra_cd_resource_group_deploy": {
-    "hash": "32687e53abb8bcb58f39687703a09dd210da24595996f017fa238c43c3145cb9",
-    "version": "0.1.2",
+    "hash": "58fa698754e138b1753f1e142cf5d4428e3f368449d6f0c9e638767912110871",
+    "version": "0.1.3",
     "name": "azure_merge_roles",
-    "source": "https://registry.terraform.io/modules/pagopa-dx/azure-merge-roles/azurerm/0.1.2"
+    "source": "https://registry.terraform.io/modules/pagopa-dx/azure-merge-roles/azurerm/0.1.3"
   },
   "azure.custom_roles.dx_infra_cd_subscription_admin": {
-    "hash": "32687e53abb8bcb58f39687703a09dd210da24595996f017fa238c43c3145cb9",
-    "version": "0.1.2",
+    "hash": "58fa698754e138b1753f1e142cf5d4428e3f368449d6f0c9e638767912110871",
+    "version": "0.1.3",
     "name": "azure_merge_roles",
-    "source": "https://registry.terraform.io/modules/pagopa-dx/azure-merge-roles/azurerm/0.1.2"
+    "source": "https://registry.terraform.io/modules/pagopa-dx/azure-merge-roles/azurerm/0.1.3"
   },
   "azure.custom_roles.dx_infra_ci_resource_group_reader": {
-    "hash": "32687e53abb8bcb58f39687703a09dd210da24595996f017fa238c43c3145cb9",
-    "version": "0.1.2",
+    "hash": "58fa698754e138b1753f1e142cf5d4428e3f368449d6f0c9e638767912110871",
+    "version": "0.1.3",
     "name": "azure_merge_roles",
-    "source": "https://registry.terraform.io/modules/pagopa-dx/azure-merge-roles/azurerm/0.1.2"
+    "source": "https://registry.terraform.io/modules/pagopa-dx/azure-merge-roles/azurerm/0.1.3"
   },
   "azure.custom_roles.dx_infra_ci_subscription_reader": {
-    "hash": "32687e53abb8bcb58f39687703a09dd210da24595996f017fa238c43c3145cb9",
-    "version": "0.1.2",
+    "hash": "58fa698754e138b1753f1e142cf5d4428e3f368449d6f0c9e638767912110871",
+    "version": "0.1.3",
     "name": "azure_merge_roles",
-    "source": "https://registry.terraform.io/modules/pagopa-dx/azure-merge-roles/azurerm/0.1.2"
+    "source": "https://registry.terraform.io/modules/pagopa-dx/azure-merge-roles/azurerm/0.1.3"
   }
 }

--- a/infra/repository/main.tf
+++ b/infra/repository/main.tf
@@ -16,6 +16,6 @@ module "github_repository" {
     homepage_url           = "https://dx.pagopa.it"
     pull_request_bypassers = ["/dx-pagopa-bot"]
     environments           = ["dev", "prod"]
-    jira_boards_ids        = ["CES"]
+    jira_boards_ids        = ["CES", "AEPDF"]
   }
 }

--- a/infra/repository/tfmodules.lock.json
+++ b/infra/repository/tfmodules.lock.json
@@ -1,8 +1,8 @@
 {
   "github_repository": {
-    "hash": "1db014314718f5f50532062d25694371e8cc17dad2d16ffa7c4ecedac5e59048",
-    "version": "1.4.0",
+    "hash": "d6e1d38d0d10278860ca5151968dcd3f9a9a9cadfe56a321bd0c9b09d194a731",
+    "version": "1.4.1",
     "name": "github_environment_bootstrap",
-    "source": "https://registry.terraform.io/modules/pagopa-dx/github-environment-bootstrap/github/1.4.0"
+    "source": "https://registry.terraform.io/modules/pagopa-dx/github-environment-bootstrap/github/1.4.1"
   }
 }

--- a/infra/resources/_modules/metrics_portal/tfmodules.lock.json
+++ b/infra/resources/_modules/metrics_portal/tfmodules.lock.json
@@ -12,9 +12,9 @@
     "source": "https://registry.terraform.io/modules/pagopa-dx/azure-postgres-server/azurerm/3.0.0"
   },
   "container_app": {
-    "hash": "cccc8bc3cc1d6b19f686bf49d76695c6e68e7a5d2df05cd2e6eb864559ba60ff",
-    "version": "4.2.0",
+    "hash": "7fa0ed8a12529a8f857503f26ff5d8d77cbb72d7cbe6f3dbc3b64dc206108bf0",
+    "version": "4.2.2",
     "name": "azure_container_app",
-    "source": "https://registry.terraform.io/modules/pagopa-dx/azure-container-app/azurerm/4.2.0"
+    "source": "https://registry.terraform.io/modules/pagopa-dx/azure-container-app/azurerm/4.2.2"
   }
 }


### PR DESCRIPTION
Adds the `AEPDF` Jira board to the repository's `jira_boards_ids` configuration, alongside the existing `CES` board. This allows pull requests in this repository to be linked to work items on the AEPDF board.