### PR TITLE
Ignore Container App revision FQDN drift

### DIFF
--- a/.nx/version-plans/version-plan-1784193057944.md
+++ b/.nx/version-plans/version-plan-1784193057944.md
@@ -1,0 +1,5 @@
+---
+azure_container_app: patch
+---
+
+Ignore externally updated latest revision FQDN

--- a/infra/modules/azure_container_app/container_app.tf
+++ b/infra/modules/azure_container_app/container_app.tf
@@ -206,7 +206,8 @@ resource "azurerm_container_app" "this" {
 
     ignore_changes = [
       # The image is not managed by Terraform, but instead updated by CD pipelines
-      template[0].container[0].image
+      template[0].container[0].image,
+      latest_revision_fqdn,
     ]
   }
 


### PR DESCRIPTION
Ignore changes to `latest_revision_fqdn` on Azure Container Apps.

Deployments performed outside Terraform create a new revision and update this computed FQDN. Keeping it in Terraform reconciliation reports expected deployment activity as external drift.

This change extends the existing lifecycle rule that already ignores container image updates managed by CD pipelines and includes a patch version plan for `azure_container_app`.

## Validation

- Pre-commit hooks executed on the modified module and version plan
- Terraform tests deferred to PR CI

Resolves CES-2220