### PR TITLE
Fix project directory identification in infra plan/apply workflow

### DIFF
--- a/.github/workflows/infra_apply.yaml
+++ b/.github/workflows/infra_apply.yaml
@@ -109,13 +109,7 @@ jobs:
           # The two layouts are mutually exclusive:
           # - flat:          a .tf exists directly in $DIR → $DIR is the single project root
           # - multi-project: no .tf directly in $DIR → each first-level subdir is a project root
-          IS_FLAT=$(printf '%s\n' "$CHANGED" | while IFS= read -r file; do
-            rel="${file#"${DIR}/"}"
-            case "$rel" in
-              */*) ;;                    # file in a subdir: not a flat indicator
-              *.tf) echo 1; break ;;    # .tf directly in $DIR: flat project
-            esac
-          done)
+          IS_FLAT=$(find "$DIR" -maxdepth 1 -type f -name '*.tf' -print -quit 2>/dev/null || true)
 
           if [ -n "$IS_FLAT" ]; then
             MATRIX=$(jq -cn --arg d "$DIR" '[$d]')
@@ -124,7 +118,9 @@ jobs:
               | while IFS= read -r file; do
                   [ -z "$file" ] && continue
                   rel="${file#"${DIR}/"}"
-                  case "$rel" in */*)  echo "${DIR}/${rel%%/*}" ;; esac
+                  if [[ "$rel" == */* ]]; then
+                    echo "${DIR}/${rel%%/*}"
+                  fi
                 done \
               | sort -u \
               | jq -R . | jq -sc .)

--- a/.github/workflows/infra_plan.yaml
+++ b/.github/workflows/infra_plan.yaml
@@ -132,13 +132,7 @@ jobs:
           # The two layouts are mutually exclusive:
           # - flat:          a .tf exists directly in $DIR → $DIR is the single project root
           # - multi-project: no .tf directly in $DIR → each first-level subdir is a project root
-          IS_FLAT=$(printf '%s\n' "$CHANGED" | while IFS= read -r file; do
-            rel="${file#"${DIR}/"}"
-            case "$rel" in
-              */*) ;;                    # file in a subdir: not a flat indicator
-              *.tf) echo 1; break ;;    # .tf directly in $DIR: flat project
-            esac
-          done)
+          IS_FLAT=$(find "$DIR" -maxdepth 1 -type f -name '*.tf' -print -quit 2>/dev/null || true)
 
           if [ -n "$IS_FLAT" ]; then
             MATRIX=$(jq -cn --arg d "$DIR" '[$d]')
@@ -147,7 +141,9 @@ jobs:
               | while IFS= read -r file; do
                   [ -z "$file" ] && continue
                   rel="${file#"${DIR}/"}"
-                  case "$rel" in */*)  echo "${DIR}/${rel%%/*}" ;; esac
+                  if [[ "$rel" == */* ]]; then
+                    echo "${DIR}/${rel%%/*}"
+                  fi
                 done \
               | sort -u \
               | jq -R . | jq -sc .)


### PR DESCRIPTION
Improve the identification of project directories by replacing the previous method with a more reliable approach.
This change enhances the workflow's ability to distinguish between flat and multi-project layouts, avoiding the finding of non terraform subdirectories.