### PR TITLE
Align SaveMoney source configuration types

### DIFF
--- a/.nx/version-plans/version-plan-1784036758879.md
+++ b/.nx/version-plans/version-plan-1784036758879.md
@@ -1,0 +1,8 @@
+---
+'@pagopa/dx-savemoney': minor
+---
+
+Align `AzureConfig.sources` with the decoded configuration by making it a
+required non-empty list. Callers constructing `AzureConfig` directly must now
+provide at least one source; `loadConfig` continues to default to
+`["advisor", "custom"]`.

--- a/.nx/version-plans/version-plan-1784036758879.md
+++ b/.nx/version-plans/version-plan-1784036758879.md
@@ -5,4 +5,5 @@
 Align `AzureConfig.sources` with the decoded configuration by making it a
 required non-empty list. Callers constructing `AzureConfig` directly must now
 provide at least one source; `loadConfig` continues to default to
-`["advisor", "custom"]`.
+`["advisor", "custom"]`. The supported values are available through
+`AZURE_SOURCE_VALUES`.

--- a/.nx/version-plans/version-plan-1784038519311.md
+++ b/.nx/version-plans/version-plan-1784038519311.md
@@ -1,0 +1,7 @@
+---
+'@pagopa/dx-cli': patch
+---
+
+Align the SaveMoney CLI source resolution with the required non-empty
+`AzureConfig.sources` type, removing the unreachable fallback for missing
+sources without changing CLI behavior.

--- a/apps/cli/src/adapters/commander/commands/__tests__/savemoney.test.ts
+++ b/apps/cli/src/adapters/commander/commands/__tests__/savemoney.test.ts
@@ -80,13 +80,6 @@ describe("resolveSourcesOption", () => {
     expect(resolveSourcesOption(undefined, ["custom"])).toEqual(["custom"]);
   });
 
-  it("uses both sources when --source is omitted and config has no sources", () => {
-    expect(resolveSourcesOption(undefined, undefined)).toEqual([
-      "advisor",
-      "custom",
-    ]);
-  });
-
   it("lets explicit --source all override a narrowed config", () => {
     expect(resolveSourcesOption("all", ["custom"])).toEqual([
       "advisor",

--- a/apps/cli/src/adapters/commander/commands/savemoney.ts
+++ b/apps/cli/src/adapters/commander/commands/savemoney.ts
@@ -1,4 +1,4 @@
-import type { AzureConfig, AzureSource } from "@pagopa/dx-savemoney";
+import type { AzureConfig } from "@pagopa/dx-savemoney";
 
 import { azure, loadConfig } from "@pagopa/dx-savemoney";
 import { Command, InvalidArgumentError } from "commander";
@@ -136,10 +136,10 @@ export function parseTagsOption(
  */
 export function resolveSourcesOption(
   option: SourceOption | undefined,
-  configSources: AzureSource[] | undefined,
-): AzureSource[] {
+  configSources: AzureConfig["sources"],
+): AzureConfig["sources"] {
   if (option === undefined) {
-    return configSources ?? ["advisor", "custom"];
+    return configSources;
   }
   return option === "all" ? ["advisor", "custom"] : [option];
 }

--- a/apps/cli/src/adapters/commander/commands/savemoney.ts
+++ b/apps/cli/src/adapters/commander/commands/savemoney.ts
@@ -1,6 +1,6 @@
 import type { AzureConfig } from "@pagopa/dx-savemoney";
 
-import { azure, loadConfig } from "@pagopa/dx-savemoney";
+import { azure, AZURE_SOURCE_VALUES, loadConfig } from "@pagopa/dx-savemoney";
 import { Command, InvalidArgumentError } from "commander";
 import { oraPromise } from "ora";
 import { z } from "zod";
@@ -90,7 +90,7 @@ export const makeSavemoneyCommand = () =>
       }
     });
 
-const SourceSchema = z.enum(["advisor", "all", "custom"]);
+const SourceSchema = z.enum([...AZURE_SOURCE_VALUES, "all"]);
 type SourceOption = z.infer<typeof SourceSchema>;
 
 /**
@@ -141,5 +141,5 @@ export function resolveSourcesOption(
   if (option === undefined) {
     return configSources;
   }
-  return option === "all" ? ["advisor", "custom"] : [option];
+  return option === "all" ? [...AZURE_SOURCE_VALUES] : [option];
 }

--- a/packages/savemoney/src/azure/__tests__/config.test.ts
+++ b/packages/savemoney/src/azure/__tests__/config.test.ts
@@ -8,7 +8,9 @@
 
 import path from "path";
 import { fileURLToPath } from "url";
-import { describe, expect, it } from "vitest";
+import { afterEach, describe, expect, expectTypeOf, it, vi } from "vitest";
+
+import type { AzureConfig, AzureSource } from "../../index.js";
 
 import { loadConfig } from "../../index.js";
 import { ConfigSchema } from "../../schema.js";
@@ -24,6 +26,10 @@ const FIXTURE_PARTIAL = path.resolve(
 const FIXTURE_FULL = path.resolve(__dirname, "fixtures/full-override.yaml");
 
 describe("loadConfig", () => {
+  afterEach(() => {
+    vi.unstubAllEnvs();
+  });
+
   it("throws when explicit path does not exist", async () => {
     await expect(loadConfig("/nonexistent/config.yaml")).rejects.toThrow(
       "Config file not found",
@@ -33,11 +39,23 @@ describe("loadConfig", () => {
   it("loads subscriptionIds and defaults from a partial YAML file", async () => {
     const result = await loadConfig(FIXTURE_PARTIAL);
 
+    expectTypeOf<AzureConfig["sources"]>().toEqualTypeOf<
+      [AzureSource, ...AzureSource[]]
+    >();
     expect(result.subscriptionIds).toEqual([
       "xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx",
     ]);
     expect(result.preferredLocation).toBe("italynorth");
+    expect(result.sources).toEqual(["advisor", "custom"]);
     expect(result.timespanDays).toBe(30);
+  });
+
+  it("applies sources defaults when loading from the environment", async () => {
+    vi.stubEnv("ARM_SUBSCRIPTION_ID", "xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx");
+
+    const result = await loadConfig();
+
+    expect(result.sources).toEqual(["advisor", "custom"]);
   });
 
   it("loads partial threshold overrides and keeps defaults for missing fields", async () => {
@@ -70,6 +88,7 @@ describe("loadConfig", () => {
 
     expect(result.subscriptionIds).toHaveLength(2);
     expect(result.preferredLocation).toBe("westeurope");
+    expect(result.sources).toEqual(["custom"]);
     expect(result.timespanDays).toBe(60);
 
     expect(result.thresholds?.vm.cpuPercent).toBe(5);
@@ -94,6 +113,17 @@ describe("loadConfig", () => {
     expect(result.thresholds).toHaveProperty("storage");
     expect(result.thresholds).toHaveProperty("publicIp");
     expect(result.thresholds).toHaveProperty("staticSite");
+  });
+
+  it("rejects an empty sources list", () => {
+    const result = ConfigSchema.safeParse({
+      azure: {
+        sources: [],
+        subscriptionIds: ["xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx"],
+      },
+    });
+
+    expect(result.success).toBe(false);
   });
 
   it("does not expose pricing settings in YAML config", () => {

--- a/packages/savemoney/src/azure/__tests__/fixtures/full-override.yaml
+++ b/packages/savemoney/src/azure/__tests__/fixtures/full-override.yaml
@@ -3,6 +3,8 @@ azure:
     - xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx
     - yyyyyyyy-yyyy-yyyy-yyyy-yyyyyyyyyyyy
   preferredLocation: westeurope
+  sources:
+    - custom
   timespanDays: 60
   thresholds:
     vm:

--- a/packages/savemoney/src/azure/analyzer.ts
+++ b/packages/savemoney/src/azure/analyzer.ts
@@ -32,11 +32,7 @@ import { getLogger } from "@logtape/logtape";
 import pLimit from "p-limit";
 
 import type { Finding } from "../finding.js";
-import type {
-  AzureConfig,
-  AzureDetailedResourceReport,
-  AzureSource,
-} from "./types.js";
+import type { AzureConfig, AzureDetailedResourceReport } from "./types.js";
 
 import { findingsFromAnalysisResult } from "../finding.js";
 import {
@@ -58,7 +54,6 @@ import { PricingClient, PricingService } from "./pricing/index.js";
 import { matchesTags, type MetricsCache } from "./utils.js";
 
 const DEFAULT_CONCURRENCY = 8;
-const DEFAULT_SOURCES: AzureSource[] = ["advisor", "custom"];
 
 const RISK_ORDER: Record<CostRisk, number> = { high: 0, low: 2, medium: 1 };
 
@@ -86,9 +81,8 @@ export async function analyzeAzureResources(
   const credential = new DefaultAzureCredential();
   const allReports: AzureDetailedResourceReport[] = [];
 
-  const sources = config.sources ?? DEFAULT_SOURCES;
-  const customEnabled = sources.includes("custom");
-  const advisorEnabled = sources.includes("advisor");
+  const customEnabled = config.sources.includes("custom");
+  const advisorEnabled = config.sources.includes("advisor");
 
   const analyzers = createDefaultAnalyzers();
   const subscriptionAnalyzers = advisorEnabled

--- a/packages/savemoney/src/azure/config.ts
+++ b/packages/savemoney/src/azure/config.ts
@@ -73,6 +73,7 @@ export async function loadAzureConfig(
 
   return {
     preferredLocation: "italynorth",
+    sources: ["advisor", "custom"],
     subscriptionIds,
     timespanDays: 30,
   };

--- a/packages/savemoney/src/azure/config.ts
+++ b/packages/savemoney/src/azure/config.ts
@@ -71,12 +71,7 @@ export async function loadAzureConfig(
     ? process.env.ARM_SUBSCRIPTION_ID.split(",")
     : (await prompt("Enter Subscription IDs (comma-separated): ")).split(",");
 
-  return {
-    preferredLocation: "italynorth",
-    sources: ["advisor", "custom"],
-    subscriptionIds,
-    timespanDays: 30,
-  };
+  return ConfigSchema.parse({ azure: { subscriptionIds } }).azure;
 }
 
 /**

--- a/packages/savemoney/src/azure/types.ts
+++ b/packages/savemoney/src/azure/types.ts
@@ -5,6 +5,7 @@
 import type * as armResources from "@azure/arm-resources";
 
 import type { Finding } from "../finding.js";
+import type { Config } from "../schema.js";
 import type {
   AnalysisResult,
   BaseConfig,
@@ -38,9 +39,10 @@ export type AzureConfig = BaseConfig & {
    * - `"custom"`  → enables the per-resource analyzer plugins
    * - `"advisor"` → enables the Azure Advisor subscription-level analyzer
    *
-   * Defaults to `["advisor", "custom"]` when omitted (i.e. all sources).
+   * Config loading applies the `["advisor", "custom"]` default, so this list
+   * is always defined and contains at least one source.
    */
-  sources?: AzureSource[];
+  sources: Config["azure"]["sources"];
   subscriptionIds: string[];
   /**
    * Analysis thresholds. Defaults from DEFAULT_THRESHOLDS are used when not provided.
@@ -88,7 +90,7 @@ export type AzureResourceReport = {
  * Narrowed from `FindingSource` to exclude "aws", which is not a valid
  * filter for Azure runs and would silently produce an empty report.
  */
-export type AzureSource = "advisor" | "custom";
+export type AzureSource = Config["azure"]["sources"][number];
 
 export type PricingConfig = {
   /**

--- a/packages/savemoney/src/index.ts
+++ b/packages/savemoney/src/index.ts
@@ -37,6 +37,7 @@ export {
   type Money,
   type ResourceReport,
 } from "./finding.js";
+export { AZURE_SOURCE_VALUES } from "./schema.js";
 
 export * from "./types.js";
 

--- a/packages/savemoney/src/schema.ts
+++ b/packages/savemoney/src/schema.ts
@@ -103,6 +103,8 @@ export const ThresholdsSchema = z
 
 // ── top-level config schema ──────────────────────────────────────────────────
 
+const AzureSourceSchema = z.enum(["advisor", "custom"]);
+
 const AzureSectionSchema = z
   .object({
     /**
@@ -117,8 +119,8 @@ const AzureSectionSchema = z
      * Azure Advisor recommendations, or `["custom"]` to skip Advisor.
      */
     sources: z
-      .array(z.enum(["advisor", "custom"]))
-      .nonempty()
+      .tuple([AzureSourceSchema])
+      .rest(AzureSourceSchema)
       .default(["advisor", "custom"]),
     subscriptionIds: z
       .array(z.string())

--- a/packages/savemoney/src/schema.ts
+++ b/packages/savemoney/src/schema.ts
@@ -103,7 +103,9 @@ export const ThresholdsSchema = z
 
 // ── top-level config schema ──────────────────────────────────────────────────
 
-const AzureSourceSchema = z.enum(["advisor", "custom"]);
+export const AZURE_SOURCE_VALUES = ["advisor", "custom"] as const;
+
+const AzureSourceSchema = z.enum(AZURE_SOURCE_VALUES);
 
 const AzureSectionSchema = z
   .object({
@@ -121,7 +123,7 @@ const AzureSectionSchema = z
     sources: z
       .tuple([AzureSourceSchema])
       .rest(AzureSourceSchema)
-      .default(["advisor", "custom"]),
+      .default([...AZURE_SOURCE_VALUES]),
     subscriptionIds: z
       .array(z.string())
       .min(


### PR DESCRIPTION
`AzureConfig.sources` currently allows `undefined` and empty arrays even though the SaveMoney decoder always returns a defined, non-empty source list. This mismatch lets TypeScript callers represent states that configuration loading rejects or normalizes.

This change derives the Azure source types from the Zod schema, models sources as a required non-empty tuple, and applies the default consistently to YAML and environment-based loading. The CLI now consumes that stricter contract without its unreachable missing-source fallback, while preserving existing behavior and support for single-source configurations such as `["custom"]`.

Callers constructing `AzureConfig` directly must now provide at least one source. Version plans cover the SaveMoney contract update and the corresponding CLI alignment.

Resolves CES-2217