### PR TITLE
Update Atlassian MCP endpoint

### DIFF
--- a/plugins/project-management/.mcp.json
+++ b/plugins/project-management/.mcp.json
@@ -2,7 +2,7 @@
   "mcpServers": {
     "atlassian-mcp-server": {
       "type": "http",
-      "url": "https://mcp.atlassian.com/v1/mcp"
+      "url": "https://mcp.atlassian.com/v1/mcp/authv2"
     }
   },
   "inputs": []

--- a/plugins/project-management/.plugin/plugin.json
+++ b/plugins/project-management/.plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "project-management",
   "description": "A plugin to manage project workflows, backlog refinement, and team collaboration",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "author": {
     "name": "PagoPA DX Team"
   },


### PR DESCRIPTION
## Summary

- Update the project-management plugin to use Atlassian's authenticated MCP endpoint.
- Bump the plugin version from 0.1.1 to 0.1.2.

This follows up on the endpoint mismatch identified in PR #1980.

## Validation

- Parsed both changed JSON files successfully.
- `git diff --check` passed.