### PR TITLE
Align GHCR source label

### DIFF
--- a/actions/docker-build-push/action.yaml
+++ b/actions/docker-build-push/action.yaml
@@ -165,7 +165,7 @@ runs:
           org.opencontainers.image.description=${{ env.DESCRIPTION }}
           org.opencontainers.image.authors=${{ env.AUTHORS }}
           org.opencontainers.image.url=github.com/${{ env.REPOSITORY }}
-          org.opencontainers.image.source=https://github.com/${{ env.IMAGE_NAME }}
+          org.opencontainers.image.source=https://github.com/${{ env.REPOSITORY }}
 
     - name: ${{ inputs.push_to_registry == 'true' && 'Build and Push Image' || 'Build Image' }}
       uses: docker/build-push-action@bcafcacb16a39f128d818304e6c9c0c18556b85f # v7.1.0


### PR DESCRIPTION
## Summary
- point the image-level OCI source label at `github.repository` instead of the image name
- keep image metadata aligned with the manifest annotations generated by `docker/metadata-action`

## Investigation note
This is a metadata cleanup, but it is **not sufficient by itself** to explain or fix the failing `e2e-azure-merge-roles-blob-rbac` workflow.

The failing run already includes manifest annotations pointing to `https://github.com/pagopa/dx`, exactly like the successful E2E Docker publish workflows. The failure is isolated to the existing GHCR package `ghcr.io/pagopa/e2e-azure-merge-roles-blob-rbac`, which rejects the repository `GITHUB_TOKEN` with `permission_denied: write_package` while comparable packages accept writes from the same actor, commit, and workflow permissions.

The likely required fix is granting `pagopa/dx` write/admin access to that GHCR package, or deleting/recreating the package so it is associated with this repository.