### PR TITLE
Support releasable Terraform environments

### DIFF
--- a/.nx/version-plans/version-plan-1784226868463.md
+++ b/.nx/version-plans/version-plan-1784226868463.md
@@ -1,0 +1,5 @@
+---
+'@pagopa/nx-terraform-plugin': minor
+---
+
+Support versioned Terraform environment projects through environment.json manifests.

--- a/packages/nx-terraform-plugin/dist/index.js
+++ b/packages/nx-terraform-plugin/dist/index.js
@@ -27,6 +27,34 @@ const parseModulePublishManifest = (input) => {
 	}
 	return parseResult.data;
 };
+const environmentManifestSchema = z.object({
+	deployment: z.object({
+		applyEnvironment: z.string().min(1),
+		planEnvironment: z.string().min(1),
+		runnerLabel: z.string().min(1)
+	}).optional(),
+	version: z.string().min(1)
+});
+var EnvironmentManifestError = class extends Error {
+	issues;
+	reasons;
+	constructor(issues, reasons) {
+		super(reasons.join("; "));
+		this.issues = issues;
+		this.reasons = reasons;
+		this.name = "EnvironmentManifestError";
+	}
+};
+const parseEnvironmentManifest = (input) => {
+	const parseResult = environmentManifestSchema.safeParse(input);
+	if (!parseResult.success) {
+		const reasons = parseResult.error.issues.map((issue) => {
+			return `${issue.path.join(".")}: ${issue.message}`;
+		});
+		throw new EnvironmentManifestError(parseResult.error.issues, reasons);
+	}
+	return parseResult.data;
+};
 
 //#endregion
 //#region src/discovery.ts
@@ -43,6 +71,28 @@ const readModulePublishManifest = async (moduleRoot) => {
 			return;
 		}
 		if (error instanceof ModulePublishManifestError) {
+			logger.warn("Invalid manifest file", {
+				issues: error.issues,
+				path: manifestPath
+			});
+			return;
+		}
+		throw error;
+	}
+};
+const readEnvironmentManifest = async (environmentRoot) => {
+	const manifestPath = path.join(environmentRoot, "environment.json");
+	const logger = getPackageLogger(["discovery"]);
+	try {
+		const rawManifest = await fs.readFile(manifestPath, "utf-8");
+		return parseEnvironmentManifest(JSON.parse(rawManifest));
+	} catch (error) {
+		if (typeof error === "object" && error !== null && "code" in error && error.code === "ENOENT") return;
+		if (error instanceof SyntaxError) {
+			logger.warn(`Invalid environment manifest at ${manifestPath}. ${error.message}`);
+			return;
+		}
+		if (error instanceof EnvironmentManifestError) {
 			logger.warn("Invalid manifest file", {
 				issues: error.issues,
 				path: manifestPath
@@ -101,7 +151,34 @@ const getPublishTarget = (opts, root, publishManifest) => {
 		throw error;
 	}
 };
-const getTargets = (opts, root, projectType, hasRootTflintConfig, publishManifest) => {
+const getEnvironmentReleaseTargets = (opts) => [[opts.planUploadTargetName, {
+	cache: false,
+	configurations: { ci: {
+		refresh: true,
+		report: true,
+		verbose: false
+	} },
+	dependsOn: [opts.initTargetName],
+	executor: "@pagopa/nx-terraform-plugin:plan-upload",
+	options: {
+		projectRoot: "{projectRoot}",
+		refresh: true,
+		report: false,
+		sensitiveKeys: opts.sensitiveOutputKeys,
+		verbose: true
+	}
+}], [opts.publishTargetName, {
+	cache: false,
+	dependsOn: [opts.initTargetName],
+	executor: "@pagopa/nx-terraform-plugin:release-apply",
+	options: {
+		projectRoot: "{projectRoot}",
+		report: false,
+		sensitiveKeys: opts.sensitiveOutputKeys,
+		verbose: true
+	}
+}]];
+const getTargets = (opts, root, projectType, hasRootTflintConfig, publishManifest, environmentManifest) => {
 	const rootTflintConfigPath = getRootConfigPath(root, ".tflint.hcl");
 	const formatArgs = ["-list=true", "-recursive=true"];
 	const cwd = "{projectRoot}";
@@ -194,37 +271,41 @@ const getTargets = (opts, root, projectType, hasRootTflintConfig, publishManifes
 		dependsOn: [opts.initTargetName],
 		options: { cwd }
 	}]);
-	if (projectType === "application") targets.push([opts.planTargetName, {
-		cache: false,
-		configurations: { ci: {
-			refresh: true,
-			report: true,
-			verbose: false
-		} },
-		dependsOn: [opts.initTargetName],
-		executor: "@pagopa/nx-terraform-plugin:plan",
-		options: {
-			projectRoot: "{projectRoot}",
-			refresh: true,
-			report: false,
-			sensitiveKeys: opts.sensitiveOutputKeys,
-			verbose: true
-		}
-	}], [opts.applyTargetName, {
-		cache: false,
-		command: `terraform apply`,
-		dependsOn: [opts.initTargetName],
-		options: {
-			cwd,
-			tty: true
-		}
-	}]);
+	if (projectType === "application") {
+		targets.push([opts.planTargetName, {
+			cache: false,
+			configurations: { ci: {
+				refresh: true,
+				report: true,
+				verbose: false
+			} },
+			dependsOn: [opts.initTargetName],
+			executor: "@pagopa/nx-terraform-plugin:plan",
+			options: {
+				projectRoot: "{projectRoot}",
+				refresh: true,
+				report: false,
+				sensitiveKeys: opts.sensitiveOutputKeys,
+				verbose: true
+			}
+		}], [opts.applyTargetName, {
+			cache: false,
+			command: `terraform apply`,
+			dependsOn: [opts.initTargetName],
+			options: {
+				cwd,
+				tty: true
+			}
+		}]);
+		if (environmentManifest) targets.push(...getEnvironmentReleaseTargets(opts));
+	}
 	return Object.fromEntries(targets);
 };
-const getProject = (opts, root, hasRootTflintConfig = false, publishManifest = void 0) => {
+const getProject = (opts, root, hasRootTflintConfig = false, publishManifest = void 0, environmentManifest = void 0) => {
 	const projectType = getProjectType(root);
 	const isPublishableLibrary = projectType === "library" && publishManifest !== void 0;
-	const targets = getTargets(opts, root, projectType, hasRootTflintConfig, publishManifest);
+	const isReleasableEnvironment = projectType === "application" && environmentManifest !== void 0;
+	const targets = getTargets(opts, root, projectType, hasRootTflintConfig, publishManifest, environmentManifest);
 	const environmentTag = projectType === "application" ? getEnvironmentTag(root, opts.additionalEnvironments) : void 0;
 	const tags = ["terraform", ...environmentTag ? [environmentTag] : []];
 	if (isPublishableLibrary) tags.push("terraform:public");
@@ -240,7 +321,7 @@ const getProject = (opts, root, hasRootTflintConfig = false, publishManifest = v
 		tags,
 		targets
 	};
-	if (isPublishableLibrary) config.release = { version: {
+	if (isPublishableLibrary || isReleasableEnvironment) config.release = { version: {
 		currentVersionResolver: "disk",
 		manifestRootsToUpdate: ["{projectRoot}"],
 		versionActions: "@pagopa/nx-terraform-plugin/release/version-actions"
@@ -369,6 +450,7 @@ const ignoreModules = [
 	"example"
 ];
 const moduleManifestFileName = "module.json";
+const environmentManifestFileName = "environment.json";
 const isIgnoredRoot = (root) => {
 	const rootSegments = new Set(root.split(path.sep));
 	return ignoreModules.some((module) => rootSegments.has(module));
@@ -385,16 +467,23 @@ const fileExists = async (filePath) => {
 const getDiscoveryState = (configFiles) => {
 	const terraformConfigFiles = [];
 	const moduleManifestRoots = /* @__PURE__ */ new Set();
+	const environmentManifestRoots = /* @__PURE__ */ new Set();
 	for (const configFile of configFiles) {
 		const root = path.dirname(configFile);
 		if (isIgnoredRoot(root)) continue;
-		if (path.basename(configFile) === moduleManifestFileName) {
+		const fileName = path.basename(configFile);
+		if (fileName === moduleManifestFileName) {
 			moduleManifestRoots.add(root);
+			continue;
+		}
+		if (fileName === environmentManifestFileName) {
+			environmentManifestRoots.add(root);
 			continue;
 		}
 		terraformConfigFiles.push(configFile);
 	}
 	return {
+		environmentManifestRoots,
 		moduleManifestRoots,
 		terraformConfigFiles
 	};
@@ -406,22 +495,31 @@ const getPublishableManifestByRoot = async (moduleManifestRoots, workspaceRoot) 
 	}));
 	return new Map(validationResults.filter((rootManifest) => rootManifest !== null));
 };
+const getEnvironmentManifestByRoot = async (environmentManifestRoots, workspaceRoot) => {
+	const validationResults = await Promise.all(environmentManifestRoots.map(async (root) => {
+		const manifest = await readEnvironmentManifest(path.join(workspaceRoot, root));
+		return manifest ? [root, manifest] : null;
+	}));
+	return new Map(validationResults.filter((rootManifest) => rootManifest !== null));
+};
 const getDiscoveryStateWithValidation = async (configFiles, workspaceRoot) => {
-	const { moduleManifestRoots, terraformConfigFiles } = getDiscoveryState(configFiles);
+	const { environmentManifestRoots, moduleManifestRoots, terraformConfigFiles } = getDiscoveryState(configFiles);
+	const publishableManifestByRoot = await getPublishableManifestByRoot(Array.from(moduleManifestRoots), workspaceRoot);
 	return {
-		publishableManifestByRoot: await getPublishableManifestByRoot(Array.from(moduleManifestRoots), workspaceRoot),
+		environmentManifestByRoot: await getEnvironmentManifestByRoot(Array.from(environmentManifestRoots), workspaceRoot),
+		publishableManifestByRoot,
 		terraformConfigFiles
 	};
 };
-const createNodesV2 = ["**/{*.tf,module.json}", async (configFiles, options, context) => {
+const createNodesV2 = ["**/{*.tf,module.json,environment.json}", async (configFiles, options, context) => {
 	await configureLogger();
 	const opts = parseOptions(options);
 	const hasRootTflintConfig = await fileExists(path.join(context.workspaceRoot, ".tflint.hcl"));
-	const { publishableManifestByRoot, terraformConfigFiles } = await getDiscoveryStateWithValidation(configFiles, context.workspaceRoot);
+	const { environmentManifestByRoot, publishableManifestByRoot, terraformConfigFiles } = await getDiscoveryStateWithValidation(configFiles, context.workspaceRoot);
 	return createNodesFromFiles((configFile) => {
 		const root = path.dirname(configFile);
 		if (isIgnoredRoot(root)) return { projects: {} };
-		return { projects: { [root]: getProject(opts, root, hasRootTflintConfig, publishableManifestByRoot.get(root)) } };
+		return { projects: { [root]: getProject(opts, root, hasRootTflintConfig, publishableManifestByRoot.get(root), environmentManifestByRoot.get(root)) } };
 	}, terraformConfigFiles, options, context);
 }];
 const createDependencies = async (opts, ctx) => {
@@ -430,4 +528,4 @@ const createDependencies = async (opts, ctx) => {
 };
 
 //#endregion
-export { createDependencies, createNodesV2, getDiscoveryState, getDiscoveryStateWithValidation, getPublishableManifestByRoot };
+export { createDependencies, createNodesV2, getDiscoveryState, getDiscoveryStateWithValidation, getEnvironmentManifestByRoot, getPublishableManifestByRoot };

--- a/packages/nx-terraform-plugin/dist/release/version-actions.js
+++ b/packages/nx-terraform-plugin/dist/release/version-actions.js
@@ -1,15 +1,20 @@
 import { VersionActions } from "nx/release";
 
 //#region src/release/version-actions.ts
+const moduleManifestFilename = "module.json";
+const environmentManifestFilename = "environment.json";
 /**
-* Custom Nx Release VersionActions implementation for Terraform modules.
+* Custom Nx Release VersionActions implementation for Terraform projects.
 *
-* This class manages versioning of publishable Terraform modules by reading
-* and writing the `version` field in module.json files.
+* This class manages versioning of both publishable Terraform modules and
+* deployable Terraform environments by reading and writing the `version`
+* field in a project-type-specific manifest file:
+* - Library modules (publishable Terraform modules): `module.json`
+* - Application projects (deployable environments): `environment.json`
 *
 * Key behaviors:
-* - Reads current version from module.json (disk-based resolution)
-* - Updates version in module.json during release
+* - Reads current version from the manifest file (disk-based resolution)
+* - Updates version in the manifest file during release
 * - Does NOT support registry-based version resolution
 * - Does NOT manage module dependencies (explicit no-op)
 *
@@ -18,7 +23,7 @@ import { VersionActions } from "nx/release";
 * in inferred Terraform project configuration.
 */
 var TerraformVersionActions = class extends VersionActions {
-	validManifestFilenames = ["module.json"];
+	validManifestFilenames = [this.getManifestFilename()];
 	/**
 	* Registry-based version resolution is not supported for Terraform modules.
 	*
@@ -34,10 +39,11 @@ var TerraformVersionActions = class extends VersionActions {
 		return null;
 	}
 	/**
-	* Reads the current version from the module.json manifest file.
+	* Reads the current version from the manifest file (module.json for
+	* libraries, environment.json for applications).
 	*
 	* Returns null if:
-	* - The module.json file does not exist
+	* - The manifest file does not exist
 	* - The file is invalid JSON
 	* - The version field is missing or not a string
 	*
@@ -45,7 +51,7 @@ var TerraformVersionActions = class extends VersionActions {
 	* @returns An object with the current version and manifest path, or null
 	*/
 	async readCurrentVersionFromSourceManifest(tree) {
-		const manifestPath = `${this.projectGraphNode.data.root}/module.json`;
+		const manifestPath = `${this.projectGraphNode.data.root}/${this.getManifestFilename()}`;
 		if (!tree.exists(manifestPath)) return null;
 		try {
 			const content = tree.read(manifestPath, "utf-8");
@@ -89,7 +95,8 @@ var TerraformVersionActions = class extends VersionActions {
 		return [];
 	}
 	/**
-	* Updates the version field in the module.json file.
+	* Updates the version field in the manifest file (module.json for
+	* libraries, environment.json for applications).
 	*
 	* Preserves:
 	* - Field order in the JSON object
@@ -101,7 +108,7 @@ var TerraformVersionActions = class extends VersionActions {
 	* @returns An array with a single log message describing the update
 	*/
 	async updateProjectVersion(tree, newVersion) {
-		const manifestPath = `${this.projectGraphNode.data.root}/module.json`;
+		const manifestPath = `${this.projectGraphNode.data.root}/${this.getManifestFilename()}`;
 		const content = tree.read(manifestPath, "utf-8");
 		if (!content) throw new Error(`Failed to read ${manifestPath}`);
 		let manifest;
@@ -114,6 +121,14 @@ var TerraformVersionActions = class extends VersionActions {
 		manifest.version = newVersion;
 		tree.write(manifestPath, JSON.stringify(manifest, null, 2) + "\n");
 		return [`Updated ${this.projectGraphNode.name} version to ${newVersion} in ${manifestPath}`];
+	}
+	/**
+	* Returns the manifest filename to use for this project, based on its
+	* Nx project type: "environment.json" for applications, "module.json"
+	* for libraries.
+	*/
+	getManifestFilename() {
+		return this.projectGraphNode.data.projectType === "application" ? environmentManifestFilename : moduleManifestFilename;
 	}
 };
 

--- a/packages/nx-terraform-plugin/package.json
+++ b/packages/nx-terraform-plugin/package.json
@@ -54,6 +54,7 @@
     "@nx/devkit": "^22.7.6",
     "@octokit/auth-app": "^8.2.0",
     "execa": "catalog:",
+    "nx": "^22.7.1",
     "octokit": "catalog:",
     "semver": "catalog:",
     "tslib": "^2.8.1",

--- a/packages/nx-terraform-plugin/src/__tests__/environment-discovery.test.ts
+++ b/packages/nx-terraform-plugin/src/__tests__/environment-discovery.test.ts
@@ -1,0 +1,70 @@
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+
+import { readEnvironmentManifest } from "../discovery.ts";
+
+describe("readEnvironmentManifest", () => {
+  const createdDirs: string[] = [];
+
+  afterEach(async () => {
+    await Promise.all(
+      createdDirs
+        .splice(0)
+        .map((directory) => fs.rm(directory, { force: true, recursive: true })),
+    );
+  });
+
+  it("returns the parsed manifest when environment.json exists and is valid", async () => {
+    const root = await fs.mkdtemp(
+      path.join(os.tmpdir(), "terraform-environment-"),
+    );
+    createdDirs.push(root);
+    const manifest = { version: "0.1.0" };
+    await fs.writeFile(
+      path.join(root, "environment.json"),
+      JSON.stringify(manifest),
+      "utf-8",
+    );
+
+    await expect(readEnvironmentManifest(root)).resolves.toEqual(manifest);
+  });
+
+  it("returns undefined when environment.json does not exist", async () => {
+    const root = await fs.mkdtemp(
+      path.join(os.tmpdir(), "terraform-environment-"),
+    );
+    createdDirs.push(root);
+
+    await expect(readEnvironmentManifest(root)).resolves.toBeUndefined();
+  });
+
+  it("returns undefined and warns when environment.json is invalid JSON", async () => {
+    const root = await fs.mkdtemp(
+      path.join(os.tmpdir(), "terraform-environment-"),
+    );
+    createdDirs.push(root);
+    await fs.writeFile(
+      path.join(root, "environment.json"),
+      "{ invalid json }",
+      "utf-8",
+    );
+
+    await expect(readEnvironmentManifest(root)).resolves.toBeUndefined();
+  });
+
+  it("returns undefined when environment.json is missing the version field", async () => {
+    const root = await fs.mkdtemp(
+      path.join(os.tmpdir(), "terraform-environment-"),
+    );
+    createdDirs.push(root);
+    await fs.writeFile(
+      path.join(root, "environment.json"),
+      JSON.stringify({}),
+      "utf-8",
+    );
+
+    await expect(readEnvironmentManifest(root)).resolves.toBeUndefined();
+  });
+});

--- a/packages/nx-terraform-plugin/src/__tests__/environment-manifest.test.ts
+++ b/packages/nx-terraform-plugin/src/__tests__/environment-manifest.test.ts
@@ -1,0 +1,70 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  EnvironmentManifestError,
+  environmentManifestSchema,
+  parseEnvironmentManifest,
+} from "../manifest.ts";
+
+describe("parseEnvironmentManifest", () => {
+  it("parses a valid environment.json manifest", () => {
+    const manifest = {
+      deployment: {
+        applyEnvironment: "infra-dev-cd",
+        planEnvironment: "infra-dev-ci",
+        runnerLabel: "dev",
+      },
+      version: "0.1.0",
+    };
+
+    expect(parseEnvironmentManifest(manifest)).toEqual(manifest);
+  });
+
+  it("throws for environment.json missing version", () => {
+    expect(() =>
+      parseEnvironmentManifest({
+        deployment: {
+          applyEnvironment: "infra-dev-cd",
+          planEnvironment: "infra-dev-ci",
+          runnerLabel: "dev",
+        },
+      }),
+    ).toThrowError(EnvironmentManifestError);
+  });
+
+  it("throws for environment.json with an empty version", () => {
+    const invalidManifest = {
+      deployment: {
+        applyEnvironment: "infra-dev-cd",
+        planEnvironment: "infra-dev-ci",
+        runnerLabel: "dev",
+      },
+      version: "",
+    };
+    const parseResult = environmentManifestSchema.safeParse(invalidManifest);
+    expect(parseResult.success).toBe(false);
+    if (parseResult.success) {
+      return;
+    }
+
+    const thrownError = (() => {
+      try {
+        parseEnvironmentManifest(invalidManifest);
+        return undefined;
+      } catch (error) {
+        return error;
+      }
+    })();
+
+    expect(thrownError).toBeInstanceOf(EnvironmentManifestError);
+    expect(thrownError).toMatchObject({
+      issues: parseResult.error.issues,
+    });
+  });
+
+  it("parses environment.json without deployment overrides", () => {
+    expect(parseEnvironmentManifest({ version: "0.1.0" })).toEqual({
+      version: "0.1.0",
+    });
+  });
+});

--- a/packages/nx-terraform-plugin/src/__tests__/index.test.ts
+++ b/packages/nx-terraform-plugin/src/__tests__/index.test.ts
@@ -28,8 +28,8 @@ import { createNodesV2, getDiscoveryStateWithValidation } from "../index.ts";
 import { parseOptions } from "../options.ts";
 
 describe("createNodesV2", () => {
-  it("discovers both terraform and module manifests", () => {
-    expect(createNodesV2[0]).toBe("**/{*.tf,module.json}");
+  it("discovers terraform files, module manifests, and environment manifests", () => {
+    expect(createNodesV2[0]).toBe("**/{*.tf,module.json,environment.json}");
   });
 });
 

--- a/packages/nx-terraform-plugin/src/__tests__/project.test.ts
+++ b/packages/nx-terraform-plugin/src/__tests__/project.test.ts
@@ -55,6 +55,10 @@ const publishManifestWithOwner = {
   },
 };
 
+const environmentManifest = {
+  version: "0.1.0",
+};
+
 const getExpectedLintTarget = (root: string) => ({
   cache: true,
   command: "tflint",
@@ -335,6 +339,66 @@ describe("getProject applications", () => {
       expect(project.tags).toEqual(["terraform", "env:prod"]);
     });
   });
+
+  describe("when the application has an environment.json manifest", () => {
+    it("adds tf-plan-upload and nx-release-publish targets", () => {
+      const root = path.join("infra", "resources", "dev");
+      const targets = getTargetsOrThrow(
+        getProject(defaultOptions, root, false, undefined, environmentManifest),
+      );
+
+      expect(Object.keys(targets)).toEqual([
+        "tf-init",
+        "tf-fmt",
+        "tf-test",
+        "tf-validate",
+        "tf-console",
+        "tf-output",
+        "tf-plan",
+        "tf-apply",
+        "tf-plan-upload",
+        "nx-release-publish",
+      ]);
+      expect(targets["tf-plan-upload"]).toEqual({
+        cache: false,
+        configurations: {
+          ci: {
+            refresh: true,
+            report: true,
+            verbose: false,
+          },
+        },
+        dependsOn: ["tf-init"],
+        executor: "@pagopa/nx-terraform-plugin:plan-upload",
+        options: {
+          projectRoot: "{projectRoot}",
+          refresh: true,
+          report: false,
+          sensitiveKeys: [],
+          verbose: true,
+        },
+      });
+      expect(targets["nx-release-publish"]).toEqual({
+        cache: false,
+        dependsOn: ["tf-init"],
+        executor: "@pagopa/nx-terraform-plugin:release-apply",
+        options: {
+          projectRoot: "{projectRoot}",
+          report: false,
+          sensitiveKeys: [],
+          verbose: true,
+        },
+      });
+    });
+
+    it("does not add tf-plan-upload or nx-release-publish without a manifest", () => {
+      const root = path.join("infra", "resources", "dev");
+      const targets = getTargetsOrThrow(getProject(defaultOptions, root));
+
+      expect(targets["tf-plan-upload"]).toBeUndefined();
+      expect(targets["nx-release-publish"]).toBeUndefined();
+    });
+  });
 });
 
 describe("getProject libraries", () => {
@@ -583,6 +647,31 @@ describe("getProject release configuration", () => {
         true,
         publishManifestWithOwner,
       );
+
+      expect(project.release).toBeUndefined();
+    });
+
+    it("infers release.version config for applications with an environment.json manifest", () => {
+      const root = path.join("infra", "resources", "dev");
+      const project = getProject(
+        defaultOptions,
+        root,
+        false,
+        undefined,
+        environmentManifest,
+      );
+
+      expect(project.release).toBeDefined();
+      expect(project.release?.version).toEqual({
+        currentVersionResolver: "disk",
+        manifestRootsToUpdate: ["{projectRoot}"],
+        versionActions: "@pagopa/nx-terraform-plugin/release/version-actions",
+      });
+    });
+
+    it("does not infer release config for applications without an environment.json manifest", () => {
+      const root = path.join("infra", "resources", "dev");
+      const project = getProject(defaultOptions, root);
 
       expect(project.release).toBeUndefined();
     });

--- a/packages/nx-terraform-plugin/src/discovery.ts
+++ b/packages/nx-terraform-plugin/src/discovery.ts
@@ -3,8 +3,11 @@ import path from "node:path";
 
 import { getPackageLogger } from "./logger.ts";
 import {
+  EnvironmentManifest,
+  EnvironmentManifestError,
   ModulePublishManifest,
   ModulePublishManifestError,
+  parseEnvironmentManifest,
   parseModulePublishManifest,
 } from "./manifest.ts";
 
@@ -48,4 +51,38 @@ export const hasPublishableModuleManifest = async (
 ): Promise<boolean> => {
   const manifest = await readModulePublishManifest(moduleRoot);
   return manifest !== undefined;
+};
+
+export const readEnvironmentManifest = async (
+  environmentRoot: string,
+): Promise<EnvironmentManifest | undefined> => {
+  const manifestPath = path.join(environmentRoot, "environment.json");
+  const logger = getPackageLogger(["discovery"]);
+  try {
+    const rawManifest = await fs.readFile(manifestPath, "utf-8");
+    return parseEnvironmentManifest(JSON.parse(rawManifest));
+  } catch (error) {
+    if (
+      typeof error === "object" &&
+      error !== null &&
+      "code" in error &&
+      error.code === "ENOENT"
+    ) {
+      return undefined;
+    }
+    if (error instanceof SyntaxError) {
+      logger.warn(
+        `Invalid environment manifest at ${manifestPath}. ${error.message}`,
+      );
+      return undefined;
+    }
+    if (error instanceof EnvironmentManifestError) {
+      logger.warn("Invalid manifest file", {
+        issues: error.issues,
+        path: manifestPath,
+      });
+      return undefined;
+    }
+    throw error;
+  }
 };

--- a/packages/nx-terraform-plugin/src/index.ts
+++ b/packages/nx-terraform-plugin/src/index.ts
@@ -6,16 +6,20 @@ import {
 import fs from "node:fs/promises";
 import path from "node:path";
 
-import { readModulePublishManifest } from "./discovery.ts";
+import {
+  readEnvironmentManifest,
+  readModulePublishManifest,
+} from "./discovery.ts";
 import { getStaticDependenciesFromFile } from "./fs.ts";
 import { configureLogger } from "./logger.ts";
-import { ModulePublishManifest } from "./manifest.ts";
+import { EnvironmentManifest, ModulePublishManifest } from "./manifest.ts";
 import { parseOptions, TerraformPluginOptions } from "./options.ts";
 import { getTerraformProjectFiles } from "./project-file.ts";
 import { getProject } from "./project.ts";
 
 const ignoreModules = ["tests", "_tests", "examples", "example"];
 const moduleManifestFileName = "module.json";
+const environmentManifestFileName = "environment.json";
 
 const isIgnoredRoot = (root: string) => {
   const rootSegments = new Set(root.split(path.sep));
@@ -42,6 +46,7 @@ const fileExists = async (filePath: string) => {
 export const getDiscoveryState = (configFiles: readonly string[]) => {
   const terraformConfigFiles: string[] = [];
   const moduleManifestRoots = new Set<string>();
+  const environmentManifestRoots = new Set<string>();
 
   for (const configFile of configFiles) {
     const root = path.dirname(configFile);
@@ -53,10 +58,15 @@ export const getDiscoveryState = (configFiles: readonly string[]) => {
       moduleManifestRoots.add(root);
       continue;
     }
+    if (fileName === environmentManifestFileName) {
+      environmentManifestRoots.add(root);
+      continue;
+    }
     terraformConfigFiles.push(configFile);
   }
 
   return {
+    environmentManifestRoots,
     moduleManifestRoots,
     terraformConfigFiles,
   };
@@ -82,34 +92,68 @@ export const getPublishableManifestByRoot = async (
   );
 };
 
+export const getEnvironmentManifestByRoot = async (
+  environmentManifestRoots: readonly string[],
+  workspaceRoot: string,
+): Promise<Map<string, EnvironmentManifest>> => {
+  const validationResults = await Promise.all(
+    environmentManifestRoots.map(async (root) => {
+      const absoluteRoot = path.join(workspaceRoot, root);
+      const manifest = await readEnvironmentManifest(absoluteRoot);
+      return manifest ? [root, manifest] : null;
+    }),
+  );
+
+  return new Map(
+    validationResults.filter(
+      (rootManifest): rootManifest is [string, EnvironmentManifest] =>
+        rootManifest !== null,
+    ),
+  );
+};
+
 export const getDiscoveryStateWithValidation = async (
   configFiles: readonly string[],
   workspaceRoot: string,
 ) => {
-  const { moduleManifestRoots, terraformConfigFiles } =
-    getDiscoveryState(configFiles);
+  const {
+    environmentManifestRoots,
+    moduleManifestRoots,
+    terraformConfigFiles,
+  } = getDiscoveryState(configFiles);
   const publishableManifestByRoot = await getPublishableManifestByRoot(
     Array.from(moduleManifestRoots),
     workspaceRoot,
   );
+  const environmentManifestByRoot = await getEnvironmentManifestByRoot(
+    Array.from(environmentManifestRoots),
+    workspaceRoot,
+  );
 
   return {
+    environmentManifestByRoot,
     publishableManifestByRoot,
     terraformConfigFiles,
   };
 };
 
 export const createNodesV2: CreateNodesV2<TerraformPluginOptions> = [
-  // We discover both Terraform modules and module manifests in one pass.
-  "**/{*.tf,module.json}",
+  // We discover Terraform files, module manifests, and environment manifests in one pass.
+  "**/{*.tf,module.json,environment.json}",
   async (configFiles, options, context) => {
     await configureLogger();
     const opts = parseOptions(options);
     const hasRootTflintConfig = await fileExists(
       path.join(context.workspaceRoot, ".tflint.hcl"),
     );
-    const { publishableManifestByRoot, terraformConfigFiles } =
-      await getDiscoveryStateWithValidation(configFiles, context.workspaceRoot);
+    const {
+      environmentManifestByRoot,
+      publishableManifestByRoot,
+      terraformConfigFiles,
+    } = await getDiscoveryStateWithValidation(
+      configFiles,
+      context.workspaceRoot,
+    );
 
     return createNodesFromFiles(
       (configFile) => {
@@ -126,6 +170,7 @@ export const createNodesV2: CreateNodesV2<TerraformPluginOptions> = [
               root,
               hasRootTflintConfig,
               publishableManifestByRoot.get(root),
+              environmentManifestByRoot.get(root),
             ),
           },
         };

--- a/packages/nx-terraform-plugin/src/manifest.ts
+++ b/packages/nx-terraform-plugin/src/manifest.ts
@@ -38,3 +38,45 @@ export const parseModulePublishManifest = (
   }
   return parseResult.data;
 };
+
+// Parses and validates environment.json files for deployable Terraform
+// environments (e.g. infra/resources/dev). Unlike module.json, this manifest
+// only tracks a release version — there is no registry/publish metadata.
+export const environmentManifestSchema = z.object({
+  deployment: z
+    .object({
+      applyEnvironment: z.string().min(1),
+      planEnvironment: z.string().min(1),
+      runnerLabel: z.string().min(1),
+    })
+    .optional(),
+  version: z.string().min(1),
+});
+
+export type EnvironmentManifest = z.infer<typeof environmentManifestSchema>;
+
+export class EnvironmentManifestError extends Error {
+  readonly issues: z.core.$ZodIssue[];
+  readonly reasons: string[];
+
+  constructor(issues: z.core.$ZodIssue[], reasons: string[]) {
+    super(reasons.join("; "));
+    this.issues = issues;
+    this.reasons = reasons;
+    this.name = "EnvironmentManifestError";
+  }
+}
+
+export const parseEnvironmentManifest = (
+  input: unknown,
+): EnvironmentManifest => {
+  const parseResult = environmentManifestSchema.safeParse(input);
+  if (!parseResult.success) {
+    const reasons = parseResult.error.issues.map((issue) => {
+      const issuePath = issue.path.join(".");
+      return `${issuePath}: ${issue.message}`;
+    });
+    throw new EnvironmentManifestError(parseResult.error.issues, reasons);
+  }
+  return parseResult.data;
+};

--- a/packages/nx-terraform-plugin/src/project.ts
+++ b/packages/nx-terraform-plugin/src/project.ts
@@ -10,7 +10,7 @@ import {
 import path from "node:path";
 
 import { getPackageLogger } from "./logger.ts";
-import { ModulePublishManifest } from "./manifest.ts";
+import { EnvironmentManifest, ModulePublishManifest } from "./manifest.ts";
 import { TerraformPluginOptions } from "./options.ts";
 import { mergePublishOptions, PublishOptionsError } from "./publish-options.ts";
 
@@ -103,12 +103,61 @@ const getPublishTarget = (
   }
 };
 
+// Deployable environments (identified by an environment.json manifest)
+// additionally get a plan-upload target (generates and persists a plan
+// bundle to the Terraform state storage backend) and a release-publish
+// target (downloads and applies that exact plan bundle). The latter is
+// invoked by `nx release publish` when this project is included in an Nx
+// release, gating the actual apply behind the same version-plan-driven
+// release flow used for the rest of the monorepo.
+const getEnvironmentReleaseTargets = (
+  opts: TerraformPluginOptions,
+): [string, TargetConfiguration][] => [
+  [
+    opts.planUploadTargetName,
+    {
+      cache: false,
+      configurations: {
+        ci: {
+          refresh: true,
+          report: true,
+          verbose: false,
+        },
+      },
+      dependsOn: [opts.initTargetName],
+      executor: "@pagopa/nx-terraform-plugin:plan-upload",
+      options: {
+        projectRoot: "{projectRoot}",
+        refresh: true,
+        report: false,
+        sensitiveKeys: opts.sensitiveOutputKeys,
+        verbose: true,
+      },
+    },
+  ],
+  [
+    opts.publishTargetName,
+    {
+      cache: false,
+      dependsOn: [opts.initTargetName],
+      executor: "@pagopa/nx-terraform-plugin:release-apply",
+      options: {
+        projectRoot: "{projectRoot}",
+        report: false,
+        sensitiveKeys: opts.sensitiveOutputKeys,
+        verbose: true,
+      },
+    },
+  ],
+];
+
 const getTargets = (
   opts: TerraformPluginOptions,
   root: string,
   projectType: ProjectType,
   hasRootTflintConfig: boolean,
   publishManifest: ModulePublishManifest | undefined,
+  environmentManifest: EnvironmentManifest | undefined,
 ): Record<string, TargetConfiguration> => {
   const rootTflintConfigPath = getRootConfigPath(root, ".tflint.hcl");
   const formatArgs = ["-list=true", "-recursive=true"];
@@ -291,6 +340,10 @@ const getTargets = (
         },
       ],
     );
+
+    if (environmentManifest) {
+      targets.push(...getEnvironmentReleaseTargets(opts));
+    }
   }
 
   return Object.fromEntries(targets);
@@ -301,16 +354,20 @@ export const getProject = (
   root: string,
   hasRootTflintConfig = false,
   publishManifest: ModulePublishManifest | undefined = undefined,
+  environmentManifest: EnvironmentManifest | undefined = undefined,
 ): ProjectConfiguration => {
   const projectType = getProjectType(root);
   const isPublishableLibrary =
     projectType === "library" && publishManifest !== undefined;
+  const isReleasableEnvironment =
+    projectType === "application" && environmentManifest !== undefined;
   const targets = getTargets(
     opts,
     root,
     projectType,
     hasRootTflintConfig,
     publishManifest,
+    environmentManifest,
   );
   const environmentTag =
     projectType === "application"
@@ -340,8 +397,11 @@ export const getProject = (
     targets,
   };
 
-  // Add Nx Release configuration for publishable libraries
-  if (isPublishableLibrary) {
+  // Add Nx Release configuration for publishable libraries and releasable
+  // (environment.json-backed) deployable environments. Both track their
+  // version on disk via the same TerraformVersionActions, which picks the
+  // right manifest filename based on projectType.
+  if (isPublishableLibrary || isReleasableEnvironment) {
     config.release = {
       version: {
         currentVersionResolver: "disk",

--- a/packages/nx-terraform-plugin/src/release/__tests__/version-actions.test.ts
+++ b/packages/nx-terraform-plugin/src/release/__tests__/version-actions.test.ts
@@ -14,15 +14,18 @@ const createMockReleaseGroup = (): any => ({
   },
 });
 
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
-const createMockProjectGraphNode = (root: string): any => ({
+const createMockProjectGraphNode = (
+  root: string,
+  projectType: "application" | "library" = "library",
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+): any => ({
   data: {
     name: "test-project",
-    projectType: "library",
+    projectType,
     root,
   },
   name: "test-project",
-  type: "lib",
+  type: projectType === "application" ? "app" : "lib",
 });
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -34,7 +37,7 @@ const createMockFinalConfigForProject = (): any => ({
 // eslint-disable-next-line max-lines-per-function
 describe("TerraformVersionActions", () => {
   describe("validManifestFilenames", () => {
-    it("defines module.json as the valid manifest filename", () => {
+    it("selects module.json for library projects", () => {
       const releaseGroup = createMockReleaseGroup();
       const projectGraphNode = createMockProjectGraphNode("infra/modules/test");
       const finalConfigForProject = createMockFinalConfigForProject();
@@ -46,6 +49,25 @@ describe("TerraformVersionActions", () => {
       );
 
       expect(versionActions.validManifestFilenames).toEqual(["module.json"]);
+    });
+
+    it("selects environment.json for application projects", () => {
+      const releaseGroup = createMockReleaseGroup();
+      const projectGraphNode = createMockProjectGraphNode(
+        "infra/resources/dev",
+        "application",
+      );
+      const finalConfigForProject = createMockFinalConfigForProject();
+
+      const versionActions = new TerraformVersionActions(
+        releaseGroup,
+        projectGraphNode,
+        finalConfigForProject,
+      );
+
+      expect(versionActions.validManifestFilenames).toEqual([
+        "environment.json",
+      ]);
     });
   });
 
@@ -114,6 +136,61 @@ describe("TerraformVersionActions", () => {
 
       const releaseGroup = createMockReleaseGroup();
       const projectGraphNode = createMockProjectGraphNode(root);
+      const finalConfigForProject = createMockFinalConfigForProject();
+
+      const versionActions = new TerraformVersionActions(
+        releaseGroup,
+        projectGraphNode,
+        finalConfigForProject,
+      );
+
+      const result =
+        await versionActions.readCurrentVersionFromSourceManifest(tree);
+
+      expect(result).toBeNull();
+    });
+
+    it("reads version from environment.json for application projects", async () => {
+      const tree = createTree();
+      const root = "infra/resources/dev";
+      tree.write(
+        `${root}/environment.json`,
+        JSON.stringify({
+          version: "0.3.1",
+        }),
+      );
+
+      const releaseGroup = createMockReleaseGroup();
+      const projectGraphNode = createMockProjectGraphNode(root, "application");
+      const finalConfigForProject = createMockFinalConfigForProject();
+
+      const versionActions = new TerraformVersionActions(
+        releaseGroup,
+        projectGraphNode,
+        finalConfigForProject,
+      );
+
+      const result =
+        await versionActions.readCurrentVersionFromSourceManifest(tree);
+
+      expect(result).toEqual({
+        currentVersion: "0.3.1",
+        manifestPath: `${root}/environment.json`,
+      });
+    });
+
+    it("does not read module.json for application projects", async () => {
+      const tree = createTree();
+      const root = "infra/resources/dev";
+      tree.write(
+        `${root}/module.json`,
+        JSON.stringify({
+          version: "9.9.9",
+        }),
+      );
+
+      const releaseGroup = createMockReleaseGroup();
+      const projectGraphNode = createMockProjectGraphNode(root, "application");
       const finalConfigForProject = createMockFinalConfigForProject();
 
       const versionActions = new TerraformVersionActions(
@@ -211,6 +288,39 @@ describe("TerraformVersionActions", () => {
       expect(updatedManifest.provider).toBe("aws");
       expect(updatedManifest.description).toBe("Test module");
       expect(Object.keys(updatedManifest)).toHaveLength(3);
+    });
+
+    it("updates version in environment.json for application projects", async () => {
+      const tree = createTree();
+      const root = "infra/resources/dev";
+      tree.write(
+        `${root}/environment.json`,
+        JSON.stringify({ version: "0.1.0" }, null, 2),
+      );
+
+      const releaseGroup = createMockReleaseGroup();
+      const projectGraphNode = createMockProjectGraphNode(root, "application");
+      const finalConfigForProject = createMockFinalConfigForProject();
+
+      const versionActions = new TerraformVersionActions(
+        releaseGroup,
+        projectGraphNode,
+        finalConfigForProject,
+      );
+
+      const logMessages = await versionActions.updateProjectVersion(
+        tree,
+        "0.2.0",
+      );
+
+      const updatedContent = tree.read(`${root}/environment.json`, "utf-8");
+      if (!updatedContent) {
+        throw new Error("Failed to read updated manifest");
+      }
+      const updatedManifest = JSON.parse(updatedContent);
+
+      expect(updatedManifest.version).toBe("0.2.0");
+      expect(logMessages[0]).toContain("environment.json");
     });
 
     it("throws descriptive error when module.json contains invalid JSON", async () => {

--- a/packages/nx-terraform-plugin/src/release/version-actions.ts
+++ b/packages/nx-terraform-plugin/src/release/version-actions.ts
@@ -2,15 +2,24 @@ import type { ProjectGraph, Tree } from "@nx/devkit";
 
 import { VersionActions } from "nx/release";
 
+// Library modules track their version in "module.json" (publishable Terraform
+// modules), while application projects (deployable environments, e.g.
+// infra/resources/dev) track theirs in "environment.json".
+const moduleManifestFilename = "module.json";
+const environmentManifestFilename = "environment.json";
+
 /**
- * Custom Nx Release VersionActions implementation for Terraform modules.
+ * Custom Nx Release VersionActions implementation for Terraform projects.
  *
- * This class manages versioning of publishable Terraform modules by reading
- * and writing the `version` field in module.json files.
+ * This class manages versioning of both publishable Terraform modules and
+ * deployable Terraform environments by reading and writing the `version`
+ * field in a project-type-specific manifest file:
+ * - Library modules (publishable Terraform modules): `module.json`
+ * - Application projects (deployable environments): `environment.json`
  *
  * Key behaviors:
- * - Reads current version from module.json (disk-based resolution)
- * - Updates version in module.json during release
+ * - Reads current version from the manifest file (disk-based resolution)
+ * - Updates version in the manifest file during release
  * - Does NOT support registry-based version resolution
  * - Does NOT manage module dependencies (explicit no-op)
  *
@@ -19,7 +28,7 @@ import { VersionActions } from "nx/release";
  * in inferred Terraform project configuration.
  */
 export default class TerraformVersionActions extends VersionActions {
-  validManifestFilenames = ["module.json"];
+  validManifestFilenames = [this.getManifestFilename()];
 
   /**
    * Registry-based version resolution is not supported for Terraform modules.
@@ -42,10 +51,11 @@ export default class TerraformVersionActions extends VersionActions {
   }
 
   /**
-   * Reads the current version from the module.json manifest file.
+   * Reads the current version from the manifest file (module.json for
+   * libraries, environment.json for applications).
    *
    * Returns null if:
-   * - The module.json file does not exist
+   * - The manifest file does not exist
    * - The file is invalid JSON
    * - The version field is missing or not a string
    *
@@ -55,7 +65,7 @@ export default class TerraformVersionActions extends VersionActions {
   async readCurrentVersionFromSourceManifest(
     tree: Tree,
   ): Promise<null | { currentVersion: string; manifestPath: string }> {
-    const manifestPath = `${this.projectGraphNode.data.root}/module.json`;
+    const manifestPath = `${this.projectGraphNode.data.root}/${this.getManifestFilename()}`;
 
     if (!tree.exists(manifestPath)) {
       return null;
@@ -129,7 +139,8 @@ export default class TerraformVersionActions extends VersionActions {
   }
 
   /**
-   * Updates the version field in the module.json file.
+   * Updates the version field in the manifest file (module.json for
+   * libraries, environment.json for applications).
    *
    * Preserves:
    * - Field order in the JSON object
@@ -144,7 +155,7 @@ export default class TerraformVersionActions extends VersionActions {
     tree: Tree,
     newVersion: string,
   ): Promise<string[]> {
-    const manifestPath = `${this.projectGraphNode.data.root}/module.json`;
+    const manifestPath = `${this.projectGraphNode.data.root}/${this.getManifestFilename()}`;
     const content = tree.read(manifestPath, "utf-8");
     if (!content) {
       throw new Error(`Failed to read ${manifestPath}`);
@@ -168,5 +179,16 @@ export default class TerraformVersionActions extends VersionActions {
     return [
       `Updated ${this.projectGraphNode.name} version to ${newVersion} in ${manifestPath}`,
     ];
+  }
+
+  /**
+   * Returns the manifest filename to use for this project, based on its
+   * Nx project type: "environment.json" for applications, "module.json"
+   * for libraries.
+   */
+  private getManifestFilename(): string {
+    return this.projectGraphNode.data.projectType === "application"
+      ? environmentManifestFilename
+      : moduleManifestFilename;
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1231,6 +1231,9 @@ importers:
       execa:
         specifier: 'catalog:'
         version: 9.6.1
+      nx:
+        specifier: ^22.7.1
+        version: 22.7.5(@swc-node/register@1.11.1(@swc/core@1.15.43(@swc/helpers@0.5.21))(@swc/types@0.1.27)(typescript@5.9.3))(@swc/core@1.15.43(@swc/helpers@0.5.21))
       octokit:
         specifier: 'catalog:'
         version: 5.0.5


### PR DESCRIPTION
## Why

Terraform environment projects need an explicit manifest contract before release orchestration can identify, version, and deploy them safely.

## What changed

- Discover and validate `environment.json` manifests in the Terraform Nx plugin.
- Infer `tf-plan-upload` and `nx-release-publish` targets for manifest-backed application projects.
- Add Nx Release configuration and environment-aware version actions.
- Add focused discovery, manifest, project, and versioning tests.
- Rebuild committed plugin artifacts and add a version plan.

No repository environment manifest is added in this PR, so existing project graphs and deployment behavior remain unchanged.

## Validation

- `pnpm nx run-many -t test lint typecheck -p @pagopa/nx-terraform-plugin`
- `pnpm nx run @pagopa/nx-terraform-plugin:build`

Depends on #1994.

Extracted from #1926.