### PR TITLE
Add GitHub App enterprise support for release-v2

### DIFF
--- a/.github/workflows/release-v2.yaml
+++ b/.github/workflows/release-v2.yaml
@@ -28,12 +28,13 @@ jobs:
     steps:
       - name: Generate GitHub App token
         id: generate-token
-        uses: actions/create-github-app-token@1b10c78c7865c340bc4f6099eb2f838309f1e8c3 # 3.1.1
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # 3.2.0
         with:
           client-id: ${{ secrets.app-client-id }}
           private-key: ${{ secrets.app-private-key }}
           permission-contents: write
           permission-pull-requests: write
+          enterprise: ${{ vars.GITHUB_ENTERPRISE || null }}
 
       - name: Checkout repository
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0

--- a/.github/workflows/release-v2.yaml
+++ b/.github/workflows/release-v2.yaml
@@ -34,7 +34,7 @@ jobs:
           private-key: ${{ secrets.app-private-key }}
           permission-contents: write
           permission-pull-requests: write
-          enterprise: ${{ vars.GITHUB_ENTERPRISE || null }}
+          enterprise: ${{ vars.GH_ENTERPRISE || null }}
 
       - name: Checkout repository
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0


### PR DESCRIPTION
Introduce support for GitHub App enterprise configuration in the token generation step, allowing for better integration with enterprise environments.

Resolves: CES-2218