### PR TITLE
Add Confluence publication skill

### DIFF
--- a/plugins/aiepfd/.mcp.json
+++ b/plugins/aiepfd/.mcp.json
@@ -1,0 +1,9 @@
+{
+  "mcpServers": {
+    "atlassian-mcp-server": {
+      "type": "http",
+      "url": "https://mcp.atlassian.com/v1/mcp"
+    }
+  },
+  "inputs": []
+}

--- a/plugins/aiepfd/.mcp.json
+++ b/plugins/aiepfd/.mcp.json
@@ -2,7 +2,7 @@
   "mcpServers": {
     "atlassian-mcp-server": {
       "type": "http",
-      "url": "https://mcp.atlassian.com/v1/mcp"
+      "url": "https://mcp.atlassian.com/v1/mcp/authv2"
     }
   },
   "inputs": []

--- a/plugins/aiepfd/.plugin/plugin.json
+++ b/plugins/aiepfd/.plugin/plugin.json
@@ -6,5 +6,6 @@
     "name": "PagoPA DX Team"
   },
   "repository": "https://github.com/pagopa/dx",
-  "keywords": ["product development", "plugin"]
+  "keywords": ["product development", "plugin"],
+  "mcpServers": ".mcp.json"
 }

--- a/plugins/aiepfd/.plugin/plugin.json
+++ b/plugins/aiepfd/.plugin/plugin.json
@@ -7,5 +7,6 @@
   },
   "repository": "https://github.com/pagopa/dx",
   "keywords": ["product development", "plugin"],
+  "skills": ["./skills"],
   "mcpServers": ".mcp.json"
 }

--- a/plugins/aiepfd/skills/confluence-librarian/SKILL.md
+++ b/plugins/aiepfd/skills/confluence-librarian/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: confluence-librarian
-description: Publish and update prepared pages and document artifacts in Confluence without losing structure or traceability. Use whenever a user asks to publish, create, update, translate, or synchronize Markdown, HTML, or another readable document to Confluence, including hierarchical child pages under a parent catalog. Require explicit confirmation before irreversible publication, synchronize and verify affected parent indexes, and preserve headings, tables, links, statuses, IDs, and intentional gaps.
+description: Publish and update prepared pages and document artifacts in Confluence without losing structure or traceability. Use whenever a user asks to publish, create, update, translate, or synchronize Markdown, HTML, or another readable document to Confluence, including hierarchical child pages under a parent catalog. Require explicit confirmation before irreversible publication and preserve headings, tables, links, statuses, IDs, and intentional gaps.
 ---
 
 # Confluence Librarian
@@ -70,14 +70,6 @@ claim to have published content that was not read.
 8. **Preserve lifecycle state.** Publication alone must not change a source
    document's status such as `draft` or `review`. Change lifecycle state only
    when the user explicitly requests it and the domain skill permits it.
-9. **Synchronize hierarchical parents.** When creating a child page under a
-   parent whose catalog contains a placeholder, update the parent catalog with
-   the child title, stable ID, local source link, and returned Confluence URL.
-   Fetch the parent before replacing its body, preserve its complete content,
-   and re-fetch it after the update. A child publication is incomplete until
-   the parent row is verified; do not leave `TBD` or missing-child placeholders
-   in a successfully published parent catalog.
-
 ## Confirmation protocol
 
 Use this question when a prepared document is ready but publication has not

--- a/plugins/aiepfd/skills/confluence-librarian/SKILL.md
+++ b/plugins/aiepfd/skills/confluence-librarian/SKILL.md
@@ -35,7 +35,8 @@ Accept the following from the calling skill or user:
 | Operation        | Yes         | Create a new page or update an existing page                     |
 | Title            | Yes         | Page title, inferred only when unambiguous                       |
 | Language         | Yes         | Visible page language; preserve machine-facing IDs               |
-| Space and parent | Yes         | Target Confluence space and parent page, inferred only when safe |
+| Space           | Yes         | Target Confluence space, inferred only when safe                 |
+| Parent page     | When needed | Parent page for hierarchical content such as a Use Case          |
 | Existing page ID | For updates | Page ID or URL when updating an existing page                    |
 
 If the source document is not available, ask the user to provide it. Do not
@@ -46,9 +47,10 @@ claim to have published content that was not read.
 1. **Confirm publication.** Before creating or updating a page, obtain an
    explicit affirmative answer. If the user only asks to write a document,
    stop after the local artifact and do not start publication questions.
-2. **Resolve destination.** Ask for the target space, parent page, title,
-   language, and operation when they cannot be inferred safely. For updates,
-   resolve the existing page ID and fetch the current page before replacing it.
+2. **Resolve destination.** Ask for the target space, parent page when the
+   document belongs in an existing page hierarchy, title, language, and
+   operation when they cannot be inferred safely. For updates, resolve the
+   existing page ID and fetch the current page before replacing it.
 3. **Read and validate the source.** Preserve the complete heading hierarchy,
    tables, lists, links, code blocks, stable HTML-comment IDs, table IDs,
    statuses, `N/A` reasons, open questions, and source references. Identify

--- a/plugins/aiepfd/skills/confluence-librarian/SKILL.md
+++ b/plugins/aiepfd/skills/confluence-librarian/SKILL.md
@@ -1,29 +1,29 @@
 ---
 name: confluence-librarian
-description: Publish and update prepared product, design, requirements, architecture, and operational documents in Confluence without losing structure or traceability. Use whenever a user asks to publish, create, update, translate, or synchronize a Markdown or document artifact to Confluence, especially after another skill has generated a PRD, DR/SRS, RFC, runbook, or similar source document. Require explicit confirmation before irreversible publication and preserve stable IDs, links, statuses, and justified gaps.
+description: Publish and update prepared pages and document artifacts in Confluence without losing structure or traceability. Use whenever a user asks to publish, create, update, translate, or synchronize Markdown, HTML, or another readable document to Confluence, whether it is a PRD, DR/SRS, RFC, runbook, meeting note, guide, decision, or any other page. Require explicit confirmation before irreversible publication and preserve headings, tables, links, statuses, IDs, and intentional gaps.
 ---
 
 # Confluence Librarian
 
-Move a prepared document into Confluence while preserving its meaning,
+Move a prepared page or document into Confluence while preserving its meaning,
 structure, traceability, and lifecycle state. This skill owns publication
-mechanics; the calling skill owns the source document's domain content.
+mechanics; the calling skill or user owns the source content and domain rules.
 
 ## When to use this skill
 
 Use this skill when:
 
-- a user asks to publish or update a prepared Markdown document in Confluence;
-- another skill has completed a PRD, DR/SRS, RFC, runbook, or similar artifact
-  and the user confirms publication;
+- a user asks to publish or update a prepared page or document in Confluence;
+- another skill has completed any artifact, such as a PRD, DR/SRS, RFC, runbook,
+  meeting note, guide, decision record, or operational page, and the user
+  confirms publication;
 - a user asks to translate or synchronize an existing document into a
   Confluence page;
 - a Confluence page must be updated without losing stable IDs, links, open
   questions, or status values.
 
-Do not invent missing product, design, architecture, compliance, or delivery
-decisions. Do not rewrite the source document's domain content merely to make
-publication easier.
+Do not invent missing domain decisions. Do not rewrite the source content's
+meaning merely to make publication easier.
 
 ## Input contract
 
@@ -31,7 +31,7 @@ Accept the following from the calling skill or user:
 
 | Input            | Required    | Description                                                      |
 | ---------------- | ----------- | ---------------------------------------------------------------- |
-| Source document  | Yes         | Path or content of the prepared Markdown/document artifact       |
+| Source document  | Yes         | Path or content of the prepared page/document artifact           |
 | Operation        | Yes         | Create a new page or update an existing page                     |
 | Title            | Yes         | Page title, inferred only when unambiguous                       |
 | Language         | Yes         | Visible page language; preserve machine-facing IDs               |

--- a/plugins/aiepfd/skills/confluence-librarian/SKILL.md
+++ b/plugins/aiepfd/skills/confluence-librarian/SKILL.md
@@ -1,0 +1,129 @@
+---
+name: confluence-librarian
+description: Publish and update prepared product, design, requirements, architecture, and operational documents in Confluence without losing structure or traceability. Use whenever a user asks to publish, create, update, translate, or synchronize a Markdown or document artifact to Confluence, especially after another skill has generated a PRD, DR/SRS, RFC, runbook, or similar source document. Require explicit confirmation before irreversible publication and preserve stable IDs, links, statuses, and justified gaps.
+---
+
+# Confluence Librarian
+
+Move a prepared document into Confluence while preserving its meaning,
+structure, traceability, and lifecycle state. This skill owns publication
+mechanics; the calling skill owns the source document's domain content.
+
+## When to use this skill
+
+Use this skill when:
+
+- a user asks to publish or update a prepared Markdown document in Confluence;
+- another skill has completed a PRD, DR/SRS, RFC, runbook, or similar artifact
+  and the user confirms publication;
+- a user asks to translate or synchronize an existing document into a
+  Confluence page;
+- a Confluence page must be updated without losing stable IDs, links, open
+  questions, or status values.
+
+Do not invent missing product, design, architecture, compliance, or delivery
+decisions. Do not rewrite the source document's domain content merely to make
+publication easier.
+
+## Input contract
+
+Accept the following from the calling skill or user:
+
+| Input            | Required    | Description                                                      |
+| ---------------- | ----------- | ---------------------------------------------------------------- |
+| Source document  | Yes         | Path or content of the prepared Markdown/document artifact       |
+| Operation        | Yes         | Create a new page or update an existing page                     |
+| Title            | Yes         | Page title, inferred only when unambiguous                       |
+| Language         | Yes         | Visible page language; preserve machine-facing IDs               |
+| Space and parent | Yes         | Target Confluence space and parent page, inferred only when safe |
+| Existing page ID | For updates | Page ID or URL when updating an existing page                    |
+
+If the source document is not available, ask the user to provide it. Do not
+claim to have published content that was not read.
+
+## Workflow
+
+1. **Confirm publication.** Before creating or updating a page, obtain an
+   explicit affirmative answer. If the user only asks to write a document,
+   stop after the local artifact and do not start publication questions.
+2. **Resolve destination.** Ask for the target space, parent page, title,
+   language, and operation when they cannot be inferred safely. For updates,
+   resolve the existing page ID and fetch the current page before replacing it.
+3. **Read and validate the source.** Preserve the complete heading hierarchy,
+   tables, lists, links, code blocks, stable HTML-comment IDs, table IDs,
+   statuses, `N/A` reasons, open questions, and source references. Identify
+   unsupported constructs before writing.
+4. **Prepare the representation.** Convert the source into the format
+   supported by the authenticated Confluence integration. Translate only
+   human-facing prose, headings, labels, and values when requested. Keep
+   stable IDs, machine-facing status values, entity IDs, URLs, API operation
+   names, and code unchanged.
+5. **Show the irreversible action.** State the operation, page title, space,
+   parent, language, and source path before creating or updating the page.
+6. **Publish through the authenticated integration.** Use the available
+   Confluence tool or API. For updates, preserve the current page's relevant
+   metadata and replace only the requested content.
+7. **Verify the result.** Retrieve or inspect the returned page identifier and
+   URL. Confirm that the operation succeeded and report the page URL. If the
+   integration reports an error, surface it rather than returning a
+   success-shaped response.
+8. **Preserve lifecycle state.** Publication alone must not change a source
+   document's status such as `draft` or `review`. Change lifecycle state only
+   when the user explicitly requests it and the domain skill permits it.
+
+## Confirmation protocol
+
+Use this question when a prepared document is ready but publication has not
+been confirmed:
+
+> Do you want me to create or update the Confluence page for this document?
+
+After an affirmative answer, ask only for destination details that are not
+already known. Do not ask for language, space, or parent before publication
+confirmation unless the user explicitly asks to plan the publication.
+
+Before the write, summarize:
+
+```text
+Operation: create/update
+Title: <page title>
+Space: <space>
+Parent: <parent or none>
+Language: <language>
+Source: <document path or artifact>
+```
+
+## Structure and traceability rules
+
+- Preserve every stable ID exactly. IDs are never translated or renumbered.
+- Preserve every source section, including conditional sections marked
+  `N/A — <reason>`.
+- Preserve links to PRDs, RFCs, ADRs, Figma, Service Blueprints, APIs, events,
+  data contracts, reviews, dashboards, and Jira.
+- Preserve visible status values and do not infer approval from publication.
+- Keep detailed source content in the page; do not replace it with a summary
+  unless the user explicitly requests a summary.
+- For updates, fetch the existing page first when the operation could overwrite
+  comments, local IDs, links, or page metadata.
+- Use the authenticated integration's native document representation when
+  available. Never store credentials in the skill or generated document.
+
+## Translation rules
+
+When a language is requested:
+
+- translate human-facing text, headings, table labels, and explanatory prose;
+- preserve stable English IDs, code, endpoint names, URLs, status enum values,
+  metric identifiers, and document references;
+- keep the hierarchy and field order unchanged;
+- do not translate content that the source marks as machine-facing.
+
+## Failure handling
+
+- If authentication or permissions are unavailable, report the concrete
+  failure and return publication-ready content instead of claiming success.
+- If the destination is ambiguous, ask for the missing destination detail.
+- If the source cannot be parsed or contains unsupported structure, identify the
+  affected section and ask how to proceed; do not silently flatten it.
+- If an update target cannot be resolved, do not create a duplicate page as a
+  fallback.

--- a/plugins/aiepfd/skills/confluence-librarian/SKILL.md
+++ b/plugins/aiepfd/skills/confluence-librarian/SKILL.md
@@ -19,8 +19,6 @@ Use this skill when:
   confirms publication;
 - a user asks to translate or synchronize an existing document into a
   Confluence page;
-- a Confluence page must be updated without losing stable IDs, links, open
-  questions, or status values.
 
 Do not invent missing domain decisions. Do not rewrite the source content's
 meaning merely to make publication easier.
@@ -117,9 +115,9 @@ Source: <document path or artifact>
 - Use the authenticated integration's native document representation when
   available. Never store credentials in the skill or generated document.
 - Markdown front matter is not native Confluence metadata. When publishing a
-  Markdown child document, preserve the front-matter values visibly or through
-  an equivalent traceability section, and verify that stable IDs and lifecycle
-  status remain visible after conversion.
+  Markdown document, render its front-matter values as a Confluence metadata
+  table, and verify that stable IDs and lifecycle status remain visible after
+  conversion.
 
 ## Translation rules
 

--- a/plugins/aiepfd/skills/confluence-librarian/SKILL.md
+++ b/plugins/aiepfd/skills/confluence-librarian/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: confluence-librarian
-description: Publish and update prepared pages and document artifacts in Confluence without losing structure or traceability. Use whenever a user asks to publish, create, update, translate, or synchronize Markdown, HTML, or another readable document to Confluence, whether it is a PRD, DR/SRS, RFC, runbook, meeting note, guide, decision, or any other page. Require explicit confirmation before irreversible publication and preserve headings, tables, links, statuses, IDs, and intentional gaps.
+description: Publish and update prepared pages and document artifacts in Confluence without losing structure or traceability. Use whenever a user asks to publish, create, update, translate, or synchronize Markdown, HTML, or another readable document to Confluence, including hierarchical child pages under a parent catalog. Require explicit confirmation before irreversible publication, synchronize and verify affected parent indexes, and preserve headings, tables, links, statuses, IDs, and intentional gaps.
 ---
 
 # Confluence Librarian
@@ -72,6 +72,13 @@ claim to have published content that was not read.
 8. **Preserve lifecycle state.** Publication alone must not change a source
    document's status such as `draft` or `review`. Change lifecycle state only
    when the user explicitly requests it and the domain skill permits it.
+9. **Synchronize hierarchical parents.** When creating a child page under a
+   parent whose catalog contains a placeholder, update the parent catalog with
+   the child title, stable ID, local source link, and returned Confluence URL.
+   Fetch the parent before replacing its body, preserve its complete content,
+   and re-fetch it after the update. A child publication is incomplete until
+   the parent row is verified; do not leave `TBD` or missing-child placeholders
+   in a successfully published parent catalog.
 
 ## Confirmation protocol
 
@@ -109,6 +116,10 @@ Source: <document path or artifact>
   comments, local IDs, links, or page metadata.
 - Use the authenticated integration's native document representation when
   available. Never store credentials in the skill or generated document.
+- Markdown front matter is not native Confluence metadata. When publishing a
+  Markdown child document, preserve the front-matter values visibly or through
+  an equivalent traceability section, and verify that stable IDs and lifecycle
+  status remain visible after conversion.
 
 ## Translation rules
 

--- a/plugins/aiepfd/skills/confluence-librarian/evals/evals.json
+++ b/plugins/aiepfd/skills/confluence-librarian/evals/evals.json
@@ -1,0 +1,42 @@
+{
+  "skill_name": "confluence-librarian",
+  "evals": [
+    {
+      "id": 0,
+      "name": "publication-confirmation",
+      "prompt": "I have a completed PRD in prd.md. Publish it to Confluence.",
+      "expected_output": "The agent asks for explicit confirmation or confirms the already explicit publication request, then asks only for missing destination details before showing the final operation.",
+      "expectations": [
+        "Does not publish before resolving the destination and operation.",
+        "Asks for missing space, parent, title, or language rather than inventing them.",
+        "Summarizes the irreversible operation before executing it."
+      ],
+      "files": []
+    },
+    {
+      "id": 1,
+      "name": "stable-id-preservation",
+      "prompt": "Create a Confluence page from this Markdown DR/SRS. Translate the visible prose into Italian, but preserve all stable IDs, status values, API operation names, URLs, and code exactly.",
+      "expected_output": "The page content is translated only where requested while machine-facing identifiers and document structure remain unchanged.",
+      "expectations": [
+        "Preserves stable IDs and machine-facing status values exactly.",
+        "Preserves headings, tables, links, and conditional N/A reasons.",
+        "Translates human-facing prose without translating code, URLs, or operation names."
+      ],
+      "files": []
+    },
+    {
+      "id": 2,
+      "name": "safe-update",
+      "prompt": "Update the existing Confluence page at https://pagopa.atlassian.net/wiki/spaces/TEAM/pages/123 with the contents of design-review.md. Keep the document status unchanged and do not create a duplicate.",
+      "expected_output": "The agent resolves and fetches the existing page, updates that page, preserves the status, and returns the updated URL.",
+      "expectations": [
+        "Uses the existing page as the update target.",
+        "Does not create a duplicate page.",
+        "Does not change lifecycle status merely because publication occurred.",
+        "Returns the updated page URL only after a successful update."
+      ],
+      "files": []
+    }
+  ]
+}

--- a/plugins/aiepfd/skills/confluence-librarian/evals/evals.json
+++ b/plugins/aiepfd/skills/confluence-librarian/evals/evals.json
@@ -37,20 +37,6 @@
         "Returns the updated page URL only after a successful update."
       ],
       "files": []
-    },
-    {
-      "id": 3,
-      "name": "hierarchical-child-catalog-sync",
-      "prompt": "Create a Use Case child page under an existing Confluence Design Review. The parent page already has a catalog row with the stable UC ID, local Markdown link, and a TBD Confluence URL. After creating the child, update and re-fetch the parent so the row contains the returned child URL and no stale placeholder. Keep the child and parent lifecycle statuses unchanged.",
-      "expected_output": "The child is created under the existing parent, the parent catalog is updated in place and verified, and the final response includes both page URLs and unchanged lifecycle states.",
-      "expectations": [
-        "Fetches the existing parent before replacing its body.",
-        "Creates the child under the existing parent rather than creating a duplicate hierarchy.",
-        "Preserves stable IDs, local links, status values, and intentional gaps.",
-        "Updates the parent row with the returned child URL and removes the stale TBD placeholder.",
-        "Re-fetches the parent after the update and reports the verified result."
-      ],
-      "files": []
     }
   ]
 }

--- a/plugins/aiepfd/skills/confluence-librarian/evals/evals.json
+++ b/plugins/aiepfd/skills/confluence-librarian/evals/evals.json
@@ -4,7 +4,7 @@
     {
       "id": 0,
       "name": "publication-confirmation",
-      "prompt": "I have a completed PRD in prd.md. Publish it to Confluence.",
+      "prompt": "I have a completed team meeting guide in meeting-guide.md. Publish it as a Confluence page.",
       "expected_output": "The agent asks for explicit confirmation or confirms the already explicit publication request, then asks only for missing destination details before showing the final operation.",
       "expectations": [
         "Does not publish before resolving the destination and operation.",
@@ -16,7 +16,7 @@
     {
       "id": 1,
       "name": "stable-id-preservation",
-      "prompt": "Create a Confluence page from this Markdown DR/SRS. Translate the visible prose into Italian, but preserve all stable IDs, status values, API operation names, URLs, and code exactly.",
+      "prompt": "Create a Confluence page from this Markdown architecture guide. Translate the visible prose into Italian, but preserve all stable IDs, status values, API operation names, URLs, and code exactly.",
       "expected_output": "The page content is translated only where requested while machine-facing identifiers and document structure remain unchanged.",
       "expectations": [
         "Preserves stable IDs and machine-facing status values exactly.",

--- a/plugins/aiepfd/skills/confluence-librarian/evals/evals.json
+++ b/plugins/aiepfd/skills/confluence-librarian/evals/evals.json
@@ -37,6 +37,20 @@
         "Returns the updated page URL only after a successful update."
       ],
       "files": []
+    },
+    {
+      "id": 3,
+      "name": "hierarchical-child-catalog-sync",
+      "prompt": "Create a Use Case child page under an existing Confluence Design Review. The parent page already has a catalog row with the stable UC ID, local Markdown link, and a TBD Confluence URL. After creating the child, update and re-fetch the parent so the row contains the returned child URL and no stale placeholder. Keep the child and parent lifecycle statuses unchanged.",
+      "expected_output": "The child is created under the existing parent, the parent catalog is updated in place and verified, and the final response includes both page URLs and unchanged lifecycle states.",
+      "expectations": [
+        "Fetches the existing parent before replacing its body.",
+        "Creates the child under the existing parent rather than creating a duplicate hierarchy.",
+        "Preserves stable IDs, local links, status values, and intentional gaps.",
+        "Updates the parent row with the returned child URL and removes the stale TBD placeholder.",
+        "Re-fetches the parent after the update and reports the verified result."
+      ],
+      "files": []
     }
   ]
 }


### PR DESCRIPTION
## Summary

Add `confluence-librarian`, a reusable skill for publishing and updating arbitrary prepared pages and document artifacts in Confluence.

## Included

- Generic triggers for Markdown, HTML, and other readable page artifacts.
- Explicit publication confirmation and destination resolution.
- Preservation of headings, tables, links, stable IDs, statuses, and intentional gaps.
- Translation rules that preserve machine-facing identifiers.
- Safe update behavior that avoids duplicate pages.
- Authenticated integration failure handling and result verification.
- Evaluation prompts for generic page publication, translation, and safe updates.

## Follow-up

PR #1966 delegates PRD publication to this skill.
