### PR TITLE
Add Terraform execution primitives

### DIFF
--- a/.nx/version-plans/version-plan-1784226768872.md
+++ b/.nx/version-plans/version-plan-1784226768872.md
@@ -1,0 +1,5 @@
+---
+'@pagopa/dx-tasks': minor
+---
+
+Add reusable Terraform plan-upload and apply tasks with sensitive output masking.

--- a/.nx/version-plans/version-plan-1784226768872.md
+++ b/.nx/version-plans/version-plan-1784226768872.md
@@ -2,4 +2,4 @@
 '@pagopa/dx-tasks': minor
 ---
 
-Add reusable Terraform plan-upload and apply tasks with sensitive output masking.
+Add reusable Terraform plan-upload and apply tasks with sensitive output masking and best-effort cleanup after successful applies.

--- a/.nx/version-plans/version-plan-1784226769468.md
+++ b/.nx/version-plans/version-plan-1784226769468.md
@@ -2,4 +2,4 @@
 '@pagopa/nx-terraform-plugin': minor
 ---
 
-Add plan-upload and release-apply executors with configurable sensitive output masking.
+Add plan-upload and release-apply executors, including an inferred configurable plan-upload target, with configurable sensitive output masking.

--- a/.nx/version-plans/version-plan-1784226769468.md
+++ b/.nx/version-plans/version-plan-1784226769468.md
@@ -1,0 +1,5 @@
+---
+'@pagopa/nx-terraform-plugin': minor
+---
+
+Add plan-upload and release-apply executors with configurable sensitive output masking.

--- a/nx.json
+++ b/nx.json
@@ -137,6 +137,10 @@
       "plugin": "@pagopa/nx-terraform-plugin",
       "include": ["infra/**"],
       "options": {
+        "sensitiveOutputKeys": [
+          "hidden-link",
+          "APPINSIGHTS_INSTRUMENTATIONKEY"
+        ],
         "publish": {
           "mode": "github",
           "github": {

--- a/packages/dx-tasks/README.md
+++ b/packages/dx-tasks/README.md
@@ -8,7 +8,7 @@ Reusable task implementations and a small dispatcher for DX orchestration tools.
 | --------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | `terraformPlan`       | Runs `terraform plan` for a module path, handles common flags, and masks sensitive output before printing it.                                                                                                                                                    |
 | `terraformPlanUpload` | Runs `terraformPlan` with a fixed output path, then uploads the resulting plan bundle (plan file, lock file, and module cache) to the same cloud storage backend used for the Terraform state, so it can be applied later by `terraformApply`.                   |
-| `terraformApply`      | Downloads the plan bundle uploaded by `terraformPlanUpload` (recomputing its deterministic storage path from the Terraform backend state and the current CI run), applies it non-interactively, and deletes the remote bundle only after a **successful** apply. |
+| `terraformApply`      | Downloads the plan bundle uploaded by `terraformPlanUpload` (recomputing its deterministic storage path from the Terraform backend state and the current CI run), applies it non-interactively, and attempts to delete the remote bundle only after a **successful** apply. |
 | `renderReport`        | Reads the persisted reports under `.dx-tasks` and renders them in a target format (currently `markdown`) to stdout, using per-namespace renderers.                                                                                                               |
 | `prComment`           | Adds a comment to a GitHub pull request, optionally replacing existing comments that match a search pattern.                                                                                                                                                     |
 | `reportPrComment`     | Renders persisted reports and posts the rendered Markdown as a GitHub pull request comment.                                                                                                                                                                      |
@@ -101,12 +101,13 @@ projects that must be applied non-interactively (e.g. from CI), while still guar
    the backend state key and the `GITHUB_RUN_ID` environment variable.
 2. `terraformApply` independently recomputes that same deterministic path (reading the same
    `.terraform/terraform.tfstate` and the same `GITHUB_RUN_ID`), downloads and extracts the bundle,
-   runs `terraform apply` non-interactively against the exact downloaded plan file, and deletes the
-   remote bundle only after a **successful** apply. On failure, the bundle is deliberately left in
-   place: a re-run of the same workflow run's apply job can retry against the exact reviewed plan,
-   and the bundle remains available for forensic inspection. Bundles left behind by abandoned or
-   failed workflow runs are not cleaned up automatically and rely on the storage backend's own
-   retention/lifecycle policy.
+   runs `terraform apply` non-interactively against the exact downloaded plan file, and attempts to
+   delete the remote bundle only after a **successful** apply. Cleanup failures are logged as
+   warnings without changing the successful apply result. On apply failure, the bundle is
+   deliberately left in place: a re-run of the same workflow run's apply job can retry against the
+   exact reviewed plan, and the bundle remains available for forensic inspection. Bundles left
+   behind by abandoned or failed workflow runs are not cleaned up automatically and rely on the
+   storage backend's own retention/lifecycle policy.
 
 Because the remote path is derived deterministically rather than passed explicitly between steps,
 the two tasks can run in separate CI jobs — even with different cloud credentials — as long as both

--- a/packages/dx-tasks/README.md
+++ b/packages/dx-tasks/README.md
@@ -4,12 +4,14 @@ Reusable task implementations and a small dispatcher for DX orchestration tools.
 
 ## Available tasks
 
-| Task              | Description                                                                                                                                        |
-| ----------------- | -------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `terraformPlan`   | Runs `terraform plan` for a module path, handles common flags, and masks sensitive output before printing it.                                      |
-| `renderReport`    | Reads the persisted reports under `.dx-tasks` and renders them in a target format (currently `markdown`) to stdout, using per-namespace renderers. |
-| `prComment`       | Adds a comment to a GitHub pull request, optionally replacing existing comments that match a search pattern.                                       |
-| `reportPrComment` | Renders persisted reports and posts the rendered Markdown as a GitHub pull request comment.                                                        |
+| Task                  | Description                                                                                                                                                                                                                                                      |
+| --------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `terraformPlan`       | Runs `terraform plan` for a module path, handles common flags, and masks sensitive output before printing it.                                                                                                                                                    |
+| `terraformPlanUpload` | Runs `terraformPlan` with a fixed output path, then uploads the resulting plan bundle (plan file, lock file, and module cache) to the same cloud storage backend used for the Terraform state, so it can be applied later by `terraformApply`.                   |
+| `terraformApply`      | Downloads the plan bundle uploaded by `terraformPlanUpload` (recomputing its deterministic storage path from the Terraform backend state and the current CI run), applies it non-interactively, and deletes the remote bundle only after a **successful** apply. |
+| `renderReport`        | Reads the persisted reports under `.dx-tasks` and renders them in a target format (currently `markdown`) to stdout, using per-namespace renderers.                                                                                                               |
+| `prComment`           | Adds a comment to a GitHub pull request, optionally replacing existing comments that match a search pattern.                                                                                                                                                     |
+| `reportPrComment`     | Renders persisted reports and posts the rendered Markdown as a GitHub pull request comment.                                                                                                                                                                      |
 
 ## Dispatcher
 
@@ -44,6 +46,7 @@ await dispatcher.dispatchTask("terraformPlan", {
   out: "plan.tfplan",
   refresh: true,
   report: true,
+  sensitiveKeys: ["hidden-link", "APPINSIGHTS_INSTRUMENTATIONKEY"],
   verbose: false,
 });
 ```
@@ -84,6 +87,57 @@ await dispatcher.dispatchTask(terraformPlanTask.name, {
 ```
 
 For payload details and task-specific behavior, see the task definitions and implementations in `src/`.
+
+## Terraform plan upload and apply
+
+`terraformPlanUpload` and `terraformApply` implement a two-phase, plan-then-apply flow for Terraform
+projects that must be applied non-interactively (e.g. from CI), while still guaranteeing that
+`terraformApply` applies exactly what `terraformPlanUpload` planned:
+
+1. `terraformPlanUpload` runs `terraform plan -out=<fixed path>` (reusing `terraformPlan`), then
+   bundles the plan file together with `.terraform.lock.hcl` and `.terraform/modules/`, and uploads
+   the bundle to the same cloud storage backend already used for the Terraform state (Azure Blob or
+   S3, detected from `.terraform/terraform.tfstate`). The remote path is deterministic, derived from
+   the backend state key and the `GITHUB_RUN_ID` environment variable.
+2. `terraformApply` independently recomputes that same deterministic path (reading the same
+   `.terraform/terraform.tfstate` and the same `GITHUB_RUN_ID`), downloads and extracts the bundle,
+   runs `terraform apply` non-interactively against the exact downloaded plan file, and deletes the
+   remote bundle only after a **successful** apply. On failure, the bundle is deliberately left in
+   place: a re-run of the same workflow run's apply job can retry against the exact reviewed plan,
+   and the bundle remains available for forensic inspection. Bundles left behind by abandoned or
+   failed workflow runs are not cleaned up automatically and rely on the storage backend's own
+   retention/lifecycle policy.
+
+Because the remote path is derived deterministically rather than passed explicitly between steps,
+the two tasks can run in separate CI jobs — even with different cloud credentials — as long as both
+jobs run within the same workflow run (so `GITHUB_RUN_ID` matches) and against the same Terraform
+backend state.
+
+```ts
+import { createDefaultTaskDispatcher } from "@pagopa/dx-tasks";
+
+const dispatcher = createDefaultTaskDispatcher();
+
+// In the "plan" job/step (read-only credentials):
+await dispatcher.dispatchTask("terraformPlanUpload", {
+  modulePath: "./infra/resources/dev",
+  report: true,
+  sensitiveKeys: ["hidden-link", "APPINSIGHTS_INSTRUMENTATIONKEY"],
+});
+
+// Later, in the "apply" job/step (write credentials, ideally gated behind a
+// manual approval so the plan above can be reviewed first):
+await dispatcher.dispatchTask("terraformApply", {
+  modulePath: "./infra/resources/dev",
+  report: true,
+  sensitiveKeys: ["hidden-link", "APPINSIGHTS_INSTRUMENTATIONKEY"],
+});
+```
+
+`terraformPlanUpload` and `terraformApply` both require the `GITHUB_RUN_ID` environment variable to
+be set (this is set automatically by GitHub Actions runners).
+The optional `sensitiveKeys` payload field lists additional Terraform output
+keys whose values must be redacted before logs or reports are written.
 
 ## Commenting on pull requests
 
@@ -166,7 +220,7 @@ and errors are rendered as GitHub Markdown notices before the summary line. Full
 never included in the Markdown comment, keeping comments compact even across many plans and linking
 back to `sourceUrl`, when provided, and report artifacts for the complete output.
 
-````markdown
+```markdown
 ### Terraform Plans
 
 #### Module: `./infra/modules/example` - ✅ Success
@@ -181,7 +235,7 @@ Plan: 0 to add, 1 to change, 0 to destroy.
 > [!NOTE]
 > Full plan output is not included in this comment.
 > See the workflow run logs or downloaded Terraform plan report artifacts for the complete output.
-````
+```
 
 To control which namespaces/formats are renderable, build your own `ReportStore` and register
 namespaces with `renderers` explicitly:

--- a/packages/dx-tasks/package.json
+++ b/packages/dx-tasks/package.json
@@ -4,9 +4,26 @@
   "type": "module",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",
+  "scripts": {
+    "build": "tsc --build tsconfig.build.json"
+  },
   "exports": {
-    "./default-dispatcher": "./src/default-dispatcher.ts",
-    "./terraform-plan-storage": "./src/terraform/plan-storage.ts"
+    ".": {
+      "types": "./dist/index.d.ts",
+      "import": "./dist/index.js"
+    },
+    "./default-dispatcher": {
+      "types": "./dist/default-dispatcher.d.ts",
+      "import": "./dist/default-dispatcher.js"
+    },
+    "./tasks": {
+      "types": "./dist/tasks.d.ts",
+      "import": "./dist/tasks.js"
+    },
+    "./terraform-plan-storage": {
+      "types": "./dist/terraform/plan-storage.d.ts",
+      "import": "./dist/terraform/plan-storage.js"
+    }
   },
   "repository": {
     "type": "git",
@@ -29,9 +46,7 @@
   "dependencies": {
     "@aws-sdk/client-s3": "catalog:aws",
     "@azure/identity": "catalog:",
-    "@azure/storage-blob": "catalog:azure"
-  },
-  "peerDependencies": {
+    "@azure/storage-blob": "catalog:azure",
     "octokit": "catalog:",
     "zod": "catalog:"
   }

--- a/packages/dx-tasks/src/default-dispatcher.ts
+++ b/packages/dx-tasks/src/default-dispatcher.ts
@@ -6,8 +6,11 @@ import {
   prCommentTask,
   renderReportTask,
   reportPrCommentTask,
+  terraformApplyTask,
   terraformPlanTask,
+  terraformPlanUploadTask,
 } from "./tasks.ts";
+import { terraformApplyReportNamespace } from "./terraform/apply.ts";
 import { terraformPlanReportNamespace } from "./terraform/plan.ts";
 
 export interface DefaultTaskDispatcherOptions {
@@ -15,13 +18,17 @@ export interface DefaultTaskDispatcherOptions {
 }
 
 const createDefaultReportStore = (): ReportStore =>
-  new ReportStore(process.cwd()).register(terraformPlanReportNamespace);
+  new ReportStore(process.cwd())
+    .register(terraformPlanReportNamespace)
+    .register(terraformApplyReportNamespace);
 
 export const createDefaultTaskDispatcher = ({
   reports = createDefaultReportStore(),
 }: DefaultTaskDispatcherOptions = {}): TaskDispatcher => {
   const dispatcher = createTaskDispatcher({ context: { reports } });
   dispatcher.registerTask(terraformPlanTask);
+  dispatcher.registerTask(terraformPlanUploadTask);
+  dispatcher.registerTask(terraformApplyTask);
   dispatcher.registerTask(renderReportTask);
   dispatcher.registerTask(reportPrCommentTask);
   dispatcher.registerTask(prCommentTask);

--- a/packages/dx-tasks/src/index.ts
+++ b/packages/dx-tasks/src/index.ts
@@ -17,4 +17,11 @@ export {
 export * from "./report-store.ts";
 export * from "./run-command.ts";
 export * from "./tasks.ts";
+export { terraformApplyReportNamespace } from "./terraform/apply.ts";
+export {
+  deleteRemotePlanBundle,
+  downloadPlanBundle,
+  type PlanStorageBackend,
+  uploadPlanBundle,
+} from "./terraform/plan-storage.ts";
 export { terraformPlanReportNamespace } from "./terraform/plan.ts";

--- a/packages/dx-tasks/src/tasks.ts
+++ b/packages/dx-tasks/src/tasks.ts
@@ -19,6 +19,16 @@ import {
   payloadSchema as reportPrCommentPayloadSchema,
 } from "./report-pr-comment.ts";
 import {
+  terraformApply,
+  type TerraformApplyPayload,
+  payloadSchema as terraformApplyPayloadSchema,
+} from "./terraform/apply.ts";
+import {
+  terraformPlanUpload,
+  type TerraformPlanUploadPayload,
+  payloadSchema as terraformPlanUploadPayloadSchema,
+} from "./terraform/plan-upload.ts";
+import {
   terraformPlan,
   type TerraformPlanPayload,
   payloadSchema as terraformPlanPayloadSchema,
@@ -28,6 +38,19 @@ export const terraformPlanTask: TaskDefinition<TerraformPlanPayload> = {
   name: "terraformPlan",
   payloadSchema: terraformPlanPayloadSchema,
   run: terraformPlan,
+};
+
+export const terraformPlanUploadTask: TaskDefinition<TerraformPlanUploadPayload> =
+  {
+    name: "terraformPlanUpload",
+    payloadSchema: terraformPlanUploadPayloadSchema,
+    run: terraformPlanUpload,
+  };
+
+export const terraformApplyTask: TaskDefinition<TerraformApplyPayload> = {
+  name: "terraformApply",
+  payloadSchema: terraformApplyPayloadSchema,
+  run: terraformApply,
 };
 
 export const renderReportTask: TaskDefinition<RenderReportPayload> = {

--- a/packages/dx-tasks/src/terraform/__tests__/apply.test.ts
+++ b/packages/dx-tasks/src/terraform/__tests__/apply.test.ts
@@ -1,0 +1,399 @@
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import type { TerraformApplyPayload } from "../apply.ts";
+
+import { ReportStore } from "../../report-store.ts";
+
+const { mockRunCommand } = vi.hoisted(() => ({
+  mockRunCommand: vi.fn(),
+}));
+
+vi.mock("../../run-command.ts", () => ({
+  runCommand: mockRunCommand,
+}));
+
+const {
+  mockComputePlanPath,
+  mockDeleteRemotePlanBundle,
+  mockDownloadPlanBundle,
+  mockReadBackendConfig,
+} = vi.hoisted(() => ({
+  mockComputePlanPath: vi.fn(),
+  mockDeleteRemotePlanBundle: vi.fn(),
+  mockDownloadPlanBundle: vi.fn(),
+  mockReadBackendConfig: vi.fn(),
+}));
+
+vi.mock("../plan-storage.ts", () => ({
+  computePlanPath: mockComputePlanPath,
+  deleteRemotePlanBundle: mockDeleteRemotePlanBundle,
+  downloadPlanBundle: mockDownloadPlanBundle,
+  readBackendConfig: mockReadBackendConfig,
+}));
+
+import {
+  terraformApply,
+  terraformApplyReportNamespace,
+  terraformApplyReportSchema,
+} from "../apply.ts";
+
+const createReports = (baseDirectoryPath: string) =>
+  new ReportStore(baseDirectoryPath).register(terraformApplyReportNamespace);
+
+type TerraformApplyMarkdownRenderer = NonNullable<
+  NonNullable<typeof terraformApplyReportNamespace.renderers>["markdown"]
+>;
+
+const renderTerraformApplyMarkdown = (
+  reports: Parameters<TerraformApplyMarkdownRenderer>[0],
+  context: Parameters<TerraformApplyMarkdownRenderer>[1] = {},
+): string => {
+  const renderer = terraformApplyReportNamespace.renderers?.markdown;
+
+  if (!renderer) {
+    throw new Error("Terraform apply Markdown renderer is not registered");
+  }
+
+  return renderer(reports, context);
+};
+
+const applies = {
+  changes: `azurerm_resource_group.example: Modifying... [id=/subscriptions/x/resourceGroups/example]
+azurerm_resource_group.example: Modifications complete after 3s [id=/subscriptions/x/resourceGroups/example]
+
+Apply complete! Resources: 0 added, 1 changed, 0 destroyed.`,
+  error: `Error: Unsupported argument
+
+  on ../_modules/azure/secrets.tf line 5, in resource "github_actions_secret" "codecov_token":
+   5:   client_secret = "super-secret-value"
+
+An argument named "client_secret" is not expected here.`,
+  warning: `Warning: Deprecated attribute
+
+The attribute "foo" is deprecated.
+
+Use "bar" instead.
+
+Apply complete! Resources: 0 added, 0 changed, 0 destroyed.`,
+};
+
+const getTerraformApplyReportPath = (
+  baseDirectoryPath: string,
+  modulePath: string,
+): string =>
+  path.join(
+    baseDirectoryPath,
+    ".dx-tasks",
+    "terraform-apply",
+    `${Buffer.from(modulePath).toString("base64url")}.json`,
+  );
+
+const createTestDirectory = async (): Promise<string> =>
+  fs.mkdtemp(path.join(os.tmpdir(), "dx-tasks-terraform-apply-"));
+
+const readTerraformApplyReport = async (
+  baseDirectoryPath: string,
+  modulePath: string,
+) =>
+  terraformApplyReportSchema.parse(
+    JSON.parse(
+      await fs.readFile(
+        getTerraformApplyReportPath(baseDirectoryPath, modulePath),
+        "utf8",
+      ),
+    ),
+  );
+
+const azureBackend = {
+  container: "tfstate",
+  key: "prod/terraform.tfstate",
+  storageAccount: "dxtfstate",
+  type: "azurerm" as const,
+};
+
+// eslint-disable-next-line max-lines-per-function
+describe("terraformApply", () => {
+  let tempDirectoryPath = "";
+
+  beforeEach(() => {
+    mockRunCommand.mockReset();
+    mockComputePlanPath.mockReset();
+    mockDeleteRemotePlanBundle.mockReset();
+    mockDownloadPlanBundle.mockReset();
+    mockReadBackendConfig.mockReset();
+
+    vi.stubEnv("CI", "false");
+    vi.stubEnv("GITHUB_RUN_ID", "12345");
+    vi.spyOn(console, "log").mockImplementation(() => undefined);
+
+    mockReadBackendConfig.mockResolvedValue(azureBackend);
+    mockComputePlanPath.mockReturnValue(
+      "prod/plan-artifacts/terraform.tfstate.12345",
+    );
+    mockDownloadPlanBundle.mockResolvedValue(undefined);
+    mockDeleteRemotePlanBundle.mockResolvedValue(undefined);
+  });
+
+  beforeEach(async () => {
+    tempDirectoryPath = await createTestDirectory();
+  });
+
+  afterEach(async () => {
+    await fs.rm(tempDirectoryPath, { force: true, recursive: true });
+    vi.restoreAllMocks();
+    vi.unstubAllEnvs();
+  });
+
+  it("throws when GITHUB_RUN_ID is not set", async () => {
+    // Stub with an empty string rather than unstubbing, since GITHUB_RUN_ID
+    // is a real ambient environment variable set by GitHub Actions runners
+    // and unstubbing would restore that value instead of clearing it.
+    vi.stubEnv("CI", "false");
+    vi.stubEnv("GITHUB_RUN_ID", "");
+
+    await expect(terraformApply({ modulePath: "/tmp/module" })).rejects.toThrow(
+      /GITHUB_RUN_ID/,
+    );
+
+    expect(mockReadBackendConfig).not.toHaveBeenCalled();
+  });
+
+  it("downloads the plan bundle before applying, using the deterministic path", async () => {
+    mockRunCommand.mockResolvedValue({
+      exitCode: 0,
+      signal: null,
+      stderr: "",
+      stdout: applies.changes,
+    });
+
+    await terraformApply({ modulePath: "/tmp/module" });
+
+    expect(mockReadBackendConfig).toHaveBeenCalledWith("/tmp/module");
+    expect(mockComputePlanPath).toHaveBeenCalledWith(azureBackend.key, "12345");
+    expect(mockDownloadPlanBundle).toHaveBeenCalledWith({
+      backend: {
+        container: "tfstate",
+        storageAccount: "dxtfstate",
+        type: "azurerm",
+      },
+      planPath: "prod/plan-artifacts/terraform.tfstate.12345",
+      workingDirectory: "/tmp/module",
+    });
+  });
+
+  it("passes the expected non-interactive arguments to runCommand", async () => {
+    mockRunCommand.mockResolvedValue({
+      exitCode: 0,
+      signal: null,
+      stderr: "",
+      stdout: applies.changes,
+    });
+
+    await terraformApply({ modulePath: "/tmp/module" });
+
+    expect(mockRunCommand).toHaveBeenCalledWith(
+      "terraform",
+      [
+        "apply",
+        "-lock-timeout=120s",
+        "-input=false",
+        "-no-color",
+        "-auto-approve",
+        "tfplan.binary",
+      ],
+      "/tmp/module",
+      { TF_IN_AUTOMATION: "true" },
+    );
+  });
+
+  it("masks configured sensitive output keys", async () => {
+    mockRunCommand.mockResolvedValue({
+      exitCode: 0,
+      signal: null,
+      stderr: "",
+      stdout: `hidden-link = "sensitive-value"
+Apply complete! Resources: 0 added, 0 changed, 0 destroyed.`,
+    });
+
+    await terraformApply({
+      modulePath: "/tmp/module",
+      sensitiveKeys: ["hidden-link"],
+      verbose: true,
+    });
+
+    expect(console.log).toHaveBeenCalledExactlyOnceWith(
+      `hidden-link = "[REDACTED]"
+Apply complete! Resources: 0 added, 0 changed, 0 destroyed.`,
+    );
+  });
+
+  it("deletes the remote plan bundle after a successful apply", async () => {
+    mockRunCommand.mockResolvedValue({
+      exitCode: 0,
+      signal: null,
+      stderr: "",
+      stdout: applies.changes,
+    });
+
+    await terraformApply({ modulePath: "/tmp/module" });
+
+    expect(mockDeleteRemotePlanBundle).toHaveBeenCalledWith({
+      backend: {
+        container: "tfstate",
+        storageAccount: "dxtfstate",
+        type: "azurerm",
+      },
+      planPath: "prod/plan-artifacts/terraform.tfstate.12345",
+    });
+  });
+
+  it("does not delete the remote plan bundle when the apply fails", async () => {
+    mockRunCommand.mockResolvedValue({
+      exitCode: 1,
+      signal: null,
+      stderr: applies.error,
+      stdout: "",
+    });
+
+    await expect(terraformApply({ modulePath: "/tmp/module" })).rejects.toThrow(
+      /Terraform apply exited with code 1/,
+    );
+
+    // The bundle is intentionally retained on failure so a re-run of the same
+    // workflow run's apply job can retry against the exact reviewed plan.
+    expect(mockDeleteRemotePlanBundle).not.toHaveBeenCalled();
+  });
+
+  it("throws a descriptive error when the process is terminated by a signal", async () => {
+    mockRunCommand.mockResolvedValue({
+      exitCode: null,
+      signal: "SIGTERM",
+      stderr: "",
+      stdout: "",
+    });
+
+    await expect(terraformApply({ modulePath: "/tmp/module" })).rejects.toThrow(
+      /terminated by signal SIGTERM/,
+    );
+  });
+
+  it("writes a JSON report when report is true", async () => {
+    mockRunCommand.mockResolvedValue({
+      exitCode: 0,
+      signal: null,
+      stderr: "",
+      stdout: applies.changes,
+    });
+
+    const reports = createReports(tempDirectoryPath);
+
+    await terraformApply(
+      { modulePath: "/tmp/module", report: true },
+      { reports },
+    );
+
+    const report = await readTerraformApplyReport(
+      tempDirectoryPath,
+      "/tmp/module",
+    );
+
+    expect(report.success).toBe(true);
+    expect(report.summaryLine).toContain("Apply complete!");
+  });
+
+  it("does not write a report when report is false", async () => {
+    mockRunCommand.mockResolvedValue({
+      exitCode: 0,
+      signal: null,
+      stderr: "",
+      stdout: applies.changes,
+    });
+
+    const reports = createReports(tempDirectoryPath);
+
+    await terraformApply(
+      { modulePath: "/tmp/module", report: false },
+      { reports },
+    );
+
+    await expect(
+      fs.access(getTerraformApplyReportPath(tempDirectoryPath, "/tmp/module")),
+    ).rejects.toThrow();
+  });
+
+  it("marks the report as unsuccessful and rethrows when the apply fails", async () => {
+    mockRunCommand.mockResolvedValue({
+      exitCode: 1,
+      signal: null,
+      stderr: applies.error,
+      stdout: "",
+    });
+
+    const reports = createReports(tempDirectoryPath);
+
+    await expect(
+      terraformApply({ modulePath: "/tmp/module", report: true }, { reports }),
+    ).rejects.toThrow();
+
+    const report = await readTerraformApplyReport(
+      tempDirectoryPath,
+      "/tmp/module",
+    );
+
+    expect(report.success).toBe(false);
+  });
+});
+
+describe("terraformApply payload validation", () => {
+  it("requires a non-empty modulePath", () => {
+    const invalidPayload = { modulePath: "" } as TerraformApplyPayload;
+
+    expect(() =>
+      terraformApplyReportSchema.parse({
+        applyOutput: "",
+        modulePath: invalidPayload.modulePath,
+        notices: [],
+        success: true,
+      }),
+    ).toThrow();
+  });
+});
+
+describe("terraformApply Markdown rendering", () => {
+  it("renders a success heading with the summary line", () => {
+    const markdown = renderTerraformApplyMarkdown([
+      {
+        applyOutput:
+          "Apply complete! Resources: 0 added, 1 changed, 0 destroyed.",
+        modulePath: "/tmp/module",
+        notices: [],
+        success: true,
+        summaryLine:
+          "Apply complete! Resources: 0 added, 1 changed, 0 destroyed.",
+      },
+    ]);
+
+    expect(markdown).toContain("Terraform Apply: `/tmp/module` - ✅ Success");
+    expect(markdown).toContain(
+      "Apply complete! Resources: 0 added, 1 changed, 0 destroyed.",
+    );
+  });
+
+  it("renders a failure heading with notices", () => {
+    const markdown = renderTerraformApplyMarkdown([
+      {
+        applyOutput: "",
+        modulePath: "/tmp/module",
+        notices: [{ message: "Something went wrong", severity: "error" }],
+        success: false,
+      },
+    ]);
+
+    expect(markdown).toContain("Terraform Apply: `/tmp/module` - ❌ Failed");
+    expect(markdown).toContain("> [!CAUTION]");
+    expect(markdown).toContain("Something went wrong");
+  });
+});

--- a/packages/dx-tasks/src/terraform/__tests__/apply.test.ts
+++ b/packages/dx-tasks/src/terraform/__tests__/apply.test.ts
@@ -3,8 +3,6 @@ import os from "node:os";
 import path from "node:path";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
-import type { TerraformApplyPayload } from "../apply.ts";
-
 import { ReportStore } from "../../report-store.ts";
 
 const { mockRunCommand } = vi.hoisted(() => ({
@@ -36,6 +34,7 @@ vi.mock("../plan-storage.ts", () => ({
 
 import {
   terraformApply,
+  payloadSchema as terraformApplyPayloadSchema,
   terraformApplyReportNamespace,
   terraformApplyReportSchema,
 } from "../apply.ts";
@@ -128,6 +127,7 @@ describe("terraformApply", () => {
     vi.stubEnv("CI", "false");
     vi.stubEnv("GITHUB_RUN_ID", "12345");
     vi.spyOn(console, "log").mockImplementation(() => undefined);
+    vi.spyOn(console, "warn").mockImplementation(() => undefined);
 
     mockReadBackendConfig.mockResolvedValue(azureBackend);
     mockComputePlanPath.mockReturnValue(
@@ -250,6 +250,26 @@ Apply complete! Resources: 0 added, 0 changed, 0 destroyed.`,
     });
   });
 
+  it("warns without failing when remote plan bundle cleanup fails", async () => {
+    mockRunCommand.mockResolvedValue({
+      exitCode: 0,
+      signal: null,
+      stderr: "",
+      stdout: applies.changes,
+    });
+    mockDeleteRemotePlanBundle.mockRejectedValue(
+      new Error("Storage unavailable"),
+    );
+
+    await expect(
+      terraformApply({ modulePath: "/tmp/module" }),
+    ).resolves.toBeUndefined();
+
+    expect(console.warn).toHaveBeenCalledExactlyOnceWith(
+      'Failed to delete remote Terraform plan bundle at "prod/plan-artifacts/terraform.tfstate.12345": Storage unavailable',
+    );
+  });
+
   it("does not delete the remote plan bundle when the apply fails", async () => {
     mockRunCommand.mockResolvedValue({
       exitCode: 1,
@@ -349,14 +369,9 @@ Apply complete! Resources: 0 added, 0 changed, 0 destroyed.`,
 
 describe("terraformApply payload validation", () => {
   it("requires a non-empty modulePath", () => {
-    const invalidPayload = { modulePath: "" } as TerraformApplyPayload;
-
     expect(() =>
-      terraformApplyReportSchema.parse({
-        applyOutput: "",
-        modulePath: invalidPayload.modulePath,
-        notices: [],
-        success: true,
+      terraformApplyPayloadSchema.parse({
+        modulePath: "",
       }),
     ).toThrow();
   });

--- a/packages/dx-tasks/src/terraform/__tests__/plan-upload.test.ts
+++ b/packages/dx-tasks/src/terraform/__tests__/plan-upload.test.ts
@@ -1,0 +1,121 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const { mockRunCommand } = vi.hoisted(() => ({
+  mockRunCommand: vi.fn(),
+}));
+
+vi.mock("../../run-command.ts", () => ({
+  runCommand: mockRunCommand,
+}));
+
+const { mockUploadPlanBundle } = vi.hoisted(() => ({
+  mockUploadPlanBundle: vi.fn(),
+}));
+
+vi.mock("../plan-storage.ts", () => ({
+  uploadPlanBundle: mockUploadPlanBundle,
+}));
+
+import { terraformPlanUpload } from "../plan-upload.ts";
+
+describe("terraformPlanUpload", () => {
+  beforeEach(() => {
+    mockRunCommand.mockReset();
+    mockUploadPlanBundle.mockReset();
+
+    vi.stubEnv("CI", "false");
+    vi.stubEnv("GITHUB_RUN_ID", "98765");
+    vi.spyOn(console, "log").mockImplementation(() => undefined);
+
+    mockRunCommand.mockResolvedValue({
+      exitCode: 0,
+      signal: null,
+      stderr: "",
+      stdout: "No changes. Your infrastructure matches the configuration.",
+    });
+    mockUploadPlanBundle.mockResolvedValue({
+      backend: {
+        container: "tfstate",
+        storageAccount: "dxtfstate",
+        type: "azurerm",
+      },
+      planPath: "prod/plan-artifacts/terraform.tfstate.98765",
+    });
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+    vi.unstubAllEnvs();
+  });
+
+  it("throws when GITHUB_RUN_ID is not set", async () => {
+    // Stub with an empty string rather than unstubbing, since GITHUB_RUN_ID
+    // is a real ambient environment variable set by GitHub Actions runners
+    // and unstubbing would restore that value instead of clearing it.
+    vi.stubEnv("CI", "false");
+    vi.stubEnv("GITHUB_RUN_ID", "");
+
+    await expect(
+      terraformPlanUpload({ modulePath: "/tmp/module" }),
+    ).rejects.toThrow(/GITHUB_RUN_ID/);
+
+    expect(mockUploadPlanBundle).not.toHaveBeenCalled();
+  });
+
+  it("runs terraform plan with a fixed -out path", async () => {
+    await terraformPlanUpload({ modulePath: "/tmp/module" });
+
+    expect(mockRunCommand).toHaveBeenCalledWith(
+      "terraform",
+      ["plan"],
+      "/tmp/module",
+      expect.objectContaining({
+        TF_CLI_ARGS_plan: expect.stringContaining("-out=tfplan.binary"),
+      }),
+    );
+  });
+
+  it("masks configured sensitive output keys", async () => {
+    mockRunCommand.mockResolvedValue({
+      exitCode: 0,
+      signal: null,
+      stderr: "",
+      stdout: 'hidden-link = "sensitive-value"',
+    });
+
+    await terraformPlanUpload({
+      modulePath: "/tmp/module",
+      sensitiveKeys: ["hidden-link"],
+    });
+
+    expect(console.log).toHaveBeenNthCalledWith(
+      1,
+      'hidden-link = "[REDACTED]"',
+    );
+  });
+
+  it("uploads the plan bundle using the same fixed plan file name", async () => {
+    await terraformPlanUpload({ modulePath: "/tmp/module" });
+
+    expect(mockUploadPlanBundle).toHaveBeenCalledWith({
+      planFile: "tfplan.binary",
+      runId: "98765",
+      workingDirectory: "/tmp/module",
+    });
+  });
+
+  it("propagates a terraform plan failure without uploading", async () => {
+    mockRunCommand.mockResolvedValue({
+      exitCode: 1,
+      signal: null,
+      stderr: "Error: invalid configuration",
+      stdout: "",
+    });
+
+    await expect(
+      terraformPlanUpload({ modulePath: "/tmp/module" }),
+    ).rejects.toThrow(/Terraform plan exited with code 1/);
+
+    expect(mockUploadPlanBundle).not.toHaveBeenCalled();
+  });
+});

--- a/packages/dx-tasks/src/terraform/__tests__/plan.test.ts
+++ b/packages/dx-tasks/src/terraform/__tests__/plan.test.ts
@@ -400,6 +400,37 @@ describe("terraformPlan", () => {
   });
 });
 
+describe("terraformPlan masking", () => {
+  beforeEach(() => {
+    mockRunCommand.mockReset();
+    vi.stubEnv("CI", "false");
+    vi.spyOn(console, "log").mockImplementation(() => undefined);
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+    vi.unstubAllEnvs();
+  });
+
+  it("masks configured sensitive output keys", async () => {
+    mockRunCommand.mockResolvedValue({
+      exitCode: 0,
+      signal: null,
+      stderr: "",
+      stdout: 'hidden-link = "sensitive-value"',
+    });
+
+    await terraformPlan({
+      modulePath: "/tmp/module",
+      sensitiveKeys: ["hidden-link"],
+    });
+
+    expect(console.log).toHaveBeenCalledExactlyOnceWith(
+      'hidden-link = "[REDACTED]"',
+    );
+  });
+});
+
 describe("terraformPlan notice reports", () => {
   let tempDirectoryPath = "";
 

--- a/packages/dx-tasks/src/terraform/apply.ts
+++ b/packages/dx-tasks/src/terraform/apply.ts
@@ -352,5 +352,11 @@ export async function terraformApply(
     sensitiveKeys,
     context,
   );
-  await deleteRemotePlanBundle({ backend, planPath });
+  try {
+    await deleteRemotePlanBundle({ backend, planPath });
+  } catch (error) {
+    console.warn(
+      `Failed to delete remote Terraform plan bundle at "${planPath}": ${error instanceof Error ? error.message : String(error)}`,
+    );
+  }
 }

--- a/packages/dx-tasks/src/terraform/apply.ts
+++ b/packages/dx-tasks/src/terraform/apply.ts
@@ -1,0 +1,356 @@
+/** This module downloads and applies a previously generated Terraform plan bundle. */
+
+import util from "node:util";
+import * as z from "zod/mini";
+
+import type { TaskRunContext } from "../dispatcher.ts";
+import type { ReportNamespace, ReportRenderContext } from "../report-store.ts";
+import type { ProcessResult } from "../run-command.ts";
+
+import { runCommand } from "../run-command.ts";
+import { maskOutput } from "./mask-output.ts";
+import { PLAN_FILE_NAME } from "./plan-file.ts";
+import {
+  computePlanPath,
+  deleteRemotePlanBundle,
+  downloadPlanBundle,
+  readBackendConfig,
+} from "./plan-storage.ts";
+
+export const TERRAFORM_APPLY_NAMESPACE = "terraform-apply";
+
+const terraformApplyPayloadShape = {
+  modulePath: z.string().check(z.minLength(1)),
+  report: z._default(z.boolean(), false),
+  sensitiveKeys: z._default(z.array(z.string().check(z.minLength(1))), []),
+  verbose: z._default(z.boolean(), false),
+};
+
+export const payloadSchema = z.object(terraformApplyPayloadShape);
+
+export interface TerraformApplyPayload {
+  modulePath: string;
+  report?: boolean;
+  sensitiveKeys?: readonly string[];
+  verbose?: boolean;
+}
+
+const terraformApplyReportShape = {
+  applyOutput: z.string(),
+  modulePath: z.string().check(z.minLength(1)),
+  notices: z.array(
+    z.object({
+      message: z.string().check(z.minLength(1)),
+      severity: z.union([z.literal("warning"), z.literal("error")]),
+    }),
+  ),
+  success: z._default(z.boolean(), true),
+  summaryLine: z.optional(z.string().check(z.minLength(1))),
+};
+
+export const terraformApplyReportSchema = z.object(terraformApplyReportShape);
+
+export interface TerraformApplyNotice {
+  message: string;
+  severity: "error" | "warning";
+}
+
+export interface TerraformApplyReport {
+  applyOutput: string;
+  modulePath: string;
+  notices: readonly TerraformApplyNotice[];
+  success: boolean;
+  summaryLine?: string;
+}
+
+const noApplyOutputMessage = "No apply output available.";
+const terraformApplyReportSeparator = "\n\n";
+
+const renderNoticeMarkdown = ({
+  message,
+  severity,
+}: TerraformApplyNotice): string => {
+  const label = severity === "warning" ? "WARNING" : "CAUTION";
+  const quotedMessage = message
+    .split("\n")
+    .map((line) => `> ${line}`)
+    .join("\n");
+
+  return `> [!${label}]\n${quotedMessage}`;
+};
+
+const renderTerraformApplyReport = (
+  {
+    applyOutput,
+    modulePath,
+    notices,
+    success,
+    summaryLine,
+  }: TerraformApplyReport,
+  { sourceUrl }: { sourceUrl?: string },
+): string => {
+  void applyOutput;
+  const status = success ? "✅ Success" : "❌ Failed";
+  const heading = `### Terraform Apply: \`${modulePath}\` - ${status}`;
+  const renderedNotices = notices.map(renderNoticeMarkdown);
+  const reference = sourceUrl
+    ? `See the [workflow run](${sourceUrl}) logs for the complete output.`
+    : "See the workflow run logs for the complete output.";
+  const details = `> [!NOTE]\n> Full apply output is not included in this comment.\n> ${reference}`;
+
+  if (renderedNotices.length > 0) {
+    const noticeSection = renderedNotices.join("\n\n");
+    const summarySection = summaryLine ? `\n\n${summaryLine}` : "";
+
+    return `${heading}\n${noticeSection}${summarySection}\n\n${details}`;
+  }
+
+  const summarySection = summaryLine ? `\n${summaryLine}` : "";
+
+  return `${heading}${summarySection}\n\n${details}`;
+};
+
+const renderTerraformApplyReports = (
+  reports: readonly TerraformApplyReport[],
+  { sourceUrl }: ReportRenderContext = {},
+): string =>
+  reports
+    .map((report) => renderTerraformApplyReport(report, { sourceUrl }))
+    .join(terraformApplyReportSeparator)
+    .trim();
+
+export const terraformApplyReportNamespace: ReportNamespace<
+  typeof terraformApplyReportSchema
+> = {
+  name: TERRAFORM_APPLY_NAMESPACE,
+  renderers: {
+    markdown: renderTerraformApplyReports,
+  },
+  schema: terraformApplyReportSchema,
+};
+
+const isRunningInCI = (): boolean => {
+  const ci = process.env.CI;
+
+  return Boolean(ci) && ci !== "false" && ci !== "0";
+};
+
+const getMaskedOutputOrFallback = (maskedOutput: string): string =>
+  maskedOutput.trim().length > 0 ? maskedOutput : noApplyOutputMessage;
+
+const getApplyOutput = (maskedOutput: string, verbose: boolean): string => {
+  if (verbose) {
+    return getMaskedOutputOrFallback(maskedOutput);
+  }
+
+  const match = maskedOutput.match(
+    /(?:^.*Error:[\s\S]*|^.*Apply complete!.*)/m,
+  );
+
+  return match?.[0] ?? getMaskedOutputOrFallback(maskedOutput);
+};
+
+const getApplySummaryLine = (maskedOutput: string): string | undefined =>
+  util
+    .stripVTControlCharacters(maskedOutput)
+    .match(/^Apply complete!.*$/m)?.[0];
+
+const noticeStartPattern = /^(?:│\s*)?(Warning|Error):/;
+
+const getNoticeSeverity = (
+  line: string,
+): TerraformApplyNotice["severity"] | undefined => {
+  const [, severity] = noticeStartPattern.exec(line) ?? [];
+
+  if (severity === "Warning") {
+    return "warning";
+  }
+  if (severity === "Error") {
+    return "error";
+  }
+
+  return undefined;
+};
+
+const isApplySectionStart = (line: string): boolean =>
+  /^(?:Apply complete!|[\w."[\]-]+: (?:Creating|Modifying|Destroying|Refreshing state|Creation complete|Modifications complete|Destruction complete)\b)/.test(
+    line,
+  );
+
+const normalizeNoticeLine = (line: string): string => line.replace(/^│ ?/, "");
+
+const getApplyNotices = (
+  maskedOutput: string,
+): readonly TerraformApplyNotice[] => {
+  const lines = util.stripVTControlCharacters(maskedOutput).split(/\r?\n/);
+  const notices: TerraformApplyNotice[] = [];
+
+  for (let lineIndex = 0; lineIndex < lines.length; lineIndex += 1) {
+    const severity = getNoticeSeverity(lines[lineIndex] ?? "");
+
+    if (!severity) {
+      continue;
+    }
+
+    const messageLines: string[] = [];
+
+    for (
+      let noticeLineIndex = lineIndex;
+      noticeLineIndex < lines.length;
+      noticeLineIndex += 1
+    ) {
+      const line = lines[noticeLineIndex] ?? "";
+      const isFirstLine = noticeLineIndex === lineIndex;
+
+      if (!isFirstLine && getNoticeSeverity(line)) {
+        lineIndex = noticeLineIndex - 1;
+        break;
+      }
+
+      if (!isFirstLine && (line === "╵" || isApplySectionStart(line))) {
+        lineIndex = noticeLineIndex - 1;
+        break;
+      }
+
+      messageLines.push(normalizeNoticeLine(line));
+      lineIndex = noticeLineIndex;
+    }
+
+    const message = messageLines.join("\n").trim();
+
+    if (message.length > 0) {
+      notices.push({
+        message,
+        severity,
+      });
+    }
+  }
+
+  return notices;
+};
+
+const getFailureMessage = (result: ProcessResult): string => {
+  if (result.signal) {
+    return `Terraform apply terminated by signal ${result.signal}`;
+  }
+  if (result.exitCode !== 0) {
+    return `Terraform apply exited with code ${result.exitCode}`;
+  }
+  return noApplyOutputMessage;
+};
+
+const getRunId = (): string => {
+  const runId = process.env.GITHUB_RUN_ID;
+
+  if (!runId) {
+    throw new Error(
+      "GITHUB_RUN_ID environment variable is required to locate the Terraform plan bundle to apply",
+    );
+  }
+
+  return runId;
+};
+
+const executeTerraformApply = async (
+  modulePath: string,
+  verbose: boolean,
+  report: boolean,
+  sensitiveKeys: readonly string[],
+  context: TaskRunContext,
+) => {
+  const env: Record<string, string> = {};
+
+  if (!verbose) {
+    env.TF_IN_AUTOMATION = "true";
+  }
+
+  if (isRunningInCI()) {
+    env.TF_IN_AUTOMATION = "true";
+  }
+
+  const result = await runCommand(
+    "terraform",
+    [
+      "apply",
+      "-lock-timeout=120s",
+      "-input=false",
+      "-no-color",
+      "-auto-approve",
+      PLAN_FILE_NAME,
+    ],
+    modulePath,
+    env,
+  );
+
+  if (result.signal) {
+    throw new Error(getFailureMessage(result));
+  }
+
+  const maskedOutput = maskOutput(
+    [result.stdout, result.stderr]
+      .filter((output) => output.trim().length > 0)
+      .join("\n"),
+    [...sensitiveKeys],
+  );
+
+  const applyOutput = getApplyOutput(maskedOutput, verbose);
+  const notices = getApplyNotices(maskedOutput);
+  const summaryLine = getApplySummaryLine(maskedOutput);
+
+  console.log(applyOutput);
+
+  if (report && context.reports) {
+    await context.reports.write(
+      TERRAFORM_APPLY_NAMESPACE,
+      Buffer.from(modulePath).toString("base64url"),
+      {
+        applyOutput: util.stripVTControlCharacters(applyOutput),
+        modulePath,
+        notices,
+        success: result.exitCode === 0,
+        ...(summaryLine ? { summaryLine } : {}),
+      },
+    );
+  }
+
+  if (result.exitCode !== 0) {
+    throw new Error(getFailureMessage(result));
+  }
+};
+
+export async function terraformApply(
+  {
+    modulePath,
+    report = false,
+    sensitiveKeys = [],
+    verbose = false,
+  }: TerraformApplyPayload,
+  context: TaskRunContext = {},
+) {
+  const runId = getRunId();
+  const { key, ...backend } = await readBackendConfig(modulePath);
+  const planPath = computePlanPath(key, runId);
+
+  await downloadPlanBundle({
+    backend,
+    planPath,
+    workingDirectory: modulePath,
+  });
+
+  // executeTerraformApply throws on failure, so the remote bundle is only
+  // deleted after a successful apply. On failure it is deliberately left in
+  // place: since the storage path is deterministic (derived from the backend
+  // state key and GITHUB_RUN_ID), a re-run of the same workflow run's apply
+  // job can retry against the exact reviewed plan, and the bundle remains
+  // available for forensic inspection of what was attempted. Cleaning up
+  // bundles from abandoned/failed runs across different workflow runs is not
+  // automatic and is left to the storage backend's own retention policy.
+  await executeTerraformApply(
+    modulePath,
+    verbose,
+    report,
+    sensitiveKeys,
+    context,
+  );
+  await deleteRemotePlanBundle({ backend, planPath });
+}

--- a/packages/dx-tasks/src/terraform/plan-file.ts
+++ b/packages/dx-tasks/src/terraform/plan-file.ts
@@ -1,0 +1,6 @@
+/** This module defines the on-disk plan file name shared by the plan-upload and apply tasks. */
+
+// terraformPlanUpload writes the plan to this fixed, project-relative path and
+// uploads it as part of the plan bundle; terraformApply downloads the same
+// bundle and looks for the plan file at this exact path before applying it.
+export const PLAN_FILE_NAME = "tfplan.binary";

--- a/packages/dx-tasks/src/terraform/plan-upload.ts
+++ b/packages/dx-tasks/src/terraform/plan-upload.ts
@@ -1,0 +1,73 @@
+/** This module runs a Terraform plan and uploads the resulting bundle for a later apply. */
+
+import * as z from "zod/mini";
+
+import type { TaskRunContext } from "../dispatcher.ts";
+
+import { PLAN_FILE_NAME } from "./plan-file.ts";
+import { uploadPlanBundle } from "./plan-storage.ts";
+import { terraformPlan } from "./plan.ts";
+
+const terraformPlanUploadPayloadShape = {
+  modulePath: z.string().check(z.minLength(1)),
+  refresh: z._default(z.boolean(), true),
+  report: z._default(z.boolean(), false),
+  sensitiveKeys: z._default(z.array(z.string().check(z.minLength(1))), []),
+  verbose: z._default(z.boolean(), false),
+};
+
+export const payloadSchema = z.object(terraformPlanUploadPayloadShape);
+
+export interface TerraformPlanUploadPayload {
+  modulePath: string;
+  refresh?: boolean;
+  report?: boolean;
+  sensitiveKeys?: readonly string[];
+  verbose?: boolean;
+}
+
+const getRunId = (): string => {
+  const runId = process.env.GITHUB_RUN_ID;
+
+  if (!runId) {
+    throw new Error(
+      "GITHUB_RUN_ID environment variable is required to upload a Terraform plan bundle",
+    );
+  }
+
+  return runId;
+};
+
+export async function terraformPlanUpload(
+  {
+    modulePath,
+    refresh = true,
+    report = false,
+    sensitiveKeys = [],
+    verbose = false,
+  }: TerraformPlanUploadPayload,
+  context: TaskRunContext = {},
+) {
+  await terraformPlan(
+    {
+      modulePath,
+      out: PLAN_FILE_NAME,
+      refresh,
+      report,
+      sensitiveKeys,
+      verbose,
+    },
+    context,
+  );
+
+  const runId = getRunId();
+  const { backend, planPath } = await uploadPlanBundle({
+    planFile: PLAN_FILE_NAME,
+    runId,
+    workingDirectory: modulePath,
+  });
+
+  console.log(
+    `Uploaded Terraform plan bundle for "${modulePath}" (${backend.type}) to "${planPath}"`,
+  );
+}

--- a/packages/dx-tasks/src/terraform/plan.ts
+++ b/packages/dx-tasks/src/terraform/plan.ts
@@ -17,6 +17,7 @@ const terraformPlanPayloadShape = {
   out: z.optional(z.string().check(z.minLength(1))),
   refresh: z._default(z.boolean(), true),
   report: z._default(z.boolean(), false),
+  sensitiveKeys: z._default(z.array(z.string().check(z.minLength(1))), []),
   verbose: z._default(z.boolean(), false),
 };
 
@@ -27,6 +28,7 @@ export interface TerraformPlanPayload {
   out?: string;
   refresh?: boolean;
   report?: boolean;
+  sensitiveKeys?: readonly string[];
   verbose?: boolean;
 }
 
@@ -232,6 +234,7 @@ const executeTerraformPlan = async (
   env: Record<string, string>,
   verbose: boolean,
   report: boolean,
+  sensitiveKeys: readonly string[],
   context: TaskRunContext,
 ) => {
   const result = await runCommand("terraform", ["plan"], modulePath, env);
@@ -244,6 +247,7 @@ const executeTerraformPlan = async (
     [result.stdout, result.stderr]
       .filter((output) => output.trim().length > 0)
       .join("\n"),
+    [...sensitiveKeys],
   );
 
   const planOutput = getPlanOutput(maskedOutput, verbose);
@@ -277,6 +281,7 @@ export async function terraformPlan(
     out,
     refresh = true,
     report = false,
+    sensitiveKeys = [],
     verbose = false,
   }: TerraformPlanPayload,
   context: TaskRunContext = {},
@@ -313,5 +318,12 @@ export async function terraformPlan(
       "",
     );
 
-  await executeTerraformPlan(modulePath, env, verbose, report, context);
+  await executeTerraformPlan(
+    modulePath,
+    env,
+    verbose,
+    report,
+    sensitiveKeys,
+    context,
+  );
 }

--- a/packages/dx-tasks/tsconfig.build.json
+++ b/packages/dx-tasks/tsconfig.build.json
@@ -1,0 +1,7 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "tsBuildInfoFile": "./dist/tsconfig.build.tsbuildinfo"
+  },
+  "exclude": ["src/**/__tests__/**"]
+}

--- a/packages/nx-terraform-plugin/dist/default-dispatcher-BTdenmPC.js
+++ b/packages/nx-terraform-plugin/dist/default-dispatcher-BTdenmPC.js
@@ -1,0 +1,925 @@
+import fs from "node:fs/promises";
+import path from "node:path";
+import * as z from "zod/mini";
+import { Octokit } from "octokit";
+import util, { promisify } from "node:util";
+import childProcess, { execFile } from "node:child_process";
+import { DeleteObjectCommand, GetObjectCommand, PutObjectCommand, S3Client } from "@aws-sdk/client-s3";
+import { AzureCliCredential } from "@azure/identity";
+import { BlobServiceClient } from "@azure/storage-blob";
+import os from "node:os";
+
+//#region ../dx-tasks/dist/dispatcher.js
+/** This module registers dx-tasks tasks and dispatches them from decoded inputs. */
+const createTaskDispatcher = ({ context = {} } = {}) => {
+	const tasks = /* @__PURE__ */ new Map();
+	const registerTask = (task) => {
+		if (tasks.has(task.name)) throw new Error(`Task "${task.name}" is already registered`);
+		tasks.set(task.name, { dispatch: async (payload) => {
+			const decodedPayload = task.payloadSchema.parse(payload);
+			return task.run(decodedPayload, context);
+		} });
+	};
+	const dispatchTask = async (name, payload) => {
+		const task = tasks.get(name);
+		if (!task) throw new Error(`Unknown task "${name}"`);
+		return task.dispatch(payload);
+	};
+	return {
+		dispatchTask,
+		registerTask
+	};
+};
+
+//#endregion
+//#region ../dx-tasks/dist/report-store.js
+/** This module stores and renders dx-tasks reports under a per-namespace directory tree. */
+const nonEmptyStringSchema$3 = z.string().check(z.minLength(1));
+const readReports = async (directoryPath) => {
+	let entries;
+	try {
+		entries = await fs.readdir(directoryPath);
+	} catch (cause) {
+		if (cause instanceof Error && cause.code === "ENOENT") return [];
+		throw new Error(`Failed to read report directory "${directoryPath}"`, { cause });
+	}
+	return Promise.all(entries.filter((entry) => entry.endsWith(".json")).sort((a, b) => a.localeCompare(b)).map(async (fileName) => {
+		const filePath = path.join(directoryPath, fileName);
+		try {
+			return JSON.parse(await fs.readFile(filePath, "utf8"));
+		} catch (cause) {
+			throw new Error(`Failed to read report file "${filePath}"`, { cause });
+		}
+	}));
+};
+var ReportStore = class {
+	namespaces = /* @__PURE__ */ new Map();
+	rootDirectoryPath;
+	constructor(baseDirectoryPath = process.cwd()) {
+		this.rootDirectoryPath = path.join(baseDirectoryPath, ".dx-tasks");
+	}
+	register(namespace) {
+		const name = nonEmptyStringSchema$3.parse(namespace.name);
+		if (this.namespaces.has(name)) throw new Error(`Report namespace "${name}" is already registered`);
+		this.namespaces.set(name, namespace);
+		return this;
+	}
+	async render(format = "markdown", context = {}) {
+		const sections = [];
+		for (const namespace of this.namespaces.values()) {
+			const renderReports = namespace.renderers?.[format];
+			if (!renderReports) continue;
+			const reports = (await readReports(path.join(this.rootDirectoryPath, namespace.name))).map((report) => namespace.schema.parse(report));
+			if (reports.length === 0) continue;
+			sections.push(renderReports(reports, context));
+		}
+		return sections.join("\n\n");
+	}
+	async write(namespaceName, objectName, content) {
+		const name = nonEmptyStringSchema$3.parse(namespaceName);
+		const namespace = this.namespaces.get(name);
+		if (!namespace) throw new Error(`Report namespace "${name}" is not registered`);
+		const report = namespace.schema.parse(content);
+		const directoryPath = path.join(this.rootDirectoryPath, name);
+		const filePath = path.join(directoryPath, `${nonEmptyStringSchema$3.parse(objectName)}.json`);
+		try {
+			await fs.mkdir(directoryPath, { recursive: true });
+		} catch (cause) {
+			throw new Error(`Failed to create reporter namespace directory "${directoryPath}"`, { cause });
+		}
+		try {
+			await fs.writeFile(filePath, JSON.stringify(report, null, 2), "utf8");
+		} catch (cause) {
+			throw new Error(`Failed to write reporter file "${filePath}"`, { cause });
+		}
+	}
+};
+
+//#endregion
+//#region ../dx-tasks/dist/github/pr-comment.js
+/** This module creates GitHub PR comments as a reusable dx-tasks task. */
+const nonEmptyStringSchema$2 = z.string().check(z.minLength(1));
+const prCommentPayloadShape = {
+	commentBody: nonEmptyStringSchema$2,
+	footer: z.optional(nonEmptyStringSchema$2),
+	githubToken: z.optional(nonEmptyStringSchema$2),
+	issueNumber: z.number().check(z.int(), z.positive()),
+	owner: nonEmptyStringSchema$2,
+	repo: nonEmptyStringSchema$2,
+	searchPattern: z.optional(nonEmptyStringSchema$2),
+	title: z.optional(nonEmptyStringSchema$2)
+};
+const payloadSchema$5 = z.object(prCommentPayloadShape);
+const githubCommentShape = {
+	body: z.optional(z.nullable(z.string())),
+	id: z.number().check(z.int(), z.positive())
+};
+const githubCreatedCommentSchema = z.object({
+	...githubCommentShape,
+	html_url: z.string().check(z.minLength(1))
+});
+const githubCommentsSchema = z.array(z.object(githubCommentShape));
+var OctokitPrCommentClient = class {
+	octokit;
+	constructor(token) {
+		this.octokit = new Octokit({ auth: token });
+	}
+	async createComment({ issueNumber, owner, repo }, body) {
+		const { data } = await this.octokit.rest.issues.createComment({
+			body,
+			issue_number: issueNumber,
+			owner,
+			repo
+		});
+		const comment = githubCreatedCommentSchema.parse(data);
+		return {
+			commentId: comment.id,
+			commentUrl: comment.html_url
+		};
+	}
+	async deleteComment(owner, repo, commentId) {
+		await this.octokit.rest.issues.deleteComment({
+			comment_id: commentId,
+			owner,
+			repo
+		});
+	}
+	async listComments({ issueNumber, owner, repo }) {
+		const comments = await this.octokit.paginate(this.octokit.rest.issues.listComments, {
+			issue_number: issueNumber,
+			owner,
+			per_page: 100,
+			repo
+		});
+		return githubCommentsSchema.parse(comments);
+	}
+};
+const createOctokitPrCommentClient = (token) => new OctokitPrCommentClient(token);
+const deleteMatchingComments = async (client, target, searchPattern) => {
+	const normalizedPattern = searchPattern.trim().toLowerCase();
+	const matchingComments = (await client.listComments(target)).filter((comment) => (comment.body ?? "").toLowerCase().includes(normalizedPattern));
+	for (const comment of matchingComments) await client.deleteComment(target.owner, target.repo, comment.id);
+};
+const getGitHubToken = (githubToken) => {
+	const token = githubToken ?? process.env.GITHUB_TOKEN;
+	if (!token) throw new Error("GitHub token not found. Please provide githubToken or GITHUB_TOKEN environment variable");
+	return token;
+};
+const formatCommentBody = ({ commentBody, footer, title }) => {
+	const titledBody = title === void 0 ? commentBody : `## ${title}\n\n${commentBody}`;
+	return footer === void 0 ? titledBody : `${titledBody}\n\n---\n\n${footer}`;
+};
+async function prComment({ commentBody, footer, githubToken, issueNumber, owner, repo, searchPattern, title }, context = {}, createClient = createOctokitPrCommentClient) {
+	const target = {
+		issueNumber,
+		owner,
+		repo
+	};
+	const client = createClient(getGitHubToken(githubToken));
+	if (searchPattern) try {
+		await deleteMatchingComments(client, target, searchPattern);
+	} catch (error) {
+		console.warn(`Failed to delete existing comments: ${error instanceof Error ? error.message : String(error)}`);
+	}
+	return client.createComment(target, formatCommentBody({
+		commentBody,
+		footer,
+		title
+	}));
+}
+
+//#endregion
+//#region ../dx-tasks/dist/render-report.js
+/** This module renders persisted dx-tasks reports and prints them to stdout. */
+const renderReportPayloadShape = { format: z._default(z.literal("markdown"), "markdown") };
+const payloadSchema$4 = z.object(renderReportPayloadShape);
+async function renderReport({ format = "markdown" }, context = {}) {
+	if (!context.reports) throw new Error("renderReport requires reports in the task context");
+	const renderedReport = await context.reports.render(format);
+	console.log(renderedReport);
+}
+
+//#endregion
+//#region ../dx-tasks/dist/report-pr-comment.js
+/** This module renders persisted dx-tasks reports and posts them as GitHub PR comments. */
+const nonEmptyStringSchema$1 = z.string().check(z.minLength(1));
+const reportPrCommentPayloadShape = {
+	footer: z.optional(nonEmptyStringSchema$1),
+	format: z._default(z.literal("markdown"), "markdown"),
+	githubToken: z.optional(nonEmptyStringSchema$1),
+	issueNumber: z.number().check(z.int(), z.positive()),
+	owner: nonEmptyStringSchema$1,
+	repo: nonEmptyStringSchema$1,
+	searchPattern: z.optional(nonEmptyStringSchema$1),
+	sourceUrl: z.optional(nonEmptyStringSchema$1),
+	title: z.optional(nonEmptyStringSchema$1)
+};
+const payloadSchema$3 = z.object(reportPrCommentPayloadShape);
+async function reportPrComment({ footer, format = "markdown", githubToken, issueNumber, owner, repo, searchPattern, sourceUrl, title }, context = {}, createClient) {
+	if (!context.reports) throw new Error("reportPrComment requires reports in the task context");
+	const renderedReport = await context.reports.render(format, { sourceUrl });
+	if (renderedReport.trim().length === 0) return;
+	return prComment({
+		commentBody: renderedReport,
+		footer,
+		githubToken,
+		issueNumber,
+		owner,
+		repo,
+		searchPattern,
+		title
+	}, context, createClient);
+}
+
+//#endregion
+//#region ../dx-tasks/dist/run-command.js
+/** This module wraps child-process execution for dx-tasks Terraform commands. */
+const runCommand = async (command, args, cwd, env) => {
+	const { promise, reject, resolve } = Promise.withResolvers();
+	const child = childProcess.spawn(command, args, {
+		cwd,
+		env: {
+			...process.env,
+			...env
+		},
+		stdio: [
+			"inherit",
+			"pipe",
+			"pipe"
+		]
+	});
+	let stderr = "";
+	let stdout = "";
+	child.stderr?.setEncoding("utf8");
+	child.stderr?.on("data", (chunk) => {
+		stderr += chunk;
+	});
+	child.stdout?.setEncoding("utf8");
+	child.stdout?.on("data", (chunk) => {
+		stdout += chunk;
+	});
+	child.on("error", reject);
+	child.on("close", (exitCode, signal) => {
+		if (signal) {
+			resolve({
+				exitCode: null,
+				signal,
+				stderr,
+				stdout
+			});
+			return;
+		}
+		if (exitCode !== null) {
+			resolve({
+				exitCode,
+				signal: null,
+				stderr,
+				stdout
+			});
+			return;
+		}
+		reject(/* @__PURE__ */ new Error(`${command} closed without an exit code or signal`));
+	});
+	return promise;
+};
+
+//#endregion
+//#region ../dx-tasks/dist/terraform/mask-output.js
+/** This module masks sensitive Terraform output before dx-tasks prints it. */
+const escapeRegExp = (string) => string.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+const beginPemMarker = "-----BEGIN ";
+const endPemMarker = "-----END ";
+const pemDelimiter = "-----";
+const maskPemBlocks = (input) => {
+	const normalizedInput = input.toUpperCase();
+	let masked = "";
+	let cursor = 0;
+	while (cursor < input.length) {
+		const beginIndex = normalizedInput.indexOf(beginPemMarker, cursor);
+		if (beginIndex === -1) return `${masked}${input.slice(cursor)}`;
+		const beginTypeEnd = normalizedInput.indexOf(pemDelimiter, beginIndex + 11);
+		if (beginTypeEnd === -1) return `${masked}${input.slice(cursor)}`;
+		const endIndex = normalizedInput.indexOf(endPemMarker, beginTypeEnd + 5);
+		if (endIndex === -1) return `${masked}${input.slice(cursor)}`;
+		const endTypeEnd = normalizedInput.indexOf(pemDelimiter, endIndex + 9);
+		if (endTypeEnd === -1) return `${masked}${input.slice(cursor)}`;
+		masked += `${input.slice(cursor, beginIndex)}[REDACTED]`;
+		cursor = endTypeEnd + 5;
+	}
+	return masked;
+};
+const maskOutput = (input, additionalKeys = []) => {
+	const keys = additionalKeys.map((k) => k.trim()).filter((k) => k.length > 0);
+	let masked = input;
+	for (const key of keys) {
+		const escapedKey = escapeRegExp(key);
+		const diffRegex = new RegExp(`("?${escapedKey}[^"]*"?\\s*=\\s*)"[^"]*"(\\s*->\\s*)"[^"]*"`, "ig");
+		masked = masked.replace(diffRegex, "$1\"[REDACTED]\"$2\"[REDACTED]\"");
+		const normalRegex = new RegExp(`("?${escapedKey}[^"]*"?\\s*=\\s*)"[^"]*"`, "ig");
+		masked = masked.replace(normalRegex, "$1\"[REDACTED]\"");
+	}
+	masked = maskPemBlocks(masked);
+	const knownSecretsPattern = "(AccessKey|AccountKey|Password|secret|SecretToken|AuthToken|auth_token|access_key|apiKey|api_key|connection_string)";
+	const hardcodedDiffRegex = new RegExp(`("?[^"\\s]*${knownSecretsPattern}([^A-Za-z0-9]|$)"?\\s*[:=]\\s*)"([^"]{12,})"(\\s*->\\s*)"([^"]{12,})"`, "ig");
+	masked = masked.replace(hardcodedDiffRegex, "$1\"[REDACTED]\"$5\"[REDACTED]\"");
+	const hardcodedNormalRegex = new RegExp(`("?[^"\\s]*${knownSecretsPattern}([^A-Za-z0-9]|$)"?\\s*[:=]\\s*)"([^"]{12,})"`, "ig");
+	masked = masked.replace(hardcodedNormalRegex, "$1\"[REDACTED]\"");
+	return masked;
+};
+
+//#endregion
+//#region ../dx-tasks/dist/terraform/plan-file.js
+/** This module defines the on-disk plan file name shared by the plan-upload and apply tasks. */
+const PLAN_FILE_NAME = "tfplan.binary";
+
+//#endregion
+//#region ../dx-tasks/dist/terraform/plan-storage.js
+/** This module stores Terraform plan bundles in the configured Terraform state backend. */
+const nonEmptyStringSchema = z.string().check(z.minLength(1));
+const execFileAsync = promisify(execFile);
+const azurermBackendSchema = z.object({
+	config: z.object({
+		container_name: nonEmptyStringSchema,
+		key: nonEmptyStringSchema,
+		storage_account_name: nonEmptyStringSchema
+	}),
+	type: z.literal("azurerm")
+});
+const s3BackendSchema = z.object({
+	config: z.object({
+		bucket: nonEmptyStringSchema,
+		key: nonEmptyStringSchema,
+		region: nonEmptyStringSchema
+	}),
+	type: z.literal("s3")
+});
+const rawTerraformStateSchema = z.object({ backend: z.object({
+	config: z.unknown(),
+	type: nonEmptyStringSchema
+}) });
+const supportedBackendTypeSchema = z.union([z.literal("azurerm"), z.literal("s3")]);
+const terraformStateSchema = z.object({ backend: z.discriminatedUnion("type", [azurermBackendSchema, s3BackendSchema]) });
+const formatZodIssues = (error) => error.issues.map((issue) => issue.message).join("; ");
+const getAbsoluteWorkingDirectory = (workingDirectory) => path.resolve(workingDirectory);
+const getTerraformStatePath = (workingDirectory) => path.join(getAbsoluteWorkingDirectory(workingDirectory), ".terraform", "terraform.tfstate");
+const getValidatedTerraformState = (content, terraformStatePath) => {
+	const rawTerraformStateResult = rawTerraformStateSchema.safeParse(content);
+	if (!rawTerraformStateResult.success) throw new Error(`Failed to validate Terraform backend state at "${terraformStatePath}": ${formatZodIssues(rawTerraformStateResult.error)}`);
+	const backendType = rawTerraformStateResult.data.backend.type;
+	if (!supportedBackendTypeSchema.safeParse(backendType).success) throw new Error(`Unsupported Terraform backend type "${backendType}" in "${terraformStatePath}"`);
+	const terraformStateResult = terraformStateSchema.safeParse(content);
+	if (!terraformStateResult.success) throw new Error(`Failed to validate Terraform backend state at "${terraformStatePath}": ${formatZodIssues(terraformStateResult.error)}`);
+	return terraformStateResult.data;
+};
+const getBackendConfig = (terraformState) => {
+	switch (terraformState.backend.type) {
+		case "azurerm": return {
+			container: terraformState.backend.config.container_name,
+			key: terraformState.backend.config.key,
+			storageAccount: terraformState.backend.config.storage_account_name,
+			type: "azurerm"
+		};
+		case "s3": return {
+			bucket: terraformState.backend.config.bucket,
+			key: terraformState.backend.config.key,
+			region: terraformState.backend.config.region,
+			type: "s3"
+		};
+	}
+};
+const getPlanFileArchivePath = (workingDirectory, planFile) => {
+	const absolutePlanFilePath = path.isAbsolute(planFile) ? path.resolve(planFile) : path.join(workingDirectory, planFile);
+	const relativePlanFilePath = path.relative(workingDirectory, absolutePlanFilePath);
+	if (relativePlanFilePath.length === 0 || relativePlanFilePath.startsWith("..") || path.isAbsolute(relativePlanFilePath)) throw new Error(`Plan file "${planFile}" must be located inside "${workingDirectory}"`);
+	return relativePlanFilePath;
+};
+const createBundleEntries = (workingDirectory, planFile) => {
+	const planFileArchivePath = getPlanFileArchivePath(workingDirectory, planFile);
+	return [
+		{
+			absolutePath: path.join(workingDirectory, planFileArchivePath),
+			archivePath: planFileArchivePath,
+			optional: false
+		},
+		{
+			absolutePath: path.join(workingDirectory, ".terraform.lock.hcl"),
+			archivePath: ".terraform.lock.hcl",
+			optional: true
+		},
+		{
+			absolutePath: path.join(workingDirectory, ".terraform/modules"),
+			archivePath: ".terraform/modules/",
+			optional: true
+		}
+	];
+};
+const getExistingBundleEntries = async (entries) => {
+	const existingEntries = [];
+	for (const entry of entries) try {
+		await fs.access(entry.absolutePath);
+		existingEntries.push(entry.archivePath);
+	} catch (cause) {
+		if (entry.optional) {
+			console.warn(`Skipping "${entry.archivePath}": not found at ${entry.absolutePath}`);
+			continue;
+		}
+		throw new Error(`Required Terraform plan bundle entry "${entry.archivePath}" was not found at "${entry.absolutePath}"`, { cause });
+	}
+	return existingEntries;
+};
+const createBundle = async (workingDirectory, planFile) => {
+	const bundleEntries = await getExistingBundleEntries(createBundleEntries(workingDirectory, planFile));
+	const temporaryDirectory = await fs.mkdtemp(path.join(os.tmpdir(), "dx-tasks-plan-storage-"));
+	const archivePath = path.join(temporaryDirectory, "bundle.tar.gz");
+	try {
+		await execFileAsync("tar", [
+			"czf",
+			archivePath,
+			"-C",
+			workingDirectory,
+			...bundleEntries
+		]);
+	} catch (cause) {
+		await fs.rm(temporaryDirectory, {
+			force: true,
+			recursive: true
+		});
+		throw new Error(`Failed to create Terraform plan bundle for "${workingDirectory}"`, { cause });
+	}
+	return {
+		archivePath,
+		temporaryDirectory
+	};
+};
+const createBlobServiceClient = (storageAccount) => new BlobServiceClient(`https://${storageAccount}.blob.core.windows.net`, new AzureCliCredential());
+const uploadToAzure = async (backend, planPath, archivePath) => {
+	await createBlobServiceClient(backend.storageAccount).getContainerClient(backend.container).getBlockBlobClient(planPath).uploadFile(archivePath);
+};
+const uploadToS3 = async (backend, planPath, archivePath) => {
+	const client = new S3Client({ region: backend.region });
+	const body = await fs.readFile(archivePath);
+	await client.send(new PutObjectCommand({
+		Body: body,
+		Bucket: backend.bucket,
+		Key: planPath
+	}));
+};
+const uploadToBackend = async (backend, planPath, archivePath) => {
+	switch (backend.type) {
+		case "azurerm": return uploadToAzure(backend, planPath, archivePath);
+		case "s3": return uploadToS3(backend, planPath, archivePath);
+	}
+};
+const downloadFromAzure = async (backend, planPath, destinationPath) => {
+	const archive = await createBlobServiceClient(backend.storageAccount).getContainerClient(backend.container).getBlobClient(planPath).downloadToBuffer();
+	await fs.writeFile(destinationPath, archive, { mode: 384 });
+};
+const downloadFromS3 = async (backend, planPath, destinationPath) => {
+	const response = await new S3Client({ region: backend.region }).send(new GetObjectCommand({
+		Bucket: backend.bucket,
+		Key: planPath
+	}));
+	if (!response.Body) throw new Error(`Received an empty response body for s3://${backend.bucket}/${planPath}`);
+	await fs.writeFile(destinationPath, await response.Body.transformToByteArray(), { mode: 384 });
+};
+const downloadFromBackend = async (backend, planPath, destinationPath) => {
+	switch (backend.type) {
+		case "azurerm": return downloadFromAzure(backend, planPath, destinationPath);
+		case "s3": return downloadFromS3(backend, planPath, destinationPath);
+	}
+};
+const deleteFromAzure = async (backend, planPath) => {
+	await createBlobServiceClient(backend.storageAccount).getContainerClient(backend.container).getBlobClient(planPath).deleteIfExists();
+};
+const deleteFromS3 = async (backend, planPath) => {
+	await new S3Client({ region: backend.region }).send(new DeleteObjectCommand({
+		Bucket: backend.bucket,
+		Key: planPath
+	}));
+};
+const readBackendConfig = async (workingDirectory) => {
+	const terraformStatePath = getTerraformStatePath(workingDirectory);
+	let rawTerraformState;
+	try {
+		rawTerraformState = await fs.readFile(terraformStatePath, "utf8");
+	} catch (cause) {
+		throw new Error(`Failed to read Terraform backend state from "${terraformStatePath}"`, { cause });
+	}
+	let parsedTerraformState;
+	try {
+		parsedTerraformState = JSON.parse(rawTerraformState);
+	} catch (cause) {
+		throw new Error(`Failed to parse Terraform backend state from "${terraformStatePath}" as JSON`, { cause });
+	}
+	return getBackendConfig(getValidatedTerraformState(parsedTerraformState, terraformStatePath));
+};
+const computePlanPath = (stateKey, runId) => {
+	const stateDirectory = path.posix.dirname(stateKey);
+	const stateBasename = path.posix.basename(stateKey);
+	if (stateDirectory === ".") return `plan-artifacts/${stateBasename}.${runId}`;
+	return `${stateDirectory}/plan-artifacts/${stateBasename}.${runId}`;
+};
+const uploadPlanBundle = async ({ planFile, runId, workingDirectory }) => {
+	const absoluteWorkingDirectory = getAbsoluteWorkingDirectory(workingDirectory);
+	const { key, ...backend } = await readBackendConfig(absoluteWorkingDirectory);
+	const planPath = computePlanPath(key, runId);
+	const { archivePath, temporaryDirectory } = await createBundle(absoluteWorkingDirectory, planFile);
+	try {
+		await uploadToBackend(backend, planPath, archivePath);
+	} finally {
+		await fs.rm(temporaryDirectory, {
+			force: true,
+			recursive: true
+		});
+	}
+	return {
+		backend,
+		planPath
+	};
+};
+const downloadPlanBundle = async ({ backend, planPath, workingDirectory }) => {
+	const absoluteWorkingDirectory = getAbsoluteWorkingDirectory(workingDirectory);
+	const temporaryDirectory = await fs.mkdtemp(path.join(os.tmpdir(), "dx-tasks-plan-storage-"));
+	const archivePath = path.join(temporaryDirectory, "bundle.tar.gz");
+	try {
+		await downloadFromBackend(backend, planPath, archivePath);
+		await fs.mkdir(absoluteWorkingDirectory, { recursive: true });
+		await execFileAsync("tar", [
+			"xzf",
+			archivePath,
+			"-C",
+			absoluteWorkingDirectory,
+			"--no-same-owner",
+			"--no-same-permissions"
+		]);
+	} finally {
+		await fs.rm(temporaryDirectory, {
+			force: true,
+			recursive: true
+		});
+	}
+};
+const deleteRemotePlanBundle = async ({ backend, planPath }) => {
+	switch (backend.type) {
+		case "azurerm": return deleteFromAzure(backend, planPath);
+		case "s3": return deleteFromS3(backend, planPath);
+	}
+};
+
+//#endregion
+//#region ../dx-tasks/dist/terraform/apply.js
+/** This module downloads and applies a previously generated Terraform plan bundle. */
+const TERRAFORM_APPLY_NAMESPACE = "terraform-apply";
+const terraformApplyPayloadShape = {
+	modulePath: z.string().check(z.minLength(1)),
+	report: z._default(z.boolean(), false),
+	sensitiveKeys: z._default(z.array(z.string().check(z.minLength(1))), []),
+	verbose: z._default(z.boolean(), false)
+};
+const payloadSchema$2 = z.object(terraformApplyPayloadShape);
+const terraformApplyReportShape = {
+	applyOutput: z.string(),
+	modulePath: z.string().check(z.minLength(1)),
+	notices: z.array(z.object({
+		message: z.string().check(z.minLength(1)),
+		severity: z.union([z.literal("warning"), z.literal("error")])
+	})),
+	success: z._default(z.boolean(), true),
+	summaryLine: z.optional(z.string().check(z.minLength(1)))
+};
+const terraformApplyReportSchema = z.object(terraformApplyReportShape);
+const noApplyOutputMessage = "No apply output available.";
+const terraformApplyReportSeparator = "\n\n";
+const renderNoticeMarkdown$1 = ({ message, severity }) => {
+	return `> [!${severity === "warning" ? "WARNING" : "CAUTION"}]\n${message.split("\n").map((line) => `> ${line}`).join("\n")}`;
+};
+const renderTerraformApplyReport = ({ applyOutput, modulePath, notices, success, summaryLine }, { sourceUrl }) => {
+	const heading = `### Terraform Apply: \`${modulePath}\` - ${success ? "✅ Success" : "❌ Failed"}`;
+	const renderedNotices = notices.map(renderNoticeMarkdown$1);
+	const details = `> [!NOTE]\n> Full apply output is not included in this comment.\n> ${sourceUrl ? `See the [workflow run](${sourceUrl}) logs for the complete output.` : "See the workflow run logs for the complete output."}`;
+	if (renderedNotices.length > 0) return `${heading}\n${renderedNotices.join("\n\n")}${summaryLine ? `\n\n${summaryLine}` : ""}\n\n${details}`;
+	return `${heading}${summaryLine ? `\n${summaryLine}` : ""}\n\n${details}`;
+};
+const renderTerraformApplyReports = (reports, { sourceUrl } = {}) => reports.map((report) => renderTerraformApplyReport(report, { sourceUrl })).join(terraformApplyReportSeparator).trim();
+const terraformApplyReportNamespace = {
+	name: TERRAFORM_APPLY_NAMESPACE,
+	renderers: { markdown: renderTerraformApplyReports },
+	schema: terraformApplyReportSchema
+};
+const isRunningInCI$1 = () => {
+	const ci = process.env.CI;
+	return Boolean(ci) && ci !== "false" && ci !== "0";
+};
+const getMaskedOutputOrFallback$1 = (maskedOutput) => maskedOutput.trim().length > 0 ? maskedOutput : noApplyOutputMessage;
+const getApplyOutput = (maskedOutput, verbose) => {
+	if (verbose) return getMaskedOutputOrFallback$1(maskedOutput);
+	return maskedOutput.match(/(?:^.*Error:[\s\S]*|^.*Apply complete!.*)/m)?.[0] ?? getMaskedOutputOrFallback$1(maskedOutput);
+};
+const getApplySummaryLine = (maskedOutput) => util.stripVTControlCharacters(maskedOutput).match(/^Apply complete!.*$/m)?.[0];
+const noticeStartPattern$1 = /^(?:│\s*)?(Warning|Error):/;
+const getNoticeSeverity$1 = (line) => {
+	const [, severity] = noticeStartPattern$1.exec(line) ?? [];
+	if (severity === "Warning") return "warning";
+	if (severity === "Error") return "error";
+};
+const isApplySectionStart = (line) => /^(?:Apply complete!|[\w."[\]-]+: (?:Creating|Modifying|Destroying|Refreshing state|Creation complete|Modifications complete|Destruction complete)\b)/.test(line);
+const normalizeNoticeLine$1 = (line) => line.replace(/^│ ?/, "");
+const getApplyNotices = (maskedOutput) => {
+	const lines = util.stripVTControlCharacters(maskedOutput).split(/\r?\n/);
+	const notices = [];
+	for (let lineIndex = 0; lineIndex < lines.length; lineIndex += 1) {
+		const severity = getNoticeSeverity$1(lines[lineIndex] ?? "");
+		if (!severity) continue;
+		const messageLines = [];
+		for (let noticeLineIndex = lineIndex; noticeLineIndex < lines.length; noticeLineIndex += 1) {
+			const line = lines[noticeLineIndex] ?? "";
+			const isFirstLine = noticeLineIndex === lineIndex;
+			if (!isFirstLine && getNoticeSeverity$1(line)) {
+				lineIndex = noticeLineIndex - 1;
+				break;
+			}
+			if (!isFirstLine && (line === "╵" || isApplySectionStart(line))) {
+				lineIndex = noticeLineIndex - 1;
+				break;
+			}
+			messageLines.push(normalizeNoticeLine$1(line));
+			lineIndex = noticeLineIndex;
+		}
+		const message = messageLines.join("\n").trim();
+		if (message.length > 0) notices.push({
+			message,
+			severity
+		});
+	}
+	return notices;
+};
+const getFailureMessage$1 = (result) => {
+	if (result.signal) return `Terraform apply terminated by signal ${result.signal}`;
+	if (result.exitCode !== 0) return `Terraform apply exited with code ${result.exitCode}`;
+	return noApplyOutputMessage;
+};
+const getRunId$1 = () => {
+	const runId = process.env.GITHUB_RUN_ID;
+	if (!runId) throw new Error("GITHUB_RUN_ID environment variable is required to locate the Terraform plan bundle to apply");
+	return runId;
+};
+const executeTerraformApply = async (modulePath, verbose, report, sensitiveKeys, context) => {
+	const env = {};
+	if (!verbose) env.TF_IN_AUTOMATION = "true";
+	if (isRunningInCI$1()) env.TF_IN_AUTOMATION = "true";
+	const result = await runCommand("terraform", [
+		"apply",
+		"-lock-timeout=120s",
+		"-input=false",
+		"-no-color",
+		"-auto-approve",
+		PLAN_FILE_NAME
+	], modulePath, env);
+	if (result.signal) throw new Error(getFailureMessage$1(result));
+	const maskedOutput = maskOutput([result.stdout, result.stderr].filter((output) => output.trim().length > 0).join("\n"), [...sensitiveKeys]);
+	const applyOutput = getApplyOutput(maskedOutput, verbose);
+	const notices = getApplyNotices(maskedOutput);
+	const summaryLine = getApplySummaryLine(maskedOutput);
+	console.log(applyOutput);
+	if (report && context.reports) await context.reports.write(TERRAFORM_APPLY_NAMESPACE, Buffer.from(modulePath).toString("base64url"), {
+		applyOutput: util.stripVTControlCharacters(applyOutput),
+		modulePath,
+		notices,
+		success: result.exitCode === 0,
+		...summaryLine ? { summaryLine } : {}
+	});
+	if (result.exitCode !== 0) throw new Error(getFailureMessage$1(result));
+};
+async function terraformApply({ modulePath, report = false, sensitiveKeys = [], verbose = false }, context = {}) {
+	const runId = getRunId$1();
+	const { key, ...backend } = await readBackendConfig(modulePath);
+	const planPath = computePlanPath(key, runId);
+	await downloadPlanBundle({
+		backend,
+		planPath,
+		workingDirectory: modulePath
+	});
+	await executeTerraformApply(modulePath, verbose, report, sensitiveKeys, context);
+	await deleteRemotePlanBundle({
+		backend,
+		planPath
+	});
+}
+
+//#endregion
+//#region ../dx-tasks/dist/terraform/plan.js
+/** This module runs Terraform plans for dx-tasks without external process helpers. */
+const TERRAFORM_PLAN_NAMESPACE = "terraform-plan";
+const terraformPlanPayloadShape = {
+	modulePath: z.string().check(z.minLength(1)),
+	out: z.optional(z.string().check(z.minLength(1))),
+	refresh: z._default(z.boolean(), true),
+	report: z._default(z.boolean(), false),
+	sensitiveKeys: z._default(z.array(z.string().check(z.minLength(1))), []),
+	verbose: z._default(z.boolean(), false)
+};
+const payloadSchema$1 = z.object(terraformPlanPayloadShape);
+const terraformPlanReportShape = {
+	modulePath: z.string().check(z.minLength(1)),
+	notices: z.array(z.object({
+		message: z.string().check(z.minLength(1)),
+		severity: z.union([z.literal("warning"), z.literal("error")])
+	})),
+	planOutput: z.string(),
+	success: z._default(z.boolean(), true),
+	summaryLine: z.optional(z.string().check(z.minLength(1)))
+};
+const terraformPlanReportSchema = z.object(terraformPlanReportShape);
+const noPlanOutputMessage = "No plan output available.";
+const terraformPlanReportSeparator = "\n\n";
+const renderTerraformPlanReports = (reports, { sourceUrl } = {}) => reports.map((report) => renderTerraformPlanReport(report, { sourceUrl })).join(terraformPlanReportSeparator).trim();
+const renderPlanOutputReference = (sourceUrl) => {
+	return `> [!NOTE]\n> Full plan output is not included in this comment.\n> ${sourceUrl ? `See the [workflow run](${sourceUrl}) logs or downloaded Terraform plan report artifacts for the complete output.` : "See the workflow run logs or downloaded Terraform plan report artifacts for the complete output."}`;
+};
+const renderTerraformPlanReport = ({ modulePath, notices, success, summaryLine }, { sourceUrl }) => {
+	const heading = `### Terraform Plan: \`${modulePath}\` - ${success ? "✅ Success" : "❌ Failed"}`;
+	const renderedNotices = notices.map(renderNoticeMarkdown);
+	const details = renderPlanOutputReference(sourceUrl);
+	if (renderedNotices.length > 0) return `${heading}\n${renderedNotices.join("\n\n")}${summaryLine ? `\n\n${summaryLine}` : ""}\n\n${details}`;
+	return `${heading}${summaryLine ? `\n${summaryLine}` : ""}\n\n${details}`;
+};
+const terraformPlanReportNamespace = {
+	name: TERRAFORM_PLAN_NAMESPACE,
+	renderers: { markdown: renderTerraformPlanReports },
+	schema: terraformPlanReportSchema
+};
+const isRunningInCI = () => {
+	const ci = process.env.CI;
+	return Boolean(ci) && ci !== "false" && ci !== "0";
+};
+const getMaskedOutputOrFallback = (maskedOutput) => maskedOutput.trim().length > 0 ? maskedOutput : noPlanOutputMessage;
+const getPlanOutput = (maskedOutput, verbose) => {
+	if (verbose) return getMaskedOutputOrFallback(maskedOutput);
+	return maskedOutput.match(/(?:^.*Terraform will perform the following actions:[\s\S]*|^.*Terraform planned the following actions, but then encountered a problem:[\s\S]*|^.*No changes\..*)/m)?.[0] ?? getMaskedOutputOrFallback(maskedOutput);
+};
+const getPlanSummaryLine = (maskedOutput) => util.stripVTControlCharacters(maskedOutput).match(/^Plan:\s+.+$/m)?.[0];
+const noticeStartPattern = /^(?:│\s*)?(Warning|Error):/;
+const getNoticeSeverity = (line) => {
+	const [, severity] = noticeStartPattern.exec(line) ?? [];
+	if (severity === "Warning") return "warning";
+	if (severity === "Error") return "error";
+};
+const isPlanSectionStart = (line) => /^(?:Terraform used the selected providers|Terraform will perform the following actions:|Terraform planned the following actions, but then encountered a problem:|No changes\.|Plan:\s+)/.test(line);
+const normalizeNoticeLine = (line) => line.replace(/^│ ?/, "");
+const getPlanNotices = (maskedOutput) => {
+	const lines = util.stripVTControlCharacters(maskedOutput).split(/\r?\n/);
+	const notices = [];
+	for (let lineIndex = 0; lineIndex < lines.length; lineIndex += 1) {
+		const severity = getNoticeSeverity(lines[lineIndex] ?? "");
+		if (!severity) continue;
+		const messageLines = [];
+		for (let noticeLineIndex = lineIndex; noticeLineIndex < lines.length; noticeLineIndex += 1) {
+			const line = lines[noticeLineIndex] ?? "";
+			const isFirstLine = noticeLineIndex === lineIndex;
+			if (!isFirstLine && getNoticeSeverity(line)) {
+				lineIndex = noticeLineIndex - 1;
+				break;
+			}
+			if (!isFirstLine && (line === "╵" || isPlanSectionStart(line))) {
+				lineIndex = noticeLineIndex - 1;
+				break;
+			}
+			messageLines.push(normalizeNoticeLine(line));
+			lineIndex = noticeLineIndex;
+		}
+		const message = messageLines.join("\n").trim();
+		if (message.length > 0) notices.push({
+			message,
+			severity
+		});
+	}
+	return notices;
+};
+const renderNoticeMarkdown = ({ message, severity }) => {
+	return `> [!${severity === "warning" ? "WARNING" : "CAUTION"}]\n${message.split("\n").map((line) => `> ${line}`).join("\n")}`;
+};
+const getFailureMessage = (result) => {
+	if (result.signal) return `Terraform plan terminated by signal ${result.signal}`;
+	if (result.exitCode !== 0) return `Terraform plan exited with code ${result.exitCode}`;
+	return noPlanOutputMessage;
+};
+const executeTerraformPlan = async (modulePath, env, verbose, report, sensitiveKeys, context) => {
+	const result = await runCommand("terraform", ["plan"], modulePath, env);
+	if (result.signal) throw new Error(getFailureMessage(result));
+	const maskedOutput = maskOutput([result.stdout, result.stderr].filter((output) => output.trim().length > 0).join("\n"), [...sensitiveKeys]);
+	const planOutput = getPlanOutput(maskedOutput, verbose);
+	const notices = getPlanNotices(maskedOutput);
+	const summaryLine = getPlanSummaryLine(maskedOutput);
+	console.log(planOutput);
+	if (report && context.reports) await context.reports.write(TERRAFORM_PLAN_NAMESPACE, Buffer.from(modulePath).toString("base64url"), {
+		modulePath,
+		notices,
+		planOutput: util.stripVTControlCharacters(planOutput),
+		success: result.exitCode === 0,
+		...summaryLine ? { summaryLine } : {}
+	});
+	if (result.exitCode !== 0) throw new Error(getFailureMessage(result));
+};
+async function terraformPlan({ modulePath, out, refresh = true, report = false, sensitiveKeys = [], verbose = false }, context = {}) {
+	const args = /* @__PURE__ */ new Map();
+	const env = {};
+	args.set("lock-timeout", "120s");
+	if (out) args.set("out", out);
+	if (!refresh) {
+		args.set("refresh", "false");
+		args.set("lock", "false");
+	}
+	if (!verbose) env.TF_IN_AUTOMATION = "true";
+	if (isRunningInCI()) {
+		args.set("input", "false");
+		args.set("no-color", true);
+		env.TF_IN_AUTOMATION = "true";
+	}
+	env.TF_CLI_ARGS_plan = args.entries().reduce((acc, [key, value]) => `${acc}-${key}${value === true ? "" : `=${value}`} `, "");
+	await executeTerraformPlan(modulePath, env, verbose, report, sensitiveKeys, context);
+}
+
+//#endregion
+//#region ../dx-tasks/dist/terraform/plan-upload.js
+/** This module runs a Terraform plan and uploads the resulting bundle for a later apply. */
+const terraformPlanUploadPayloadShape = {
+	modulePath: z.string().check(z.minLength(1)),
+	refresh: z._default(z.boolean(), true),
+	report: z._default(z.boolean(), false),
+	sensitiveKeys: z._default(z.array(z.string().check(z.minLength(1))), []),
+	verbose: z._default(z.boolean(), false)
+};
+const payloadSchema = z.object(terraformPlanUploadPayloadShape);
+const getRunId = () => {
+	const runId = process.env.GITHUB_RUN_ID;
+	if (!runId) throw new Error("GITHUB_RUN_ID environment variable is required to upload a Terraform plan bundle");
+	return runId;
+};
+async function terraformPlanUpload({ modulePath, refresh = true, report = false, sensitiveKeys = [], verbose = false }, context = {}) {
+	await terraformPlan({
+		modulePath,
+		out: PLAN_FILE_NAME,
+		refresh,
+		report,
+		sensitiveKeys,
+		verbose
+	}, context);
+	const { backend, planPath } = await uploadPlanBundle({
+		planFile: PLAN_FILE_NAME,
+		runId: getRunId(),
+		workingDirectory: modulePath
+	});
+	console.log(`Uploaded Terraform plan bundle for "${modulePath}" (${backend.type}) to "${planPath}"`);
+}
+
+//#endregion
+//#region ../dx-tasks/dist/tasks.js
+/** This module exposes built-in dx-tasks task definitions for external registries. */
+const terraformPlanTask = {
+	name: "terraformPlan",
+	payloadSchema: payloadSchema$1,
+	run: terraformPlan
+};
+const terraformPlanUploadTask = {
+	name: "terraformPlanUpload",
+	payloadSchema,
+	run: terraformPlanUpload
+};
+const terraformApplyTask = {
+	name: "terraformApply",
+	payloadSchema: payloadSchema$2,
+	run: terraformApply
+};
+const renderReportTask = {
+	name: "renderReport",
+	payloadSchema: payloadSchema$4,
+	run: renderReport
+};
+const reportPrCommentTask = {
+	name: "reportPrComment",
+	payloadSchema: payloadSchema$3,
+	run: reportPrComment
+};
+const prCommentTask = {
+	name: "prComment",
+	payloadSchema: payloadSchema$5,
+	run: prComment
+};
+
+//#endregion
+//#region ../dx-tasks/dist/default-dispatcher.js
+/** This module wires the default dx-tasks registry with built-in task definitions. */
+const createDefaultReportStore = () => new ReportStore(process.cwd()).register(terraformPlanReportNamespace).register(terraformApplyReportNamespace);
+const createDefaultTaskDispatcher = ({ reports = createDefaultReportStore() } = {}) => {
+	const dispatcher = createTaskDispatcher({ context: { reports } });
+	dispatcher.registerTask(terraformPlanTask);
+	dispatcher.registerTask(terraformPlanUploadTask);
+	dispatcher.registerTask(terraformApplyTask);
+	dispatcher.registerTask(renderReportTask);
+	dispatcher.registerTask(reportPrCommentTask);
+	dispatcher.registerTask(prCommentTask);
+	return dispatcher;
+};
+
+//#endregion
+export { createDefaultTaskDispatcher as t };

--- a/packages/nx-terraform-plugin/dist/default-dispatcher-X0vwzN5B.js
+++ b/packages/nx-terraform-plugin/dist/default-dispatcher-X0vwzN5B.js
@@ -700,10 +700,14 @@ async function terraformApply({ modulePath, report = false, sensitiveKeys = [], 
 		workingDirectory: modulePath
 	});
 	await executeTerraformApply(modulePath, verbose, report, sensitiveKeys, context);
-	await deleteRemotePlanBundle({
-		backend,
-		planPath
-	});
+	try {
+		await deleteRemotePlanBundle({
+			backend,
+			planPath
+		});
+	} catch (error) {
+		console.warn(`Failed to delete remote Terraform plan bundle at "${planPath}": ${error instanceof Error ? error.message : String(error)}`);
+	}
 }
 
 //#endregion

--- a/packages/nx-terraform-plugin/dist/executors/plan-upload/plan-upload.js
+++ b/packages/nx-terraform-plugin/dist/executors/plan-upload/plan-upload.js
@@ -2,9 +2,8 @@ import { t as createDefaultTaskDispatcher } from "../../default-dispatcher-BTden
 import { n as getPackageLogger, t as configureLogger } from "../../logger-DZ1KFLzv.js";
 import { z } from "zod/v4";
 
-//#region src/executors/plan/schema.ts
-const planExecutorSchema = z.object({
-	out: z.string().min(1).optional(),
+//#region src/executors/plan-upload/schema.ts
+const planUploadExecutorSchema = z.object({
 	projectRoot: z.string().min(1),
 	refresh: z.boolean().default(true),
 	report: z.boolean().default(false),
@@ -13,22 +12,21 @@ const planExecutorSchema = z.object({
 });
 
 //#endregion
-//#region src/executors/plan/plan.ts
+//#region src/executors/plan-upload/plan-upload.ts
 const runExecutor = async (options) => {
-	const logger = getPackageLogger(["plan"]);
-	const parseResult = planExecutorSchema.safeParse(options);
+	const logger = getPackageLogger(["plan-upload"]);
+	const parseResult = planUploadExecutorSchema.safeParse(options);
 	await configureLogger();
 	if (!parseResult.success) {
-		logger.warn("Invalid plan options", {
+		logger.warn("Invalid plan-upload options", {
 			issues: parseResult.error.issues,
-			path: options.projectRoot ?? "plan options"
+			path: options?.projectRoot ?? "plan-upload options"
 		});
 		return { success: false };
 	}
-	const { out, projectRoot, refresh, report, sensitiveKeys, verbose } = parseResult.data;
-	await createDefaultTaskDispatcher().dispatchTask("terraformPlan", {
+	const { projectRoot, refresh, report, sensitiveKeys, verbose } = parseResult.data;
+	await createDefaultTaskDispatcher().dispatchTask("terraformPlanUpload", {
 		modulePath: projectRoot,
-		out,
 		refresh,
 		report,
 		sensitiveKeys,

--- a/packages/nx-terraform-plugin/dist/executors/plan-upload/plan-upload.js
+++ b/packages/nx-terraform-plugin/dist/executors/plan-upload/plan-upload.js
@@ -1,4 +1,4 @@
-import { t as createDefaultTaskDispatcher } from "../../default-dispatcher-BTdenmPC.js";
+import { t as createDefaultTaskDispatcher } from "../../default-dispatcher-X0vwzN5B.js";
 import { n as getPackageLogger, t as configureLogger } from "../../logger-DZ1KFLzv.js";
 import { z } from "zod/v4";
 

--- a/packages/nx-terraform-plugin/dist/executors/plan/plan.js
+++ b/packages/nx-terraform-plugin/dist/executors/plan/plan.js
@@ -1,4 +1,4 @@
-import { t as createDefaultTaskDispatcher } from "../../default-dispatcher-BTdenmPC.js";
+import { t as createDefaultTaskDispatcher } from "../../default-dispatcher-X0vwzN5B.js";
 import { n as getPackageLogger, t as configureLogger } from "../../logger-DZ1KFLzv.js";
 import { z } from "zod/v4";
 

--- a/packages/nx-terraform-plugin/dist/executors/publish/publish.js
+++ b/packages/nx-terraform-plugin/dist/executors/publish/publish.js
@@ -3,9 +3,9 @@ import { i as publishSchema } from "../../publish-options-DI4KrjU0.js";
 import { cp, mkdtemp, readdir, rm } from "node:fs/promises";
 import { basename, join } from "node:path";
 import { Octokit } from "octokit";
+import { tmpdir } from "node:os";
 import { z } from "zod/v4";
 import { $ } from "execa";
-import { tmpdir } from "node:os";
 import { createAppAuth } from "@octokit/auth-app";
 
 //#region src/adapters/github/octokit.ts

--- a/packages/nx-terraform-plugin/dist/executors/release-apply/release-apply.js
+++ b/packages/nx-terraform-plugin/dist/executors/release-apply/release-apply.js
@@ -1,4 +1,4 @@
-import { t as createDefaultTaskDispatcher } from "../../default-dispatcher-BTdenmPC.js";
+import { t as createDefaultTaskDispatcher } from "../../default-dispatcher-X0vwzN5B.js";
 import { n as getPackageLogger, t as configureLogger } from "../../logger-DZ1KFLzv.js";
 import { z } from "zod/v4";
 

--- a/packages/nx-terraform-plugin/dist/executors/release-apply/release-apply.js
+++ b/packages/nx-terraform-plugin/dist/executors/release-apply/release-apply.js
@@ -1,0 +1,48 @@
+import { t as createDefaultTaskDispatcher } from "../../default-dispatcher-BTdenmPC.js";
+import { n as getPackageLogger, t as configureLogger } from "../../logger-DZ1KFLzv.js";
+import { z } from "zod/v4";
+
+//#region src/executors/release-apply/schema.ts
+const releaseApplyExecutorSchema = z.object({
+	dryRun: z.boolean().default(false),
+	projectRoot: z.string().min(1),
+	report: z.boolean().default(false),
+	sensitiveKeys: z.array(z.string().min(1)).default([]),
+	verbose: z.boolean().default(false)
+});
+
+//#endregion
+//#region src/executors/release-apply/release-apply.ts
+const nxDryRunSchema = z.enum(["false", "true"]).optional();
+const runExecutor = async (options) => {
+	const logger = getPackageLogger(["release-apply"]);
+	const parseResult = releaseApplyExecutorSchema.safeParse(options);
+	const nxDryRunParseResult = nxDryRunSchema.safeParse(process.env.NX_DRY_RUN);
+	await configureLogger();
+	if (!parseResult.success) {
+		logger.warn("Invalid release-apply options", {
+			issues: parseResult.error.issues,
+			path: options?.projectRoot ?? "release-apply options"
+		});
+		return { success: false };
+	}
+	if (!nxDryRunParseResult.success) {
+		logger.warn("Invalid NX_DRY_RUN environment variable", { issues: nxDryRunParseResult.error.issues });
+		return { success: false };
+	}
+	const { dryRun, projectRoot, report, sensitiveKeys, verbose } = parseResult.data;
+	if (dryRun || nxDryRunParseResult.data === "true") {
+		logger.info("Skipping Terraform apply during release dry run", { projectRoot });
+		return { success: true };
+	}
+	await createDefaultTaskDispatcher().dispatchTask("terraformApply", {
+		modulePath: projectRoot,
+		report,
+		sensitiveKeys,
+		verbose
+	});
+	return { success: true };
+};
+
+//#endregion
+export { runExecutor as default };

--- a/packages/nx-terraform-plugin/dist/index.js
+++ b/packages/nx-terraform-plugin/dist/index.js
@@ -207,6 +207,7 @@ const getTargets = (opts, root, projectType, hasRootTflintConfig, publishManifes
 			projectRoot: "{projectRoot}",
 			refresh: true,
 			report: false,
+			sensitiveKeys: opts.sensitiveOutputKeys,
 			verbose: true
 		}
 	}], [opts.applyTargetName, {
@@ -298,8 +299,10 @@ const terraformPluginOptionsSchema = z.object({
 	lintTargetName: targetNameSchema,
 	outputTargetName: targetNameSchema,
 	planTargetName: targetNameSchema,
+	planUploadTargetName: targetNameSchema,
 	publish: publishOptionsSchema,
 	publishTargetName: targetNameSchema,
+	sensitiveOutputKeys: z.array(z.string().min(1)),
 	testTargetName: targetNameSchema,
 	validateTargetName: targetNameSchema
 });
@@ -313,8 +316,10 @@ const defaultOptions = {
 	lintTargetName: "tflint",
 	outputTargetName: "tf-output",
 	planTargetName: "tf-plan",
+	planUploadTargetName: "tf-plan-upload",
 	publish: { mode: "github" },
 	publishTargetName: "nx-release-publish",
+	sensitiveOutputKeys: [],
 	testTargetName: "tf-test",
 	validateTargetName: "tf-validate"
 };

--- a/packages/nx-terraform-plugin/dist/index.js
+++ b/packages/nx-terraform-plugin/dist/index.js
@@ -101,6 +101,23 @@ const getPublishTarget = (opts, root, publishManifest) => {
 		throw error;
 	}
 };
+const getPlanTarget = (opts, executor) => ({
+	cache: false,
+	configurations: { ci: {
+		refresh: true,
+		report: true,
+		verbose: false
+	} },
+	dependsOn: [opts.initTargetName],
+	executor,
+	options: {
+		projectRoot: "{projectRoot}",
+		refresh: true,
+		report: false,
+		sensitiveKeys: opts.sensitiveOutputKeys,
+		verbose: true
+	}
+});
 const getTargets = (opts, root, projectType, hasRootTflintConfig, publishManifest) => {
 	const rootTflintConfigPath = getRootConfigPath(root, ".tflint.hcl");
 	const formatArgs = ["-list=true", "-recursive=true"];
@@ -194,23 +211,7 @@ const getTargets = (opts, root, projectType, hasRootTflintConfig, publishManifes
 		dependsOn: [opts.initTargetName],
 		options: { cwd }
 	}]);
-	if (projectType === "application") targets.push([opts.planTargetName, {
-		cache: false,
-		configurations: { ci: {
-			refresh: true,
-			report: true,
-			verbose: false
-		} },
-		dependsOn: [opts.initTargetName],
-		executor: "@pagopa/nx-terraform-plugin:plan",
-		options: {
-			projectRoot: "{projectRoot}",
-			refresh: true,
-			report: false,
-			sensitiveKeys: opts.sensitiveOutputKeys,
-			verbose: true
-		}
-	}], [opts.applyTargetName, {
+	if (projectType === "application") targets.push([opts.planTargetName, getPlanTarget(opts, "@pagopa/nx-terraform-plugin:plan")], [opts.planUploadTargetName, getPlanTarget(opts, "@pagopa/nx-terraform-plugin:plan-upload")], [opts.applyTargetName, {
 		cache: false,
 		command: `terraform apply`,
 		dependsOn: [opts.initTargetName],

--- a/packages/nx-terraform-plugin/executors.json
+++ b/packages/nx-terraform-plugin/executors.json
@@ -9,6 +9,16 @@
       "implementation": "./dist/executors/plan/plan.js",
       "schema": "./src/executors/plan/schema.json",
       "description": "plan executor"
+    },
+    "plan-upload": {
+      "implementation": "./dist/executors/plan-upload/plan-upload.js",
+      "schema": "./src/executors/plan-upload/schema.json",
+      "description": "plan-upload executor"
+    },
+    "release-apply": {
+      "implementation": "./dist/executors/release-apply/release-apply.js",
+      "schema": "./src/executors/release-apply/schema.json",
+      "description": "release-apply executor"
     }
   }
 }

--- a/packages/nx-terraform-plugin/package.json
+++ b/packages/nx-terraform-plugin/package.json
@@ -47,6 +47,9 @@
     "node": ">=22.0.0"
   },
   "dependencies": {
+    "@aws-sdk/client-s3": "catalog:aws",
+    "@azure/identity": "catalog:",
+    "@azure/storage-blob": "catalog:azure",
     "@logtape/logtape": "catalog:",
     "@nx/devkit": "^22.7.6",
     "@octokit/auth-app": "^8.2.0",

--- a/packages/nx-terraform-plugin/src/__tests__/options.test.ts
+++ b/packages/nx-terraform-plugin/src/__tests__/options.test.ts
@@ -14,10 +14,12 @@ describe("parseOptions", () => {
       lintTargetName: "tflint",
       outputTargetName: "tf-output",
       planTargetName: "tf-plan",
+      planUploadTargetName: "tf-plan-upload",
       publish: {
         mode: "github",
       },
       publishTargetName: "nx-release-publish",
+      sensitiveOutputKeys: [],
       testTargetName: "tf-test",
       validateTargetName: "tf-validate",
     });
@@ -56,6 +58,14 @@ describe("parseOptions", () => {
         additionalEnvironments: ["sandbox", "qa_env"],
       }).additionalEnvironments,
     ).toEqual(["sandbox", "qa_env"]);
+  });
+
+  it("accepts sensitive Terraform output keys", () => {
+    expect(
+      parseOptions({
+        sensitiveOutputKeys: ["hidden-link", "APPINSIGHTS_INSTRUMENTATIONKEY"],
+      }).sensitiveOutputKeys,
+    ).toEqual(["hidden-link", "APPINSIGHTS_INSTRUMENTATIONKEY"]);
   });
 
   it("rejects invalid additional environment names", () => {

--- a/packages/nx-terraform-plugin/src/__tests__/package-manifest.test.ts
+++ b/packages/nx-terraform-plugin/src/__tests__/package-manifest.test.ts
@@ -1,0 +1,47 @@
+import fs from "node:fs/promises";
+import { describe, expect, it } from "vitest";
+import { z } from "zod/v4";
+
+const packageManifestSchema = z.object({
+  dependencies: z.record(z.string(), z.string()).default({}),
+  devDependencies: z.record(z.string(), z.string()).default({}),
+});
+
+const readPackageManifest = async (
+  packageJsonUrl: URL,
+): Promise<z.output<typeof packageManifestSchema>> =>
+  packageManifestSchema.parse(
+    JSON.parse(await fs.readFile(packageJsonUrl, "utf8")),
+  );
+
+describe("package manifest", () => {
+  it("declares external runtime dependencies for bundled dx-tasks code", async () => {
+    const manifest = await readPackageManifest(
+      new URL("../../package.json", import.meta.url),
+    );
+    const dxTasksManifest = await readPackageManifest(
+      new URL("../../../dx-tasks/package.json", import.meta.url),
+    );
+
+    expect(manifest.devDependencies["@pagopa/dx-tasks"]).toBe("workspace:^");
+    expect(manifest.dependencies["@pagopa/dx-tasks"]).toBeUndefined();
+
+    for (const dependencyName of [
+      "@aws-sdk/client-s3",
+      "@azure/identity",
+      "@azure/storage-blob",
+      "octokit",
+      "zod",
+    ]) {
+      expect(manifest.dependencies[dependencyName]).toBe(
+        dxTasksManifest.dependencies[dependencyName],
+      );
+    }
+  });
+
+  it("keeps third-party node_modules out of the plugin bundle", async () => {
+    await expect(
+      fs.readFile(new URL("../../tsdown.config.ts", import.meta.url), "utf8"),
+    ).resolves.toContain("skipNodeModulesBundle: true");
+  });
+});

--- a/packages/nx-terraform-plugin/src/__tests__/project.test.ts
+++ b/packages/nx-terraform-plugin/src/__tests__/project.test.ts
@@ -29,6 +29,7 @@ const customOptions = parseOptions({
   lintTargetName: "terraform-lint",
   outputTargetName: "terraform-output",
   planTargetName: "terraform-plan",
+  planUploadTargetName: "terraform-plan-upload",
   testTargetName: "terraform-test",
   validateTargetName: "terraform-validate",
 });
@@ -223,6 +224,7 @@ describe("getProject applications", () => {
         "tf-console",
         "tf-output",
         "tf-plan",
+        "tf-plan-upload",
         "tf-apply",
       ]);
     });
@@ -234,6 +236,7 @@ describe("getProject applications", () => {
       expect(targets["tf-console"]?.cache).toBe(false);
       expect(targets["tf-output"]?.cache).toBe(false);
       expect(targets["tf-plan"]?.cache).toBe(false);
+      expect(targets["tf-plan-upload"]?.cache).toBe(false);
       expect(targets["tf-apply"]?.cache).toBe(false);
     });
 
@@ -260,6 +263,7 @@ describe("getProject applications", () => {
         "tf-console",
         "tf-output",
         "tf-plan",
+        "tf-plan-upload",
         "tf-apply",
       ]);
       expect(targets.tflint).toEqual(getExpectedLintTarget(root));
@@ -280,6 +284,7 @@ describe("getProject applications", () => {
         "tf-console",
         "tf-output",
         "tf-plan",
+        "tf-plan-upload",
         "tf-apply",
       ]);
       expect(targets["terraform-docs"]).toBeUndefined();
@@ -292,7 +297,34 @@ describe("getProject applications", () => {
 
       expect(targets["tf-test"]?.dependsOn).toEqual(["tf-init"]);
       expect(targets["tf-plan"]?.dependsOn).toEqual(["tf-init"]);
+      expect(targets["tf-plan-upload"]?.dependsOn).toEqual(["tf-init"]);
       expect(targets["tf-apply"]?.dependsOn).toEqual(["tf-init"]);
+    });
+
+    it("uses the configured plan-upload target name", () => {
+      const root = path.join("infra", "resources", "prod", "my_stack");
+      const targets = getTargetsOrThrow(getProject(customOptions, root));
+
+      expect(targets["terraform-plan-upload"]).toEqual({
+        cache: false,
+        configurations: {
+          ci: {
+            refresh: true,
+            report: true,
+            verbose: false,
+          },
+        },
+        dependsOn: ["terraform-init"],
+        executor: "@pagopa/nx-terraform-plugin:plan-upload",
+        options: {
+          projectRoot: "{projectRoot}",
+          refresh: true,
+          report: false,
+          sensitiveKeys: [],
+          verbose: true,
+        },
+      });
+      expect(targets["tf-plan-upload"]).toBeUndefined();
     });
 
     it("adds the resource environment tag to flat resource applications", () => {
@@ -367,6 +399,7 @@ describe("getProject libraries", () => {
       expect(project.projectType).toBe("library");
       expect(project.tags).toEqual(["terraform"]);
       expect(getTargetsOrThrow(project)["tf-plan"]).toBeUndefined();
+      expect(getTargetsOrThrow(project)["tf-plan-upload"]).toBeUndefined();
       expect(getTargetsOrThrow(project)["tf-apply"]).toBeUndefined();
     });
 

--- a/packages/nx-terraform-plugin/src/executors/plan-upload/__tests__/plan-upload.test.ts
+++ b/packages/nx-terraform-plugin/src/executors/plan-upload/__tests__/plan-upload.test.ts
@@ -1,7 +1,7 @@
 import { ExecutorContext } from "@nx/devkit";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
-import type { PlanExecutorSchema } from "../schema.ts";
+import type { PlanUploadExecutorSchema } from "../schema.ts";
 
 const loggerMocks = vi.hoisted(() => {
   const configureLogger = vi.fn(async () => {});
@@ -38,7 +38,7 @@ vi.mock("@pagopa/dx-tasks/default-dispatcher", () => ({
   createDefaultTaskDispatcher: dispatcherMocks.createDefaultTaskDispatcher,
 }));
 
-import executor from "../plan.ts";
+import executor from "../plan-upload.ts";
 
 const baseContext: ExecutorContext = {
   cwd: process.cwd(),
@@ -55,15 +55,14 @@ const baseContext: ExecutorContext = {
   root: "",
 };
 
-describe("Plan Executor", () => {
+describe("Plan Upload Executor", () => {
   beforeEach(() => {
     vi.clearAllMocks();
   });
 
-  it("dispatches terraformPlan with the project root as module path", async () => {
-    const options: PlanExecutorSchema = {
-      out: "plan.tfplan",
-      projectRoot: "infra/modules/azure_core_infra",
+  it("dispatches terraformPlanUpload with the project root as module path", async () => {
+    const options: PlanUploadExecutorSchema = {
+      projectRoot: "infra/resources/dev",
       refresh: true,
       report: true,
       sensitiveKeys: ["hidden-link"],
@@ -77,51 +76,55 @@ describe("Plan Executor", () => {
     expect(dispatcherMocks.createDefaultTaskDispatcher).toHaveBeenCalledTimes(
       1,
     );
-    expect(dispatcherMocks.dispatchTask).toHaveBeenCalledWith("terraformPlan", {
-      modulePath: "infra/modules/azure_core_infra",
-      out: "plan.tfplan",
-      refresh: true,
-      report: true,
-      sensitiveKeys: ["hidden-link"],
-      verbose: false,
-    });
-    expect(loggerMocks.getPackageLogger).toHaveBeenCalledWith(["plan"]);
+    expect(dispatcherMocks.dispatchTask).toHaveBeenCalledWith(
+      "terraformPlanUpload",
+      {
+        modulePath: "infra/resources/dev",
+        refresh: true,
+        report: true,
+        sensitiveKeys: ["hidden-link"],
+        verbose: false,
+      },
+    );
+    expect(loggerMocks.getPackageLogger).toHaveBeenCalledWith(["plan-upload"]);
   });
 
   it("applies default options when only projectRoot is provided", async () => {
     const options = {
-      projectRoot: "infra/modules/azure_core_infra",
-    } satisfies Partial<PlanExecutorSchema>;
+      projectRoot: "infra/resources/dev",
+    } satisfies Partial<PlanUploadExecutorSchema>;
 
     const output = await executor(options, baseContext);
 
     expect(output.success).toBe(true);
-    expect(dispatcherMocks.dispatchTask).toHaveBeenCalledWith("terraformPlan", {
-      modulePath: "infra/modules/azure_core_infra",
-      out: undefined,
-      refresh: true,
-      report: false,
-      sensitiveKeys: [],
-      verbose: false,
-    });
+    expect(dispatcherMocks.dispatchTask).toHaveBeenCalledWith(
+      "terraformPlanUpload",
+      {
+        modulePath: "infra/resources/dev",
+        refresh: true,
+        report: false,
+        sensitiveKeys: [],
+        verbose: false,
+      },
+    );
   });
 
   it("fails when projectRoot is missing", async () => {
-    const options = {} satisfies Partial<PlanExecutorSchema>;
+    const options = {} satisfies Partial<PlanUploadExecutorSchema>;
 
     const output = await executor(options, baseContext);
 
     expect(output.success).toBe(false);
     expect(loggerMocks.configureLogger).toHaveBeenCalledTimes(1);
     expect(loggerMocks.warn).toHaveBeenCalledWith(
-      "Invalid plan options",
+      "Invalid plan-upload options",
       expect.objectContaining({
         issues: expect.arrayContaining([
           expect.objectContaining({
             path: ["projectRoot"],
           }),
         ]),
-        path: "plan options",
+        path: "plan-upload options",
       }),
     );
     expect(dispatcherMocks.dispatchTask).not.toHaveBeenCalled();

--- a/packages/nx-terraform-plugin/src/executors/plan-upload/plan-upload.ts
+++ b/packages/nx-terraform-plugin/src/executors/plan-upload/plan-upload.ts
@@ -2,32 +2,36 @@ import { PromiseExecutor } from "@nx/devkit";
 import { createDefaultTaskDispatcher } from "@pagopa/dx-tasks/default-dispatcher";
 
 import { configureLogger, getPackageLogger } from "../../logger.ts";
-import { type PlanExecutorInput, planExecutorSchema } from "./schema.ts";
+import {
+  type PlanUploadExecutorInput,
+  planUploadExecutorSchema,
+} from "./schema.ts";
 
-const runExecutor: PromiseExecutor<PlanExecutorInput> = async (options) => {
-  const logger = getPackageLogger(["plan"]);
-  const parseResult = planExecutorSchema.safeParse(options);
+const runExecutor: PromiseExecutor<PlanUploadExecutorInput> = async (
+  options,
+) => {
+  const logger = getPackageLogger(["plan-upload"]);
+  const parseResult = planUploadExecutorSchema.safeParse(options);
 
   await configureLogger();
 
   if (!parseResult.success) {
-    logger.warn("Invalid plan options", {
+    logger.warn("Invalid plan-upload options", {
       issues: parseResult.error.issues,
-      path: options.projectRoot ?? "plan options",
+      path: options?.projectRoot ?? "plan-upload options",
     });
     return {
       success: false,
     };
   }
 
-  const { out, projectRoot, refresh, report, sensitiveKeys, verbose } =
+  const { projectRoot, refresh, report, sensitiveKeys, verbose } =
     parseResult.data;
 
   const dispatcher = createDefaultTaskDispatcher();
 
-  await dispatcher.dispatchTask("terraformPlan", {
+  await dispatcher.dispatchTask("terraformPlanUpload", {
     modulePath: projectRoot,
-    out,
     refresh,
     report,
     sensitiveKeys,

--- a/packages/nx-terraform-plugin/src/executors/plan-upload/schema.json
+++ b/packages/nx-terraform-plugin/src/executors/plan-upload/schema.json
@@ -1,16 +1,12 @@
 {
   "$schema": "https://json-schema.org/schema",
   "version": 2,
-  "title": "Plan executor",
-  "description": "Runs terraform plan for a Terraform project through @pagopa/dx-tasks",
+  "title": "Plan upload executor",
+  "description": "Runs terraform plan for a Terraform project and uploads the resulting plan bundle to the Terraform state storage backend, through @pagopa/dx-tasks",
   "type": "object",
   "properties": {
     "projectRoot": {
       "description": "Terraform project root used as the module path",
-      "type": "string"
-    },
-    "out": {
-      "description": "Optional path passed to terraform plan -out",
       "type": "string"
     },
     "refresh": {

--- a/packages/nx-terraform-plugin/src/executors/plan-upload/schema.ts
+++ b/packages/nx-terraform-plugin/src/executors/plan-upload/schema.ts
@@ -1,7 +1,6 @@
 import { z } from "zod/v4";
 
-export const planExecutorSchema = z.object({
-  out: z.string().min(1).optional(),
+export const planUploadExecutorSchema = z.object({
   projectRoot: z.string().min(1),
   refresh: z.boolean().default(true),
   report: z.boolean().default(false),
@@ -9,6 +8,6 @@ export const planExecutorSchema = z.object({
   verbose: z.boolean().default(false),
 });
 
-export type PlanExecutorInput = Partial<PlanExecutorSchema>;
+export type PlanUploadExecutorInput = Partial<PlanUploadExecutorSchema>;
 
-export type PlanExecutorSchema = z.infer<typeof planExecutorSchema>;
+export type PlanUploadExecutorSchema = z.infer<typeof planUploadExecutorSchema>;

--- a/packages/nx-terraform-plugin/src/executors/release-apply/__tests__/release-apply.test.ts
+++ b/packages/nx-terraform-plugin/src/executors/release-apply/__tests__/release-apply.test.ts
@@ -1,0 +1,171 @@
+import { ExecutorContext } from "@nx/devkit";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import type { ReleaseApplyExecutorSchema } from "../schema.ts";
+
+const loggerMocks = vi.hoisted(() => {
+  const configureLogger = vi.fn(async () => {});
+  const info = vi.fn();
+  const warn = vi.fn();
+  return {
+    configureLogger,
+    getPackageLogger: vi.fn(() => ({
+      info,
+      warn,
+    })),
+    info,
+    warn,
+  };
+});
+
+const dispatcherMocks = vi.hoisted(() => {
+  const dispatchTask = vi.fn(async () => {});
+  return {
+    createDefaultTaskDispatcher: vi.fn(() => ({
+      dispatchTask,
+      registerTask: vi.fn(),
+    })),
+    dispatchTask,
+  };
+});
+
+vi.mock("../../../logger.ts", () => ({
+  configureLogger: loggerMocks.configureLogger,
+  getPackageLogger: loggerMocks.getPackageLogger,
+}));
+
+vi.mock("@pagopa/dx-tasks/default-dispatcher", () => ({
+  createDefaultTaskDispatcher: dispatcherMocks.createDefaultTaskDispatcher,
+}));
+
+import executor from "../release-apply.ts";
+
+const baseContext: ExecutorContext = {
+  cwd: process.cwd(),
+  isVerbose: false,
+  nxJsonConfiguration: {},
+  projectGraph: {
+    dependencies: {},
+    nodes: {},
+  },
+  projectsConfigurations: {
+    projects: {},
+    version: 2,
+  },
+  root: "",
+};
+
+describe("Release Apply Executor", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  afterEach(() => {
+    vi.unstubAllEnvs();
+  });
+
+  it("dispatches terraformApply with the project root as module path", async () => {
+    const options: ReleaseApplyExecutorSchema = {
+      dryRun: false,
+      projectRoot: "infra/resources/prod",
+      report: true,
+      sensitiveKeys: ["hidden-link"],
+      verbose: false,
+    };
+
+    const output = await executor(options, baseContext);
+
+    expect(output.success).toBe(true);
+    expect(loggerMocks.configureLogger).toHaveBeenCalledTimes(1);
+    expect(dispatcherMocks.createDefaultTaskDispatcher).toHaveBeenCalledTimes(
+      1,
+    );
+    expect(dispatcherMocks.dispatchTask).toHaveBeenCalledWith(
+      "terraformApply",
+      {
+        modulePath: "infra/resources/prod",
+        report: true,
+        sensitiveKeys: ["hidden-link"],
+        verbose: false,
+      },
+    );
+    expect(loggerMocks.getPackageLogger).toHaveBeenCalledWith([
+      "release-apply",
+    ]);
+  });
+
+  it("does not dispatch terraformApply when the executor is a dry run", async () => {
+    const options: ReleaseApplyExecutorSchema = {
+      dryRun: true,
+      projectRoot: "infra/resources/prod",
+      report: false,
+      sensitiveKeys: [],
+      verbose: false,
+    };
+
+    const output = await executor(options, baseContext);
+
+    expect(output.success).toBe(true);
+    expect(dispatcherMocks.createDefaultTaskDispatcher).not.toHaveBeenCalled();
+    expect(dispatcherMocks.dispatchTask).not.toHaveBeenCalled();
+    expect(loggerMocks.info).toHaveBeenCalledWith(
+      "Skipping Terraform apply during release dry run",
+      {
+        projectRoot: "infra/resources/prod",
+      },
+    );
+  });
+
+  it("does not dispatch terraformApply when Nx sets dry-run mode", async () => {
+    vi.stubEnv("NX_DRY_RUN", "true");
+    const options = {
+      projectRoot: "infra/resources/prod",
+    } satisfies Partial<ReleaseApplyExecutorSchema>;
+
+    const output = await executor(options, baseContext);
+
+    expect(output.success).toBe(true);
+    expect(dispatcherMocks.createDefaultTaskDispatcher).not.toHaveBeenCalled();
+    expect(dispatcherMocks.dispatchTask).not.toHaveBeenCalled();
+  });
+
+  it("applies default options when only projectRoot is provided", async () => {
+    const options = {
+      projectRoot: "infra/resources/prod",
+    } satisfies Partial<ReleaseApplyExecutorSchema>;
+
+    const output = await executor(options, baseContext);
+
+    expect(output.success).toBe(true);
+    expect(dispatcherMocks.dispatchTask).toHaveBeenCalledWith(
+      "terraformApply",
+      {
+        modulePath: "infra/resources/prod",
+        report: false,
+        sensitiveKeys: [],
+        verbose: false,
+      },
+    );
+  });
+
+  it("fails when projectRoot is missing", async () => {
+    const options = {} satisfies Partial<ReleaseApplyExecutorSchema>;
+
+    const output = await executor(options, baseContext);
+
+    expect(output.success).toBe(false);
+    expect(loggerMocks.configureLogger).toHaveBeenCalledTimes(1);
+    expect(loggerMocks.warn).toHaveBeenCalledWith(
+      "Invalid release-apply options",
+      expect.objectContaining({
+        issues: expect.arrayContaining([
+          expect.objectContaining({
+            path: ["projectRoot"],
+          }),
+        ]),
+        path: "release-apply options",
+      }),
+    );
+    expect(dispatcherMocks.dispatchTask).not.toHaveBeenCalled();
+  });
+});

--- a/packages/nx-terraform-plugin/src/executors/release-apply/release-apply.ts
+++ b/packages/nx-terraform-plugin/src/executors/release-apply/release-apply.ts
@@ -1,0 +1,67 @@
+import { PromiseExecutor } from "@nx/devkit";
+import { createDefaultTaskDispatcher } from "@pagopa/dx-tasks/default-dispatcher";
+import { z } from "zod/v4";
+
+import { configureLogger, getPackageLogger } from "../../logger.ts";
+import {
+  type ReleaseApplyExecutorInput,
+  releaseApplyExecutorSchema,
+} from "./schema.ts";
+
+const nxDryRunSchema = z.enum(["false", "true"]).optional();
+
+const runExecutor: PromiseExecutor<ReleaseApplyExecutorInput> = async (
+  options,
+) => {
+  const logger = getPackageLogger(["release-apply"]);
+  const parseResult = releaseApplyExecutorSchema.safeParse(options);
+  const nxDryRunParseResult = nxDryRunSchema.safeParse(process.env.NX_DRY_RUN);
+
+  await configureLogger();
+
+  if (!parseResult.success) {
+    logger.warn("Invalid release-apply options", {
+      issues: parseResult.error.issues,
+      path: options?.projectRoot ?? "release-apply options",
+    });
+    return {
+      success: false,
+    };
+  }
+
+  if (!nxDryRunParseResult.success) {
+    logger.warn("Invalid NX_DRY_RUN environment variable", {
+      issues: nxDryRunParseResult.error.issues,
+    });
+    return {
+      success: false,
+    };
+  }
+
+  const { dryRun, projectRoot, report, sensitiveKeys, verbose } =
+    parseResult.data;
+
+  if (dryRun || nxDryRunParseResult.data === "true") {
+    logger.info("Skipping Terraform apply during release dry run", {
+      projectRoot,
+    });
+    return {
+      success: true,
+    };
+  }
+
+  const dispatcher = createDefaultTaskDispatcher();
+
+  await dispatcher.dispatchTask("terraformApply", {
+    modulePath: projectRoot,
+    report,
+    sensitiveKeys,
+    verbose,
+  });
+
+  return {
+    success: true,
+  };
+};
+
+export default runExecutor;

--- a/packages/nx-terraform-plugin/src/executors/release-apply/schema.json
+++ b/packages/nx-terraform-plugin/src/executors/release-apply/schema.json
@@ -1,25 +1,21 @@
 {
   "$schema": "https://json-schema.org/schema",
   "version": 2,
-  "title": "Plan executor",
-  "description": "Runs terraform plan for a Terraform project through @pagopa/dx-tasks",
+  "title": "Release apply executor",
+  "description": "Downloads the previously uploaded terraform plan bundle and applies it, through @pagopa/dx-tasks. Intended to be assigned to the nx-release-publish target of deployable Terraform environment projects.",
   "type": "object",
   "properties": {
+    "dryRun": {
+      "description": "Whether to skip applying infrastructure and only preview the release",
+      "type": "boolean",
+      "default": false
+    },
     "projectRoot": {
       "description": "Terraform project root used as the module path",
       "type": "string"
     },
-    "out": {
-      "description": "Optional path passed to terraform plan -out",
-      "type": "string"
-    },
-    "refresh": {
-      "description": "Whether to refresh state before planning",
-      "type": "boolean",
-      "default": true
-    },
     "report": {
-      "description": "Whether to write a dx-tasks JSON report of the plan output",
+      "description": "Whether to write a dx-tasks JSON report of the apply output",
       "type": "boolean",
       "default": false
     },
@@ -33,7 +29,7 @@
       "default": []
     },
     "verbose": {
-      "description": "Whether to print the full terraform plan output",
+      "description": "Whether to print the full terraform apply output",
       "type": "boolean",
       "default": false
     }

--- a/packages/nx-terraform-plugin/src/executors/release-apply/schema.ts
+++ b/packages/nx-terraform-plugin/src/executors/release-apply/schema.ts
@@ -1,0 +1,15 @@
+import { z } from "zod/v4";
+
+export const releaseApplyExecutorSchema = z.object({
+  dryRun: z.boolean().default(false),
+  projectRoot: z.string().min(1),
+  report: z.boolean().default(false),
+  sensitiveKeys: z.array(z.string().min(1)).default([]),
+  verbose: z.boolean().default(false),
+});
+
+export type ReleaseApplyExecutorInput = Partial<ReleaseApplyExecutorSchema>;
+
+export type ReleaseApplyExecutorSchema = z.infer<
+  typeof releaseApplyExecutorSchema
+>;

--- a/packages/nx-terraform-plugin/src/options.ts
+++ b/packages/nx-terraform-plugin/src/options.ts
@@ -29,8 +29,10 @@ const terraformPluginOptionsSchema = z.object({
   lintTargetName: targetNameSchema,
   outputTargetName: targetNameSchema,
   planTargetName: targetNameSchema,
+  planUploadTargetName: targetNameSchema,
   publish: publishOptionsSchema,
   publishTargetName: targetNameSchema,
+  sensitiveOutputKeys: z.array(z.string().min(1)),
   testTargetName: targetNameSchema,
   validateTargetName: targetNameSchema,
 });
@@ -49,10 +51,12 @@ const defaultOptions: TerraformPluginOptions = {
   lintTargetName: "tflint",
   outputTargetName: "tf-output",
   planTargetName: "tf-plan",
+  planUploadTargetName: "tf-plan-upload",
   publish: {
     mode: "github",
   },
   publishTargetName: "nx-release-publish",
+  sensitiveOutputKeys: [],
   testTargetName: "tf-test",
   validateTargetName: "tf-validate",
 };

--- a/packages/nx-terraform-plugin/src/project.ts
+++ b/packages/nx-terraform-plugin/src/project.ts
@@ -273,6 +273,7 @@ const getTargets = (
             projectRoot: "{projectRoot}",
             refresh: true,
             report: false,
+            sensitiveKeys: opts.sensitiveOutputKeys,
             verbose: true,
           },
         },

--- a/packages/nx-terraform-plugin/src/project.ts
+++ b/packages/nx-terraform-plugin/src/project.ts
@@ -103,6 +103,29 @@ const getPublishTarget = (
   }
 };
 
+const getPlanTarget = (
+  opts: TerraformPluginOptions,
+  executor: string,
+): TargetConfiguration => ({
+  cache: false,
+  configurations: {
+    ci: {
+      refresh: true,
+      report: true,
+      verbose: false,
+    },
+  },
+  dependsOn: [opts.initTargetName],
+  executor,
+  options: {
+    projectRoot: "{projectRoot}",
+    refresh: true,
+    report: false,
+    sensitiveKeys: opts.sensitiveOutputKeys,
+    verbose: true,
+  },
+});
+
 const getTargets = (
   opts: TerraformPluginOptions,
   root: string,
@@ -258,25 +281,11 @@ const getTargets = (
     targets.push(
       [
         opts.planTargetName,
-        {
-          cache: false,
-          configurations: {
-            ci: {
-              refresh: true,
-              report: true,
-              verbose: false,
-            },
-          },
-          dependsOn: [opts.initTargetName],
-          executor: "@pagopa/nx-terraform-plugin:plan",
-          options: {
-            projectRoot: "{projectRoot}",
-            refresh: true,
-            report: false,
-            sensitiveKeys: opts.sensitiveOutputKeys,
-            verbose: true,
-          },
-        },
+        getPlanTarget(opts, "@pagopa/nx-terraform-plugin:plan"),
+      ],
+      [
+        opts.planUploadTargetName,
+        getPlanTarget(opts, "@pagopa/nx-terraform-plugin:plan-upload"),
       ],
       [
         opts.applyTargetName,

--- a/packages/nx-terraform-plugin/tsdown.config.ts
+++ b/packages/nx-terraform-plugin/tsdown.config.ts
@@ -6,8 +6,12 @@ export default defineConfig({
   },
   dts: false,
   entry: {
+    "executors/plan-upload/plan-upload":
+      "src/executors/plan-upload/plan-upload.ts",
     "executors/plan/plan": "src/executors/plan/plan.ts",
     "executors/publish/publish": "src/executors/publish/publish.ts",
+    "executors/release-apply/release-apply":
+      "src/executors/release-apply/release-apply.ts",
     index: "src/index.ts",
     "release/version-actions": "src/release/version-actions.ts",
   },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1210,6 +1210,15 @@ importers:
 
   packages/nx-terraform-plugin:
     dependencies:
+      '@aws-sdk/client-s3':
+        specifier: catalog:aws
+        version: 3.1075.0
+      '@azure/identity':
+        specifier: 'catalog:'
+        version: 4.13.1
+      '@azure/storage-blob':
+        specifier: catalog:azure
+        version: 12.33.0
       '@logtape/logtape':
         specifier: 'catalog:'
         version: 1.3.11


### PR DESCRIPTION
## Why

The release workflow needs reusable, tested primitives for persisting a Terraform plan and later applying that exact reviewed plan.

## What changed

- Add `terraformPlanUpload` and `terraformApply` tasks to `@pagopa/dx-tasks`.
- Add `plan-upload` and `release-apply` executors to the Terraform Nx plugin.
- Support configurable sensitive Terraform output keys across plan and apply execution.
- Publish compiled dx-tasks entry points and declare the plugin runtime dependencies required by bundled task code.
- Rebuild committed plugin artifacts and add version plans.

This PR adds execution capabilities only; it does not discover releasable environments or dispatch deployments.

## Validation

- `pnpm nx run-many -t test lint typecheck -p @pagopa/dx-tasks @pagopa/nx-terraform-plugin`
- `pnpm nx run @pagopa/nx-terraform-plugin:build`

Depends on #1993.

Extracted from #1926.