### PR TITLE
Refine Terraform publish plugin authentication

### DIFF
--- a/.nx/version-plans/version-plan-1784215260242.md
+++ b/.nx/version-plans/version-plan-1784215260242.md
@@ -1,0 +1,5 @@
+---
+'@pagopa/nx-terraform-plugin': patch
+---
+
+Refine Terraform module publish GitHub authentication by reusing Octokit clients and validating authentication inputs with a single schema.

--- a/packages/nx-terraform-plugin/dist/executors/publish/publish.js
+++ b/packages/nx-terraform-plugin/dist/executors/publish/publish.js
@@ -9,14 +9,15 @@ import { tmpdir } from "node:os";
 import { createAppAuth } from "@octokit/auth-app";
 
 //#region src/adapters/github/octokit.ts
-const createGitHubAppToken = async (owner, credentials) => {
-	const installation = await new Octokit({
-		auth: {
-			appId: credentials.clientId,
-			privateKey: credentials.privateKey
-		},
-		authStrategy: createAppAuth
-	}).rest.apps.getOrgInstallation({ org: owner });
+const createGitHubAppOctokit = (credentials) => new Octokit({
+	auth: {
+		appId: credentials.clientId,
+		privateKey: credentials.privateKey
+	},
+	authStrategy: createAppAuth
+});
+const createGitHubAppToken = async (owner, credentials, appOctokit = createGitHubAppOctokit(credentials)) => {
+	const installation = await appOctokit.rest.apps.getOrgInstallation({ org: owner });
 	return (await createAppAuth({
 		appId: credentials.clientId,
 		installationId: installation.data.id,
@@ -26,8 +27,8 @@ const createGitHubAppToken = async (owner, credentials) => {
 		type: "installation"
 	})).token;
 };
-const revokeGitHubAppToken = async (token) => {
-	await new Octokit({ auth: token }).rest.apps.revokeInstallationAccessToken();
+const revokeGitHubAppToken = async (octokit) => {
+	await octokit.rest.apps.revokeInstallationAccessToken();
 };
 const getAuthenticatedUserLogin = async (octokit, owner) => {
 	try {
@@ -36,8 +37,7 @@ const getAuthenticatedUserLogin = async (octokit, owner) => {
 		throw new Error(`Cannot create repository for user owner "${owner}" without user-scoped GitHub credentials. GitHub App installation tokens can create organization repositories, but not user-owned repositories.`, { cause: error });
 	}
 };
-const ensureGitHubRepository = async (owner, repo, token) => {
-	const octokit = new Octokit({ auth: token });
+const ensureGitHubRepository = async (owner, repo, octokit) => {
 	try {
 		await octokit.rest.repos.get({
 			owner,
@@ -83,22 +83,36 @@ const clearExportWorkingTree = async (exportDirectory) => {
 		recursive: true
 	})));
 };
+const createPublishGitHubAuthentication = async (input) => {
+	if (input.githubAppCredentials === void 0) return {
+		octokit: new Octokit({ auth: input.githubToken }),
+		shouldRevokeToken: false,
+		token: input.githubToken
+	};
+	const appOctokit = createGitHubAppOctokit(input.githubAppCredentials);
+	const token = await createGitHubAppToken(input.githubOwner, input.githubAppCredentials, appOctokit);
+	return {
+		octokit: new Octokit({ auth: token }),
+		shouldRevokeToken: true,
+		token
+	};
+};
 const publishToGithub = async (input) => {
 	const repo = getRepoNameFromProjectRoot(input.projectRoot, input.provider);
 	const repoUrl = `https://github.com/${input.githubOwner}/${repo}.git`;
 	const sourceModuleDirectory = join(input.workspaceRoot, input.projectRoot);
-	const token = input.githubAppCredentials === void 0 ? input.githubToken : await createGitHubAppToken(input.githubOwner, input.githubAppCredentials);
+	const githubAuthentication = await createPublishGitHubAuthentication(input);
 	let publishError;
 	let publishResult = "published";
 	let tempExportDir;
 	try {
-		await ensureGitHubRepository(input.githubOwner, repo, token);
+		await ensureGitHubRepository(input.githubOwner, repo, githubAuthentication.octokit);
 		tempExportDir = await mkdtemp(join(tmpdir(), "export-repo-"));
 		await copyModuleDirectoryContents(sourceModuleDirectory, tempExportDir);
 		const $$1 = $({
 			cwd: tempExportDir,
 			env: {
-				GH_TOKEN: token,
+				GH_TOKEN: githubAuthentication.token,
 				GIT_AUTHOR_EMAIL: "pagopa-dx-bot@pagopa.it",
 				GIT_AUTHOR_NAME: "PagoPA DX Bot",
 				GIT_COMMITTER_EMAIL: "pagopa-dx-bot@pagopa.it",
@@ -146,8 +160,8 @@ const publishToGithub = async (input) => {
 		cleanupError = new Error(cleanupMessage, { cause: error });
 	}
 	let revokeError;
-	if (input.githubAppCredentials !== void 0) try {
-		await revokeGitHubAppToken(token);
+	if (githubAuthentication.shouldRevokeToken) try {
+		await revokeGitHubAppToken(githubAuthentication.octokit);
 	} catch (error) {
 		revokeError = error;
 	}
@@ -177,7 +191,7 @@ const githubTokenEnvironmentSchema = z.object({
 	}
 	return token;
 });
-const nxReleasePublishExecutorSchema = z.object({
+const nxReleasePublishExecutorOptionsSchema = z.object({
 	description: publishSchema.shape.description,
 	githubOwner: publishSchema.shape.github.shape.owner,
 	projectRoot: z.string().min(1),
@@ -186,48 +200,52 @@ const nxReleasePublishExecutorSchema = z.object({
 	version: publishSchema.shape.version,
 	workspaceRoot: z.string()
 });
+const hasOwnProperty = (value, property) => Object.prototype.hasOwnProperty.call(value, property);
+const nxReleasePublishExecutorAuthenticationSchema = z.preprocess((input) => {
+	if (input !== null && typeof input === "object" && !Array.isArray(input) && !hasOwnProperty(input, "useGitHubAppAuthentication")) return {
+		...input,
+		useGitHubAppAuthentication: false
+	};
+	return input;
+}, z.xor([nxReleasePublishExecutorOptionsSchema.extend({
+	environment: githubAppEnvironmentSchema,
+	useGitHubAppAuthentication: z.literal(true)
+}).transform(({ environment, ...options }) => ({
+	...options,
+	githubAppCredentials: {
+		clientId: environment.GH_APP_CLIENT_ID,
+		privateKey: environment.GH_APP_KEY
+	},
+	githubToken: ""
+})), nxReleasePublishExecutorOptionsSchema.extend({
+	environment: githubTokenEnvironmentSchema,
+	useGitHubAppAuthentication: z.literal(false).default(false)
+}).transform(({ environment, ...options }) => ({
+	...options,
+	githubAppCredentials: void 0,
+	githubToken: environment
+}))]));
+const nxReleasePublishExecutorSchema = nxReleasePublishExecutorAuthenticationSchema;
 
 //#endregion
 //#region src/executors/publish/publish.ts
 const runExecutor = async (options) => {
 	const logger = getPackageLogger(["publish"]);
-	const parseResult = nxReleasePublishExecutorSchema.safeParse(options);
+	const parseResult = nxReleasePublishExecutorSchema.safeParse({
+		...options,
+		environment: process.env
+	});
 	await configureLogger();
 	if (!parseResult.success) {
-		logger.warn("Invalid publish options", {
-			issues: parseResult.error.issues,
+		const issues = parseResult.error.issues.flatMap((issue) => issue.code === "invalid_union" ? issue.errors.flat() : [issue]);
+		const hasEnvironmentIssue = issues.some((issue) => issue.path[0] === "environment");
+		logger.warn(hasEnvironmentIssue ? "Invalid GitHub authentication environment" : "Invalid publish options", {
+			issues,
 			path: options.projectRoot ?? "publish options"
 		});
 		return { success: false };
 	}
 	const validatedOptions = parseResult.data;
-	let githubAppCredentials;
-	let githubToken;
-	if (validatedOptions.useGitHubAppAuthentication) {
-		const environmentParseResult = githubAppEnvironmentSchema.safeParse(process.env);
-		if (!environmentParseResult.success) {
-			logger.warn("Invalid GitHub authentication environment", {
-				issues: environmentParseResult.error.issues,
-				path: validatedOptions.projectRoot
-			});
-			return { success: false };
-		}
-		githubAppCredentials = {
-			clientId: environmentParseResult.data.GH_APP_CLIENT_ID,
-			privateKey: environmentParseResult.data.GH_APP_KEY
-		};
-		githubToken = "";
-	} else {
-		const environmentParseResult = githubTokenEnvironmentSchema.safeParse(process.env);
-		if (!environmentParseResult.success) {
-			logger.warn("Invalid GitHub authentication environment", {
-				issues: environmentParseResult.error.issues,
-				path: validatedOptions.projectRoot
-			});
-			return { success: false };
-		}
-		githubToken = environmentParseResult.data;
-	}
 	const repoName = getRepoNameFromProjectRoot(validatedOptions.projectRoot, validatedOptions.provider);
 	logger.info("Publishing Terraform module from {projectRoot} to repository {repoName}...", {
 		projectRoot: validatedOptions.projectRoot,
@@ -235,9 +253,9 @@ const runExecutor = async (options) => {
 	});
 	if (await publishToGithub({
 		description: validatedOptions.description,
-		githubAppCredentials,
+		githubAppCredentials: validatedOptions.githubAppCredentials,
 		githubOwner: validatedOptions.githubOwner,
-		githubToken,
+		githubToken: validatedOptions.githubToken,
 		projectRoot: validatedOptions.projectRoot,
 		provider: validatedOptions.provider,
 		version: validatedOptions.version,

--- a/packages/nx-terraform-plugin/dist/executors/publish/publish.js
+++ b/packages/nx-terraform-plugin/dist/executors/publish/publish.js
@@ -16,7 +16,7 @@ const createGitHubAppOctokit = (credentials) => new Octokit({
 	},
 	authStrategy: createAppAuth
 });
-const createGitHubAppToken = async (owner, credentials, appOctokit = createGitHubAppOctokit(credentials)) => {
+const createGitHubAppToken = async (owner, credentials, appOctokit) => {
 	const installation = await appOctokit.rest.apps.getOrgInstallation({ org: owner });
 	return (await createAppAuth({
 		appId: credentials.clientId,
@@ -84,7 +84,7 @@ const clearExportWorkingTree = async (exportDirectory) => {
 	})));
 };
 const createPublishGitHubAuthentication = async (input) => {
-	if (input.githubAppCredentials === void 0) return {
+	if (!input.useGitHubAppAuthentication) return {
 		octokit: new Octokit({ auth: input.githubToken }),
 		shouldRevokeToken: false,
 		token: input.githubToken
@@ -196,35 +196,28 @@ const nxReleasePublishExecutorOptionsSchema = z.object({
 	githubOwner: publishSchema.shape.github.shape.owner,
 	projectRoot: z.string().min(1),
 	provider: publishSchema.shape.provider,
-	useGitHubAppAuthentication: z.boolean().default(false),
 	version: publishSchema.shape.version,
 	workspaceRoot: z.string()
 });
-const hasOwnProperty = (value, property) => Object.prototype.hasOwnProperty.call(value, property);
-const nxReleasePublishExecutorAuthenticationSchema = z.preprocess((input) => {
-	if (input !== null && typeof input === "object" && !Array.isArray(input) && !hasOwnProperty(input, "useGitHubAppAuthentication")) return {
-		...input,
-		useGitHubAppAuthentication: false
+const nxReleasePublishExecutorGitHubAppOptionsSchema = nxReleasePublishExecutorOptionsSchema.extend({ useGitHubAppAuthentication: z.literal(true) });
+const nxReleasePublishExecutorGitHubTokenOptionsSchema = nxReleasePublishExecutorOptionsSchema.extend({ useGitHubAppAuthentication: z.literal(false) });
+const nxReleasePublishExecutorAuthenticationSchema = z.looseObject({ useGitHubAppAuthentication: z.boolean().default(false) }).pipe(z.discriminatedUnion("useGitHubAppAuthentication", [nxReleasePublishExecutorGitHubAppOptionsSchema.extend({ environment: githubAppEnvironmentSchema }), nxReleasePublishExecutorGitHubTokenOptionsSchema.extend({ environment: githubTokenEnvironmentSchema })])).transform((options) => {
+	if (options.useGitHubAppAuthentication) {
+		const { environment, ...publishOptions } = options;
+		return {
+			...publishOptions,
+			githubAppCredentials: {
+				clientId: environment.GH_APP_CLIENT_ID,
+				privateKey: environment.GH_APP_KEY
+			}
+		};
+	}
+	const { environment: githubToken, ...publishOptions } = options;
+	return {
+		...publishOptions,
+		githubToken
 	};
-	return input;
-}, z.xor([nxReleasePublishExecutorOptionsSchema.extend({
-	environment: githubAppEnvironmentSchema,
-	useGitHubAppAuthentication: z.literal(true)
-}).transform(({ environment, ...options }) => ({
-	...options,
-	githubAppCredentials: {
-		clientId: environment.GH_APP_CLIENT_ID,
-		privateKey: environment.GH_APP_KEY
-	},
-	githubToken: ""
-})), nxReleasePublishExecutorOptionsSchema.extend({
-	environment: githubTokenEnvironmentSchema,
-	useGitHubAppAuthentication: z.literal(false).default(false)
-}).transform(({ environment, ...options }) => ({
-	...options,
-	githubAppCredentials: void 0,
-	githubToken: environment
-}))]));
+});
 const nxReleasePublishExecutorSchema = nxReleasePublishExecutorAuthenticationSchema;
 
 //#endregion
@@ -237,10 +230,8 @@ const runExecutor = async (options) => {
 	});
 	await configureLogger();
 	if (!parseResult.success) {
-		const issues = parseResult.error.issues.flatMap((issue) => issue.code === "invalid_union" ? issue.errors.flat() : [issue]);
-		const hasEnvironmentIssue = issues.some((issue) => issue.path[0] === "environment");
-		logger.warn(hasEnvironmentIssue ? "Invalid GitHub authentication environment" : "Invalid publish options", {
-			issues,
+		logger.warn("Invalid publish options", {
+			error: z.prettifyError(parseResult.error),
 			path: options.projectRoot ?? "publish options"
 		});
 		return { success: false };
@@ -251,16 +242,7 @@ const runExecutor = async (options) => {
 		projectRoot: validatedOptions.projectRoot,
 		repoName
 	});
-	if (await publishToGithub({
-		description: validatedOptions.description,
-		githubAppCredentials: validatedOptions.githubAppCredentials,
-		githubOwner: validatedOptions.githubOwner,
-		githubToken: validatedOptions.githubToken,
-		projectRoot: validatedOptions.projectRoot,
-		provider: validatedOptions.provider,
-		version: validatedOptions.version,
-		workspaceRoot: validatedOptions.workspaceRoot
-	}) === "skipped") logger.info("Skipping release, tag already exists");
+	if (await publishToGithub(validatedOptions) === "skipped") logger.info("Skipping release, tag already exists");
 	return { success: true };
 };
 

--- a/packages/nx-terraform-plugin/src/adapters/github/__tests__/octokit.test.ts
+++ b/packages/nx-terraform-plugin/src/adapters/github/__tests__/octokit.test.ts
@@ -51,8 +51,10 @@ vi.mock("octokit", () => ({
 }));
 
 import { createAppAuth } from "@octokit/auth-app";
+import { Octokit } from "octokit";
 
 import {
+  createGitHubAppOctokit,
   createGitHubAppToken,
   ensureGitHubRepository,
   revokeGitHubAppToken,
@@ -64,13 +66,32 @@ const appCredentials = {
 };
 const token = "installation-token";
 
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe("createGitHubAppOctokit", () => {
+  it("creates an app-authenticated Octokit client", () => {
+    createGitHubAppOctokit(appCredentials);
+
+    expect(octokitMocks.Octokit).toHaveBeenCalledWith({
+      auth: {
+        appId: "Iv23.client-id",
+        privateKey: "private-key",
+      },
+      authStrategy: createAppAuth,
+    });
+  });
+});
+
 describe("createGitHubAppToken", () => {
   it("creates an owner installation token with contents write permission", async () => {
     octokitMocks.getOrgInstallation.mockResolvedValue({ data: { id: 123 } });
     octokitMocks.auth.mockResolvedValue({ token });
+    const appOctokit = createGitHubAppOctokit(appCredentials);
 
     await expect(
-      createGitHubAppToken("pagopa-dx", appCredentials),
+      createGitHubAppToken("pagopa-dx", appCredentials, appOctokit),
     ).resolves.toBe(token);
 
     expect(octokitMocks.getOrgInstallation).toHaveBeenCalledWith({
@@ -93,8 +114,9 @@ describe("createGitHubAppToken", () => {
 describe("revokeGitHubAppToken", () => {
   it("revokes the installation token", async () => {
     octokitMocks.revokeInstallationAccessToken.mockResolvedValue(undefined);
+    const octokit = new Octokit({ auth: token });
 
-    await expect(revokeGitHubAppToken(token)).resolves.toBeUndefined();
+    await expect(revokeGitHubAppToken(octokit)).resolves.toBeUndefined();
 
     expect(octokitMocks.Octokit).toHaveBeenCalledWith({ auth: token });
     expect(octokitMocks.revokeInstallationAccessToken).toHaveBeenCalledTimes(1);
@@ -102,17 +124,14 @@ describe("revokeGitHubAppToken", () => {
 });
 
 describe("ensureGitHubRepository", () => {
-  beforeEach(() => {
-    vi.clearAllMocks();
-  });
-
   it("returns created false when the repository exists", async () => {
     octokitMocks.get.mockResolvedValue({ data: {} });
+    const octokit = new Octokit({ auth: token });
 
     const result = await ensureGitHubRepository(
       "pagopa-dx",
       "terraform-aws-x",
-      token,
+      octokit,
     );
 
     expect(result).toBeUndefined();
@@ -133,11 +152,12 @@ describe("ensureGitHubRepository", () => {
       data: { type: "Organization" },
     });
     octokitMocks.createInOrg.mockResolvedValue({ data: {} });
+    const octokit = new Octokit({ auth: token });
 
     const result = await ensureGitHubRepository(
       "pagopa-dx",
       "terraform-aws-x",
-      token,
+      octokit,
     );
 
     expect(result).toBeUndefined();
@@ -165,11 +185,12 @@ describe("ensureGitHubRepository", () => {
     octokitMocks.createForAuthenticatedUser.mockResolvedValueOnce({
       data: {},
     });
+    const octokit = new Octokit({ auth: token });
 
     const result = await ensureGitHubRepository(
       "pagopa-user",
       "terraform-aws-x",
-      token,
+      octokit,
     );
 
     expect(result).toBeUndefined();
@@ -195,9 +216,10 @@ describe("ensureGitHubRepository", () => {
     octokitMocks.getAuthenticated.mockResolvedValueOnce({
       data: { login: "another-user" },
     });
+    const octokit = new Octokit({ auth: token });
 
     await expect(
-      ensureGitHubRepository("pagopa-user", "terraform-aws-x", token),
+      ensureGitHubRepository("pagopa-user", "terraform-aws-x", octokit),
     ).rejects.toThrow(
       'Cannot create repository for user owner "pagopa-user" with authenticated user "another-user".',
     );
@@ -222,9 +244,10 @@ describe("ensureGitHubRepository", () => {
         status: 403,
       }),
     );
+    const octokit = new Octokit({ auth: token });
 
     await expect(
-      ensureGitHubRepository("pagopa-user", "terraform-aws-x", token),
+      ensureGitHubRepository("pagopa-user", "terraform-aws-x", octokit),
     ).rejects.toThrow(
       'Cannot create repository for user owner "pagopa-user" without user-scoped GitHub credentials. GitHub App installation tokens can create organization repositories, but not user-owned repositories.',
     );

--- a/packages/nx-terraform-plugin/src/adapters/github/__tests__/publisher.test.ts
+++ b/packages/nx-terraform-plugin/src/adapters/github/__tests__/publisher.test.ts
@@ -56,7 +56,11 @@ vi.mock("node:os", () => ({
   tmpdir: osMocks.tmpdir,
 }));
 
-import { getRepoNameFromProjectRoot, publishToGithub } from "../publisher.ts";
+import {
+  getRepoNameFromProjectRoot,
+  publishToGithub,
+  type PublishToGithubInput,
+} from "../publisher.ts";
 
 const defaultCommandResult = {
   exitCode: 0,
@@ -64,19 +68,23 @@ const defaultCommandResult = {
   stdout: "",
 };
 
-const publishInput = {
+const publishOptions = {
   description: "Terraform module description",
-  githubAppCredentials: {
-    clientId: "Iv23.client-id",
-    privateKey: "private-key",
-  },
   githubOwner: "pagopa-dx",
-  githubToken: "legacy-token",
   projectRoot: "infra/modules/azure_core_infra",
   provider: "aws",
   version: "1.2.3",
   workspaceRoot: "/repo",
 };
+
+const publishInput = {
+  ...publishOptions,
+  githubAppCredentials: {
+    clientId: "Iv23.client-id",
+    privateKey: "private-key",
+  },
+  useGitHubAppAuthentication: true,
+} satisfies PublishToGithubInput;
 
 const expectedRepo = "terraform-aws-azure-core-infra";
 const expectedRepoUrl = `https://github.com/pagopa-dx/${expectedRepo}.git`;
@@ -362,10 +370,10 @@ it("configures git credentials and keeps the remote URL token-free", async () =>
 it("uses the provided token without generating a GitHub App token", async () => {
   createGitCommandHarness();
   const legacyInput = {
-    ...publishInput,
-    githubAppCredentials: undefined,
+    ...publishOptions,
     githubToken: "legacy-token",
-  };
+    useGitHubAppAuthentication: false,
+  } satisfies PublishToGithubInput;
 
   await publishToGithub(legacyInput);
 

--- a/packages/nx-terraform-plugin/src/adapters/github/__tests__/publisher.test.ts
+++ b/packages/nx-terraform-plugin/src/adapters/github/__tests__/publisher.test.ts
@@ -1,10 +1,24 @@
 import { beforeEach, expect, it, vi } from "vitest";
 
 const githubMocks = vi.hoisted(() => ({
+  appOctokit: { client: "app" },
+  createGitHubAppOctokit: vi.fn(),
   createGitHubAppToken: vi.fn(),
   ensureGitHubRepository: vi.fn(),
   revokeGitHubAppToken: vi.fn(),
 }));
+
+const octokitMocks = vi.hoisted(() => {
+  const repoOctokit = { client: "repo" };
+  const Octokit = vi.fn(function Octokit() {
+    return repoOctokit;
+  });
+
+  return {
+    Octokit,
+    repoOctokit,
+  };
+});
 
 const execaMocks = vi.hoisted(() => ({
   $: vi.fn(),
@@ -22,9 +36,14 @@ const osMocks = vi.hoisted(() => ({
 }));
 
 vi.mock("../octokit.ts", () => ({
+  createGitHubAppOctokit: githubMocks.createGitHubAppOctokit,
   createGitHubAppToken: githubMocks.createGitHubAppToken,
   ensureGitHubRepository: githubMocks.ensureGitHubRepository,
   revokeGitHubAppToken: githubMocks.revokeGitHubAppToken,
+}));
+
+vi.mock("octokit", () => ({
+  Octokit: octokitMocks.Octokit,
 }));
 
 vi.mock("execa", () => ({
@@ -117,6 +136,7 @@ const createGitCommandHarness = ({
 
 beforeEach(() => {
   vi.clearAllMocks();
+  githubMocks.createGitHubAppOctokit.mockReturnValue(githubMocks.appOctokit);
   githubMocks.createGitHubAppToken.mockResolvedValue("installation-token");
   githubMocks.revokeGitHubAppToken.mockResolvedValue(undefined);
   osMocks.tmpdir.mockReturnValue("/tmp-prefix");
@@ -140,11 +160,22 @@ it("publishes by committing on top of remote main without force-pushing history"
   expect(githubMocks.ensureGitHubRepository).toHaveBeenCalledWith(
     "pagopa-dx",
     expectedRepo,
-    "installation-token",
+    octokitMocks.repoOctokit,
   );
-  expect(githubMocks.createGitHubAppToken).toHaveBeenCalledWith("pagopa-dx", {
+  expect(githubMocks.createGitHubAppOctokit).toHaveBeenCalledWith({
     clientId: "Iv23.client-id",
     privateKey: "private-key",
+  });
+  expect(githubMocks.createGitHubAppToken).toHaveBeenCalledWith(
+    "pagopa-dx",
+    {
+      clientId: "Iv23.client-id",
+      privateKey: "private-key",
+    },
+    githubMocks.appOctokit,
+  );
+  expect(octokitMocks.Octokit).toHaveBeenCalledWith({
+    auth: "installation-token",
   });
   expect(osMocks.tmpdir).toHaveBeenCalledWith();
   expect(fsMocks.mkdtemp).toHaveBeenCalledWith("/tmp-prefix/export-repo-");
@@ -343,8 +374,11 @@ it("uses the provided token without generating a GitHub App token", async () => 
   expect(githubMocks.ensureGitHubRepository).toHaveBeenCalledWith(
     "pagopa-dx",
     expectedRepo,
-    "legacy-token",
+    octokitMocks.repoOctokit,
   );
+  expect(octokitMocks.Octokit).toHaveBeenCalledWith({
+    auth: "legacy-token",
+  });
   expect(execaMocks.$).toHaveBeenCalledWith(
     expect.objectContaining({
       env: expect.objectContaining({ GH_TOKEN: "legacy-token" }),
@@ -358,8 +392,16 @@ it("revokes the GitHub App token after a successful publish", async () => {
   await publishToGithub(publishInput);
 
   expect(githubMocks.revokeGitHubAppToken).toHaveBeenCalledWith(
-    "installation-token",
+    octokitMocks.repoOctokit,
   );
+});
+
+it("fails with revoke error when token revocation fails after a successful publish", async () => {
+  const revokeError = new Error("revoke failed");
+  createGitCommandHarness();
+  githubMocks.revokeGitHubAppToken.mockRejectedValue(revokeError);
+
+  await expect(publishToGithub(publishInput)).rejects.toBe(revokeError);
 });
 
 it("cleans up temporary directory after successful publish", async () => {
@@ -402,7 +444,25 @@ it("cleans up temporary directory even when publish fails", async () => {
     recursive: true,
   });
   expect(githubMocks.revokeGitHubAppToken).toHaveBeenCalledWith(
-    "installation-token",
+    octokitMocks.repoOctokit,
+  );
+});
+
+it("prioritizes publish failure over revoke failure", async () => {
+  const publishError = new Error("push failed");
+  const revokeError = new Error("revoke failed");
+  createGitCommandHarness({
+    onCommand: (command) => {
+      if (command.startsWith("git push ")) {
+        return Promise.reject(publishError);
+      }
+    },
+  });
+  githubMocks.revokeGitHubAppToken.mockRejectedValue(revokeError);
+
+  await expect(publishToGithub(publishInput)).rejects.toBe(publishError);
+  expect(githubMocks.revokeGitHubAppToken).toHaveBeenCalledWith(
+    octokitMocks.repoOctokit,
   );
 });
 

--- a/packages/nx-terraform-plugin/src/adapters/github/octokit.ts
+++ b/packages/nx-terraform-plugin/src/adapters/github/octokit.ts
@@ -24,7 +24,7 @@ export const createGitHubAppOctokit = (
 export const createGitHubAppToken = async (
   owner: string,
   credentials: GitHubAppCredentials,
-  appOctokit: Octokit = createGitHubAppOctokit(credentials),
+  appOctokit: Octokit,
 ): Promise<string> => {
   const installation = await appOctokit.rest.apps.getOrgInstallation({
     org: owner,

--- a/packages/nx-terraform-plugin/src/adapters/github/octokit.ts
+++ b/packages/nx-terraform-plugin/src/adapters/github/octokit.ts
@@ -8,17 +8,24 @@ export interface GitHubAppCredentials {
   privateKey: string;
 }
 
-export const createGitHubAppToken = async (
-  owner: string,
+export const createGitHubAppOctokit = (
   credentials: GitHubAppCredentials,
-): Promise<string> => {
-  const appOctokit = new Octokit({
+): Octokit =>
+  new Octokit({
     auth: {
       appId: credentials.clientId,
       privateKey: credentials.privateKey,
     },
     authStrategy: createAppAuth,
   });
+
+// Resolves the owner installation and creates the short-lived token used by
+// git and repository API calls during the Terraform module publish flow.
+export const createGitHubAppToken = async (
+  owner: string,
+  credentials: GitHubAppCredentials,
+  appOctokit: Octokit = createGitHubAppOctokit(credentials),
+): Promise<string> => {
   const installation = await appOctokit.rest.apps.getOrgInstallation({
     org: owner,
   });
@@ -37,8 +44,7 @@ export const createGitHubAppToken = async (
   return authentication.token;
 };
 
-export const revokeGitHubAppToken = async (token: string): Promise<void> => {
-  const octokit = new Octokit({ auth: token });
+export const revokeGitHubAppToken = async (octokit: Octokit): Promise<void> => {
   await octokit.rest.apps.revokeInstallationAccessToken();
 };
 
@@ -60,12 +66,8 @@ const getAuthenticatedUserLogin = async (
 export const ensureGitHubRepository = async (
   owner: string,
   repo: string,
-  token: string,
+  octokit: Octokit,
 ): Promise<void> => {
-  const octokit = new Octokit({
-    auth: token,
-  });
-
   try {
     await octokit.rest.repos.get({
       owner,

--- a/packages/nx-terraform-plugin/src/adapters/github/publisher.ts
+++ b/packages/nx-terraform-plugin/src/adapters/github/publisher.ts
@@ -4,8 +4,10 @@ import { $ as $_ } from "execa";
 import { cp, mkdtemp, readdir, rm } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { basename, join } from "node:path";
+import { Octokit } from "octokit";
 
 import {
+  createGitHubAppOctokit,
   createGitHubAppToken,
   ensureGitHubRepository,
   type GitHubAppCredentials,
@@ -24,6 +26,12 @@ export interface PublishToGithubInput {
 }
 
 export type PublishToGithubResult = "published" | "skipped";
+
+interface PublishGitHubAuthentication {
+  octokit: Octokit;
+  shouldRevokeToken: boolean;
+  token: string;
+}
 
 export const getRepoNameFromProjectRoot = (
   projectRoot: string,
@@ -64,26 +72,49 @@ const clearExportWorkingTree = async (
   );
 };
 
+const createPublishGitHubAuthentication = async (
+  input: PublishToGithubInput,
+): Promise<PublishGitHubAuthentication> => {
+  if (input.githubAppCredentials === undefined) {
+    return {
+      octokit: new Octokit({ auth: input.githubToken }),
+      shouldRevokeToken: false,
+      token: input.githubToken,
+    };
+  }
+
+  const appOctokit = createGitHubAppOctokit(input.githubAppCredentials);
+  const token = await createGitHubAppToken(
+    input.githubOwner,
+    input.githubAppCredentials,
+    appOctokit,
+  );
+
+  return {
+    octokit: new Octokit({ auth: token }),
+    shouldRevokeToken: true,
+    token,
+  };
+};
+
 export const publishToGithub = async (
   input: PublishToGithubInput,
 ): Promise<PublishToGithubResult> => {
   const repo = getRepoNameFromProjectRoot(input.projectRoot, input.provider);
   const repoUrl = `https://github.com/${input.githubOwner}/${repo}.git`;
   const sourceModuleDirectory = join(input.workspaceRoot, input.projectRoot);
-  const token =
-    input.githubAppCredentials === undefined
-      ? input.githubToken
-      : await createGitHubAppToken(
-          input.githubOwner,
-          input.githubAppCredentials,
-        );
+  const githubAuthentication = await createPublishGitHubAuthentication(input);
 
   let publishError: unknown;
   let publishResult: PublishToGithubResult = "published";
   let tempExportDir: string | undefined;
 
   try {
-    await ensureGitHubRepository(input.githubOwner, repo, token);
+    await ensureGitHubRepository(
+      input.githubOwner,
+      repo,
+      githubAuthentication.octokit,
+    );
     tempExportDir = await mkdtemp(join(tmpdir(), "export-repo-"));
 
     await copyModuleDirectoryContents(sourceModuleDirectory, tempExportDir);
@@ -91,7 +122,7 @@ export const publishToGithub = async (
     const $ = $_({
       cwd: tempExportDir,
       env: {
-        GH_TOKEN: token,
+        GH_TOKEN: githubAuthentication.token,
         GIT_AUTHOR_EMAIL: "pagopa-dx-bot@pagopa.it",
         GIT_AUTHOR_NAME: "PagoPA DX Bot",
         GIT_COMMITTER_EMAIL: "pagopa-dx-bot@pagopa.it",
@@ -183,11 +214,11 @@ export const publishToGithub = async (
   }
 
   let revokeError: unknown;
-  if (input.githubAppCredentials !== undefined) {
+  if (githubAuthentication.shouldRevokeToken) {
     try {
       // Installation tokens are temporary, but revoking them minimizes their
       // usable lifetime even when publishing failed or was skipped.
-      await revokeGitHubAppToken(token);
+      await revokeGitHubAppToken(githubAuthentication.octokit);
     } catch (error) {
       revokeError = error;
     }

--- a/packages/nx-terraform-plugin/src/adapters/github/publisher.ts
+++ b/packages/nx-terraform-plugin/src/adapters/github/publisher.ts
@@ -14,16 +14,17 @@ import {
   revokeGitHubAppToken,
 } from "./octokit.ts";
 
-export interface PublishToGithubInput {
-  description: string;
-  githubAppCredentials?: GitHubAppCredentials;
-  githubOwner: string;
-  githubToken: string;
-  projectRoot: string;
-  provider: string;
-  version: string;
-  workspaceRoot: string;
-}
+export type PublishToGithubInput = PublishToGithubOptions &
+  (
+    | {
+        githubAppCredentials: GitHubAppCredentials;
+        useGitHubAppAuthentication: true;
+      }
+    | {
+        githubToken: string;
+        useGitHubAppAuthentication: false;
+      }
+  );
 
 export type PublishToGithubResult = "published" | "skipped";
 
@@ -31,6 +32,15 @@ interface PublishGitHubAuthentication {
   octokit: Octokit;
   shouldRevokeToken: boolean;
   token: string;
+}
+
+interface PublishToGithubOptions {
+  description: string;
+  githubOwner: string;
+  projectRoot: string;
+  provider: string;
+  version: string;
+  workspaceRoot: string;
 }
 
 export const getRepoNameFromProjectRoot = (
@@ -75,7 +85,7 @@ const clearExportWorkingTree = async (
 const createPublishGitHubAuthentication = async (
   input: PublishToGithubInput,
 ): Promise<PublishGitHubAuthentication> => {
-  if (input.githubAppCredentials === undefined) {
+  if (!input.useGitHubAppAuthentication) {
     return {
       octokit: new Octokit({ auth: input.githubToken }),
       shouldRevokeToken: false,

--- a/packages/nx-terraform-plugin/src/executors/publish/__tests__/publish.test.ts
+++ b/packages/nx-terraform-plugin/src/executors/publish/__tests__/publish.test.ts
@@ -94,9 +94,9 @@ describe("Publish Executor", () => {
         privateKey: "private-key\nsecond-line",
       },
       githubOwner: "pagopa-dx",
-      githubToken: "",
       projectRoot: "infra/modules/azure_core_infra",
       provider: "aws",
+      useGitHubAppAuthentication: true,
       version: "1.2.3",
       workspaceRoot: "/repo",
     });
@@ -129,14 +129,11 @@ describe("Publish Executor authentication", () => {
 
     expect(output.success).toBe(false);
     expect(loggerMocks.warn).toHaveBeenCalledWith(
-      "Invalid GitHub authentication environment",
+      "Invalid publish options",
       expect.objectContaining({
-        issues: expect.arrayContaining([
-          expect.objectContaining({
-            path: ["environment", "GH_APP_CLIENT_ID"],
-          }),
-          expect.objectContaining({ path: ["environment", "GH_APP_KEY"] }),
-        ]),
+        error: expect.stringMatching(
+          /environment\.(GH_APP_CLIENT_ID|GH_APP_KEY)/,
+        ),
       }),
     );
     expect(publisherMocks.publishToGithub).not.toHaveBeenCalled();
@@ -158,12 +155,16 @@ describe("Publish Executor authentication", () => {
     const output = await executor(options, baseContext);
 
     expect(output.success).toBe(true);
-    expect(publisherMocks.publishToGithub).toHaveBeenCalledWith(
-      expect.objectContaining({
-        githubOwner: "manifest-owner",
-        githubToken: "legacy-token",
-      }),
-    );
+    expect(publisherMocks.publishToGithub).toHaveBeenCalledWith({
+      description: "Terraform module description",
+      githubOwner: "manifest-owner",
+      githubToken: "legacy-token",
+      projectRoot: "infra/modules/azure_core_infra",
+      provider: "aws",
+      useGitHubAppAuthentication: false,
+      version: "1.2.3",
+      workspaceRoot: "/repo",
+    });
   });
 
   it("falls back to GITHUB_TOKEN when GH_TOKEN is not set", async () => {
@@ -230,17 +231,7 @@ describe("Publish Executor validation", () => {
     expect(loggerMocks.warn).toHaveBeenCalledWith(
       "Invalid publish options",
       expect.objectContaining({
-        issues: expect.arrayContaining([
-          expect.objectContaining({
-            path: ["githubOwner"],
-          }),
-          expect.objectContaining({
-            path: ["projectRoot"],
-          }),
-          expect.objectContaining({
-            path: ["workspaceRoot"],
-          }),
-        ]),
+        error: expect.stringMatching(/githubOwner|projectRoot|workspaceRoot/),
         path: "publish options",
       }),
     );

--- a/packages/nx-terraform-plugin/src/executors/publish/__tests__/publish.test.ts
+++ b/packages/nx-terraform-plugin/src/executors/publish/__tests__/publish.test.ts
@@ -132,8 +132,10 @@ describe("Publish Executor authentication", () => {
       "Invalid GitHub authentication environment",
       expect.objectContaining({
         issues: expect.arrayContaining([
-          expect.objectContaining({ path: ["GH_APP_CLIENT_ID"] }),
-          expect.objectContaining({ path: ["GH_APP_KEY"] }),
+          expect.objectContaining({
+            path: ["environment", "GH_APP_CLIENT_ID"],
+          }),
+          expect.objectContaining({ path: ["environment", "GH_APP_KEY"] }),
         ]),
       }),
     );

--- a/packages/nx-terraform-plugin/src/executors/publish/publish.ts
+++ b/packages/nx-terraform-plugin/src/executors/publish/publish.ts
@@ -6,8 +6,6 @@ import {
 } from "../../adapters/github/publisher.ts";
 import { configureLogger, getPackageLogger } from "../../logger.ts";
 import {
-  githubAppEnvironmentSchema,
-  githubTokenEnvironmentSchema,
   type NxReleasePublishExecutorInput,
   nxReleasePublishExecutorSchema,
 } from "./schema.ts";
@@ -18,55 +16,35 @@ const runExecutor: PromiseExecutor<NxReleasePublishExecutorInput> = async (
   options,
 ) => {
   const logger = getPackageLogger(["publish"]);
-  const parseResult = nxReleasePublishExecutorSchema.safeParse(options);
+  const parseResult = nxReleasePublishExecutorSchema.safeParse({
+    ...options,
+    environment: process.env,
+  });
 
   await configureLogger();
 
   if (!parseResult.success) {
-    logger.warn("Invalid publish options", {
-      issues: parseResult.error.issues,
-      path: options.projectRoot ?? "publish options",
-    });
+    const issues = parseResult.error.issues.flatMap((issue) =>
+      issue.code === "invalid_union" ? issue.errors.flat() : [issue],
+    );
+    const hasEnvironmentIssue = issues.some(
+      (issue) => issue.path[0] === "environment",
+    );
+    logger.warn(
+      hasEnvironmentIssue
+        ? "Invalid GitHub authentication environment"
+        : "Invalid publish options",
+      {
+        issues,
+        path: options.projectRoot ?? "publish options",
+      },
+    );
     return {
       success: false,
     };
   }
 
   const validatedOptions = parseResult.data;
-  let githubAppCredentials:
-    | undefined
-    | { clientId: string; privateKey: string };
-  let githubToken: string;
-
-  if (validatedOptions.useGitHubAppAuthentication) {
-    const environmentParseResult = githubAppEnvironmentSchema.safeParse(
-      process.env,
-    );
-    if (!environmentParseResult.success) {
-      logger.warn("Invalid GitHub authentication environment", {
-        issues: environmentParseResult.error.issues,
-        path: validatedOptions.projectRoot,
-      });
-      return { success: false };
-    }
-    githubAppCredentials = {
-      clientId: environmentParseResult.data.GH_APP_CLIENT_ID,
-      privateKey: environmentParseResult.data.GH_APP_KEY,
-    };
-    githubToken = "";
-  } else {
-    const environmentParseResult = githubTokenEnvironmentSchema.safeParse(
-      process.env,
-    );
-    if (!environmentParseResult.success) {
-      logger.warn("Invalid GitHub authentication environment", {
-        issues: environmentParseResult.error.issues,
-        path: validatedOptions.projectRoot,
-      });
-      return { success: false };
-    }
-    githubToken = environmentParseResult.data;
-  }
 
   const repoName = getRepoNameFromProjectRoot(
     validatedOptions.projectRoot,
@@ -83,9 +61,9 @@ const runExecutor: PromiseExecutor<NxReleasePublishExecutorInput> = async (
 
   const publishResult = await publishToGithub({
     description: validatedOptions.description,
-    githubAppCredentials,
+    githubAppCredentials: validatedOptions.githubAppCredentials,
     githubOwner: validatedOptions.githubOwner,
-    githubToken,
+    githubToken: validatedOptions.githubToken,
     projectRoot: validatedOptions.projectRoot,
     provider: validatedOptions.provider,
     version: validatedOptions.version,

--- a/packages/nx-terraform-plugin/src/executors/publish/publish.ts
+++ b/packages/nx-terraform-plugin/src/executors/publish/publish.ts
@@ -1,4 +1,5 @@
 import { PromiseExecutor } from "@nx/devkit";
+import { z } from "zod/v4";
 
 import {
   getRepoNameFromProjectRoot,
@@ -24,21 +25,10 @@ const runExecutor: PromiseExecutor<NxReleasePublishExecutorInput> = async (
   await configureLogger();
 
   if (!parseResult.success) {
-    const issues = parseResult.error.issues.flatMap((issue) =>
-      issue.code === "invalid_union" ? issue.errors.flat() : [issue],
-    );
-    const hasEnvironmentIssue = issues.some(
-      (issue) => issue.path[0] === "environment",
-    );
-    logger.warn(
-      hasEnvironmentIssue
-        ? "Invalid GitHub authentication environment"
-        : "Invalid publish options",
-      {
-        issues,
-        path: options.projectRoot ?? "publish options",
-      },
-    );
+    logger.warn("Invalid publish options", {
+      error: z.prettifyError(parseResult.error),
+      path: options.projectRoot ?? "publish options",
+    });
     return {
       success: false,
     };
@@ -59,16 +49,7 @@ const runExecutor: PromiseExecutor<NxReleasePublishExecutorInput> = async (
     },
   );
 
-  const publishResult = await publishToGithub({
-    description: validatedOptions.description,
-    githubAppCredentials: validatedOptions.githubAppCredentials,
-    githubOwner: validatedOptions.githubOwner,
-    githubToken: validatedOptions.githubToken,
-    projectRoot: validatedOptions.projectRoot,
-    provider: validatedOptions.provider,
-    version: validatedOptions.version,
-    workspaceRoot: validatedOptions.workspaceRoot,
-  });
+  const publishResult = await publishToGithub(validatedOptions);
 
   if (publishResult === "skipped") {
     logger.info("Skipping release, tag already exists");

--- a/packages/nx-terraform-plugin/src/executors/publish/schema.ts
+++ b/packages/nx-terraform-plugin/src/executors/publish/schema.ts
@@ -28,7 +28,7 @@ export const githubTokenEnvironmentSchema = z
     return token;
   });
 
-export const nxReleasePublishExecutorSchema = z.object({
+const nxReleasePublishExecutorOptionsSchema = z.object({
   description: publishSchema.shape.description,
   githubOwner: publishSchema.shape.github.shape.owner,
   projectRoot: z.string().min(1),
@@ -38,9 +38,58 @@ export const nxReleasePublishExecutorSchema = z.object({
   workspaceRoot: z.string(),
 });
 
+const hasOwnProperty = (value: object, property: string): boolean =>
+  Object.prototype.hasOwnProperty.call(value, property);
+
+const nxReleasePublishExecutorAuthenticationSchema = z.preprocess(
+  (input) => {
+    if (
+      input !== null &&
+      typeof input === "object" &&
+      !Array.isArray(input) &&
+      !hasOwnProperty(input, "useGitHubAppAuthentication")
+    ) {
+      return {
+        ...input,
+        useGitHubAppAuthentication: false,
+      };
+    }
+
+    return input;
+  },
+  z.xor([
+    nxReleasePublishExecutorOptionsSchema
+      .extend({
+        environment: githubAppEnvironmentSchema,
+        useGitHubAppAuthentication: z.literal(true),
+      })
+      .transform(({ environment, ...options }) => ({
+        ...options,
+        githubAppCredentials: {
+          clientId: environment.GH_APP_CLIENT_ID,
+          privateKey: environment.GH_APP_KEY,
+        },
+        githubToken: "",
+      })),
+    nxReleasePublishExecutorOptionsSchema
+      .extend({
+        environment: githubTokenEnvironmentSchema,
+        useGitHubAppAuthentication: z.literal(false).default(false),
+      })
+      .transform(({ environment, ...options }) => ({
+        ...options,
+        githubAppCredentials: undefined,
+        githubToken: environment,
+      })),
+  ]),
+);
+
+export const nxReleasePublishExecutorSchema =
+  nxReleasePublishExecutorAuthenticationSchema;
+
 export type NxReleasePublishExecutorInput =
   Partial<NxReleasePublishExecutorSchema>;
 
 export type NxReleasePublishExecutorSchema = z.input<
-  typeof nxReleasePublishExecutorSchema
+  typeof nxReleasePublishExecutorOptionsSchema
 >;

--- a/packages/nx-terraform-plugin/src/executors/publish/schema.ts
+++ b/packages/nx-terraform-plugin/src/executors/publish/schema.ts
@@ -33,56 +33,52 @@ const nxReleasePublishExecutorOptionsSchema = z.object({
   githubOwner: publishSchema.shape.github.shape.owner,
   projectRoot: z.string().min(1),
   provider: publishSchema.shape.provider,
-  useGitHubAppAuthentication: z.boolean().default(false),
   version: publishSchema.shape.version,
   workspaceRoot: z.string(),
 });
 
-const hasOwnProperty = (value: object, property: string): boolean =>
-  Object.prototype.hasOwnProperty.call(value, property);
+const nxReleasePublishExecutorGitHubAppOptionsSchema =
+  nxReleasePublishExecutorOptionsSchema.extend({
+    useGitHubAppAuthentication: z.literal(true),
+  });
 
-const nxReleasePublishExecutorAuthenticationSchema = z.preprocess(
-  (input) => {
-    if (
-      input !== null &&
-      typeof input === "object" &&
-      !Array.isArray(input) &&
-      !hasOwnProperty(input, "useGitHubAppAuthentication")
-    ) {
-      return {
-        ...input,
-        useGitHubAppAuthentication: false,
-      };
-    }
+const nxReleasePublishExecutorGitHubTokenOptionsSchema =
+  nxReleasePublishExecutorOptionsSchema.extend({
+    useGitHubAppAuthentication: z.literal(false),
+  });
 
-    return input;
-  },
-  z.xor([
-    nxReleasePublishExecutorOptionsSchema
-      .extend({
+const nxReleasePublishExecutorAuthenticationSchema = z
+  .looseObject({
+    useGitHubAppAuthentication: z.boolean().default(false),
+  })
+  .pipe(
+    z.discriminatedUnion("useGitHubAppAuthentication", [
+      nxReleasePublishExecutorGitHubAppOptionsSchema.extend({
         environment: githubAppEnvironmentSchema,
-        useGitHubAppAuthentication: z.literal(true),
-      })
-      .transform(({ environment, ...options }) => ({
-        ...options,
+      }),
+      nxReleasePublishExecutorGitHubTokenOptionsSchema.extend({
+        environment: githubTokenEnvironmentSchema,
+      }),
+    ]),
+  )
+  .transform((options) => {
+    if (options.useGitHubAppAuthentication) {
+      const { environment, ...publishOptions } = options;
+      return {
+        ...publishOptions,
         githubAppCredentials: {
           clientId: environment.GH_APP_CLIENT_ID,
           privateKey: environment.GH_APP_KEY,
         },
-        githubToken: "",
-      })),
-    nxReleasePublishExecutorOptionsSchema
-      .extend({
-        environment: githubTokenEnvironmentSchema,
-        useGitHubAppAuthentication: z.literal(false).default(false),
-      })
-      .transform(({ environment, ...options }) => ({
-        ...options,
-        githubAppCredentials: undefined,
-        githubToken: environment,
-      })),
-  ]),
-);
+      };
+    }
+
+    const { environment: githubToken, ...publishOptions } = options;
+    return {
+      ...publishOptions,
+      githubToken,
+    };
+  });
 
 export const nxReleasePublishExecutorSchema =
   nxReleasePublishExecutorAuthenticationSchema;
@@ -90,6 +86,8 @@ export const nxReleasePublishExecutorSchema =
 export type NxReleasePublishExecutorInput =
   Partial<NxReleasePublishExecutorSchema>;
 
-export type NxReleasePublishExecutorSchema = z.input<
-  typeof nxReleasePublishExecutorOptionsSchema
->;
+export type NxReleasePublishExecutorSchema =
+  | z.input<typeof nxReleasePublishExecutorGitHubAppOptionsSchema>
+  | (z.input<typeof nxReleasePublishExecutorOptionsSchema> & {
+      useGitHubAppAuthentication?: false;
+    });


### PR DESCRIPTION
Enhance GitHub authentication for the Terraform module publish process by reusing Octokit clients and validating inputs through a unified schema. This update simplifies the authentication flow and improves error handling for invalid configurations.