### PR TITLE
Add new GitHub App config for Terraform publish

### DIFF
--- a/.github/workflows/_release-changesets-pull-request.yaml
+++ b/.github/workflows/_release-changesets-pull-request.yaml
@@ -22,3 +22,5 @@ jobs:
     secrets:
       app-client-id: ${{ secrets.GH_APP_RELEASE_CLIENT_ID }}
       app-private-key: ${{ secrets.GH_APP_RELEASE_APP_KEY }}
+      app-tf-client-id: ${{ secrets.GH_TF_APP_RELEASE_CLIENT_ID }}
+      app-tf-private-key: ${{ secrets.GH_TF_APP_RELEASE_APP_KEY }}

--- a/.github/workflows/release-v2.yaml
+++ b/.github/workflows/release-v2.yaml
@@ -15,6 +15,12 @@ on:
       app-private-key:
         description: "GitHub App private key for authentication"
         required: true
+      app-tf-client-id:
+        description: "GitHub App Client ID for authentication for Terraform publish"
+        required: true
+      app-tf-private-key:
+        description: "GitHub App private key for authentication for Terraform publish"
+        required: true
 
 jobs:
   release:
@@ -32,6 +38,15 @@ jobs:
         with:
           client-id: ${{ secrets.app-client-id }}
           private-key: ${{ secrets.app-private-key }}
+          permission-contents: write
+          permission-pull-requests: write
+
+      - name: Generate GitHub App token for Terraform publish
+        id: generate-terraform-token
+        uses: actions/create-github-app-token@1b10c78c7865c340bc4f6099eb2f838309f1e8c3 # 3.1.1
+        with:
+          client-id: ${{ secrets.app-tf-client-id }}
+          private-key: ${{ secrets.app-tf-private-key }}
           permission-contents: write
           permission-pull-requests: write
 
@@ -81,3 +96,4 @@ jobs:
         with:
           app-slug: ${{ steps.generate-token.outputs.app-slug }}
           github-token: ${{ steps.generate-token.outputs.token }}
+          github-terraform-token: ${{ steps.generate-terraform-token.outputs.token }}

--- a/.github/workflows/release-v2.yaml
+++ b/.github/workflows/release-v2.yaml
@@ -17,16 +17,18 @@ on:
         required: true
       app-tf-client-id:
         description: "GitHub App Client ID for authentication for Terraform publish"
-        required: true
+        required: false
       app-tf-private-key:
         description: "GitHub App private key for authentication for Terraform publish"
-        required: true
+        required: false
 
 jobs:
   release:
     name: Release
     runs-on: ubuntu-latest
     environment: ${{ inputs.environment }}
+    env:
+      HAS_TF_APP_CREDENTIALS: ${{ secrets.app-tf-client-id != '' && secrets.app-tf-private-key != '' }}
     permissions:
       contents: write
       id-token: write
@@ -42,6 +44,7 @@ jobs:
           permission-pull-requests: write
 
       - name: Generate GitHub App token for Terraform publish
+        if: env.HAS_TF_APP_CREDENTIALS == 'true'
         id: generate-terraform-token
         uses: actions/create-github-app-token@1b10c78c7865c340bc4f6099eb2f838309f1e8c3 # 3.1.1
         with:
@@ -91,9 +94,17 @@ jobs:
         shell: bash
         run: npm ci
 
-      - name: Nx Publish
+      - name: Nx Publish with Terraform token
+        if: env.HAS_TF_APP_CREDENTIALS == 'true'
         uses: pagopa/dx/actions/nx-release@main
         with:
           app-slug: ${{ steps.generate-token.outputs.app-slug }}
           github-token: ${{ steps.generate-token.outputs.token }}
           github-terraform-token: ${{ steps.generate-terraform-token.outputs.token }}
+
+      - name: Nx Publish
+        if: env.HAS_TF_APP_CREDENTIALS != 'true'
+        uses: pagopa/dx/actions/nx-release@main
+        with:
+          app-slug: ${{ steps.generate-token.outputs.app-slug }}
+          github-token: ${{ steps.generate-token.outputs.token }}

--- a/.nx/version-plans/version-plan-1784110587121.md
+++ b/.nx/version-plans/version-plan-1784110587121.md
@@ -1,0 +1,5 @@
+---
+'@pagopa/nx-terraform-plugin': patch
+---
+
+Add as default secret GH_TF_TOKEN, which is a pre-generated GitHub App installation token for Terraform publish.

--- a/.nx/version-plans/version-plan-1784110587122.md
+++ b/.nx/version-plans/version-plan-1784110587122.md
@@ -1,0 +1,5 @@
+---
+'nx-release': patch
+---
+
+Add new input `github-terraform-token` to nx-release action, which is a pre-generated GitHub App installation token for Terraform publish. This token is generated in the release workflow and passed to the action to be used for Terraform publishing tasks.

--- a/.nx/version-plans/version-plan-1784110587122.md
+++ b/.nx/version-plans/version-plan-1784110587122.md
@@ -1,5 +1,5 @@
 ---
-'nx-release': patch
+"nx-release": patch
 ---
 
-Add new input `github-terraform-token` to nx-release action, which is a pre-generated GitHub App installation token for Terraform publish. This token is generated in the release workflow and passed to the action to be used for Terraform publishing tasks.
+Add the optional `github-terraform-token` input to the nx-release action. The release workflow generates and passes this GitHub App installation token for Terraform publishing only when both Terraform App secrets are configured.

--- a/actions/nx-release/action.yaml
+++ b/actions/nx-release/action.yaml
@@ -9,7 +9,7 @@ inputs:
     description: "GitHub App slug associated with github-token"
     required: true
   github-terraform-token:
-    description: "Pre-generated GitHub App installation token for Terraform publish"
+    description: "Optional pre-generated GitHub App installation token for Terraform publish"
     required: false
     default: ""
   base-branch:

--- a/actions/nx-release/action.yaml
+++ b/actions/nx-release/action.yaml
@@ -10,7 +10,8 @@ inputs:
     required: true
   github-terraform-token:
     description: "Pre-generated GitHub App installation token for Terraform publish"
-    required: true
+    required: false
+    default: ""
   base-branch:
     description: "Base branch where release flow runs"
     required: false

--- a/actions/nx-release/action.yaml
+++ b/actions/nx-release/action.yaml
@@ -8,6 +8,9 @@ inputs:
   app-slug:
     description: "GitHub App slug associated with github-token"
     required: true
+  github-terraform-token:
+    description: "Pre-generated GitHub App installation token for Terraform publish"
+    required: true
   base-branch:
     description: "Base branch where release flow runs"
     required: false
@@ -163,6 +166,7 @@ runs:
       env:
         NPM_CONFIG_PROVENANCE: true
         GH_TOKEN: ${{ inputs.github-token }}
+        GH_TF_TOKEN: ${{ inputs.github-terraform-token }}
         ACTION_PATH: ${{ github.action_path }}
         BASE_BRANCH: ${{ inputs.base-branch }}
         RELEASE_MODE: ${{ steps.release-mode.outputs.mode }}

--- a/packages/nx-terraform-plugin/src/adapters/github/octokit.ts
+++ b/packages/nx-terraform-plugin/src/adapters/github/octokit.ts
@@ -3,7 +3,7 @@
 import { Octokit } from "octokit";
 
 export const getGitHubToken = (): string | undefined =>
-  process.env.GH_TOKEN ?? process.env.GITHUB_TOKEN;
+  process.env.GH_TF_TOKEN ?? process.env.GH_TOKEN ?? process.env.GITHUB_TOKEN;
 
 const getAuthenticatedUserLogin = async (
   octokit: Octokit,


### PR DESCRIPTION
This pull request introduces support for a dedicated GitHub App installation token specifically for Terraform publishing tasks. It updates the workflows, action inputs, and environment variables to use this new token, ensuring Terraform publishing is authenticated with the correct credentials. Additionally, the `nx-release` action and the `nx-terraform-plugin` package are updated to recognize and use the new token.

Resolves: CES-2218