### PR TITLE
ingest AZQR reports as cost and cleanup findings

### DIFF
--- a/.nx/version-plans/version-plan-1784646063753.md
+++ b/.nx/version-plans/version-plan-1784646063753.md
@@ -1,0 +1,5 @@
+---
+docs: patch
+---
+
+Update SaveMoney docs with AZQR as new baseline

--- a/.nx/version-plans/version-plan-1784646106426.md
+++ b/.nx/version-plans/version-plan-1784646106426.md
@@ -1,0 +1,6 @@
+---
+'@pagopa/dx-cli': patch
+---
+
+Ingest AZQR (`azqr scan --json`) reports as a SaveMoney baseline.
+The report path can be supplied via a new `--azqr-report <path>` CLI option.

--- a/.nx/version-plans/version-plan-1784646148709.md
+++ b/.nx/version-plans/version-plan-1784646148709.md
@@ -1,0 +1,18 @@
+---
+"@pagopa/dx-savemoney": minor
+---
+
+Ingest AZQR (`azqr scan --json`) reports as a SaveMoney baseline. The report
+path can be supplied via a new `--azqr-report <path>` CLI option or the
+`azure.azqrReportPath` YAML config key (the CLI flag takes precedence). Its
+FinOps-relevant `impacted` resources are merged into the normal scan output as
+findings with an `azqr` source. A noise-reduction filter classifies them as
+either `cost` opportunities (rows AZQR categorises as `Cost`, and orphaned
+billable resources such as public IPs, NAT gateways, application gateways, App
+Service plans, SQL elastic pools, load balancers, DDoS plans, VNet gateways and
+managed disks) or low-severity `operationalExcellence` cleanup candidates
+(orphaned free resources flagged by AZQR's `AOR` checks — empty subnets,
+unattached NSGs, orphan API connections, unconnected private endpoints), while
+dropping security, reliability and high-availability best-practice noise. Masked
+reports are detected and a warning advises re-running AZQR with `--mask=false`
+so resource IDs match the live scan.

--- a/apps/cli/README.md
+++ b/apps/cli/README.md
@@ -218,14 +218,15 @@ dx savemoney [options]
 
 **Options:**
 
-| Option       | Alias | Description                                                                                                                                  | Default      |
-| :----------- | :---- | :------------------------------------------------------------------------------------------------------------------------------------------- | :----------- |
-| `--config`   | `-c`  | Path to a YAML configuration file.                                                                                                           | N/A          |
-| `--format`   | `-f`  | Report format: `table`, `json`, `detailed-json`, or `lint`.                                                                                  | `table`      |
-| `--days`     | `-d`  | Metric analysis period in days (overrides config file).                                                                                      | `30`         |
-| `--location` | `-l`  | Preferred Azure location for resources (overrides config file).                                                                              | `italynorth` |
-| `--tags`     | `-t`  | Filter resources by tags (`key=value key2=value2`). Only resources matching **all** specified tags are analyzed (variadic: space-separated). | N/A          |
-| `--source`   | `-s`  | Restrict findings to a specific source: `advisor`, `custom`, or `all`.                                                                       | `all`        |
+| Option          | Alias | Description                                                                                                                                  | Default      |
+| :-------------- | :---- | :------------------------------------------------------------------------------------------------------------------------------------------- | :----------- |
+| `--config`      | `-c`  | Path to a YAML configuration file.                                                                                                           | N/A          |
+| `--format`      | `-f`  | Report format: `table`, `json`, `detailed-json`, or `lint`.                                                                                  | `table`      |
+| `--days`        | `-d`  | Metric analysis period in days (overrides config file).                                                                                      | `30`         |
+| `--location`    | `-l`  | Preferred Azure location for resources (overrides config file).                                                                              | `italynorth` |
+| `--tags`        | `-t`  | Filter resources by tags (`key=value key2=value2`). Only resources matching **all** specified tags are analyzed (variadic: space-separated). | N/A          |
+| `--source`      | `-s`  | Restrict findings to a specific source: `advisor`, `custom`, or `all`.                                                                       | `all`        |
+| `--azqr-report` |       | Path to an [AZQR](https://github.com/Azure/azqr) `scan --json` report to merge as additional findings (overrides `azure.azqrReportPath`).    | N/A          |
 
 > `--verbose` / `-v` is inherited from the root command. See [Global Options](#global-options).
 
@@ -249,6 +250,9 @@ dx savemoney --config config.yaml --tags "environment=prod"
 
 # Analyze with specific timespan
 dx savemoney --days 60 --location italynorth
+
+# Merge an AZQR report (run `azqr scan --mask=false --json` first)
+dx savemoney --config config.yaml --azqr-report azqr_action_plan.json
 ```
 
 **Configuration file example (`config.yaml`):**
@@ -260,6 +264,7 @@ azure:
     - subscription-2
   preferredLocation: italynorth
   timespanDays: 30
+  azqrReportPath: ./azqr_action_plan.json # optional — merge an AZQR scan report
   thresholds: # optional — omit to use built-in defaults
     vm:
       cpuPercent: 5
@@ -282,6 +287,7 @@ azure:
 - **Container Apps**: Not running, zero replicas, low resource usage
 - **Static Web Apps**: No traffic or very low usage patterns
 - **Azure Advisor recommendations**: Reserved Instance and Savings Plan opportunities, right-sizing suggestions, and other cost recommendations surfaced directly from Azure Advisor — with estimated monthly savings where available
+- **AZQR report** (optional, via `--azqr-report`): billable orphans (cost) and free orphaned resources such as empty subnets or unattached NSGs (cleanup candidates) parsed from an `azqr scan --json` report
 
 > [!NOTE]
 > Currently only Azure is supported. Support for additional cloud providers (AWS) is planned for future releases.

--- a/apps/cli/src/adapters/commander/commands/savemoney.ts
+++ b/apps/cli/src/adapters/commander/commands/savemoney.ts
@@ -42,6 +42,10 @@ export const makeSavemoneyCommand = () =>
       "--no-pricing",
       "Disable Azure Retail Prices enrichment (skips custom cost-at-risk estimates)",
     )
+    .option(
+      "--azqr-report <path>",
+      "Path to an AZQR (`azqr scan --json`) report; its FinOps-relevant impacted resources are merged into the output. Overrides `azure.azqrReportPath` from the config file. Run AZQR with `--mask=false` so resource IDs match.",
+    )
     .action(async function (options) {
       const { verbose } = this.optsWithGlobals<GlobalOptions>();
       try {
@@ -54,6 +58,7 @@ export const makeSavemoneyCommand = () =>
 
         const finalConfig: AzureConfig = {
           ...config,
+          ...(options.azqrReport ? { azqrReportPath: options.azqrReport } : {}),
           filterTags,
           preferredLocation:
             this.getOptionValueSource("location") === "cli"

--- a/apps/website/docs/dx-cli/usage.md
+++ b/apps/website/docs/dx-cli/usage.md
@@ -307,6 +307,9 @@ The tool supports multiple authentication methods:
   `json`, `detailed-json`, `lint`
 - `--source`, `-s` - Restrict findings to a specific source: `advisor`,
   `custom`, or `all` (default: `all`)
+- `--azqr-report` - Path to an [AZQR](https://github.com/Azure/azqr)
+  `scan --json` report to merge as additional findings (overrides
+  `azure.azqrReportPath`)
 - `--tags`, `-t` - Filter resources by Azure tags (e.g. `env=prod team=dx`)
 - `--verbose`, `-v` - Enable detailed logging
 
@@ -321,6 +324,7 @@ azure:
     - yyyyyyyy-yyyy-yyyy-yyyy-yyyyyyyyyyyy
   preferredLocation: italynorth
   timespanDays: 30
+  azqrReportPath: ./azqr_action_plan.json # optional — merge an AZQR scan report
   thresholds: # optional — omit to use built-in defaults
     vm:
       cpuPercent: 5
@@ -348,18 +352,19 @@ identity).
 The tool analyzes the following Azure resource types for potential cost
 optimization:
 
-| Resource Type       | Risk | What It Detects                                    |
-| :------------------ | :--: | :------------------------------------------------- |
-| Virtual Machines    |  🔴  | VMs that are deallocated or severely underutilized |
-| App Service Plans   |  🔴  | Empty or underutilized plans (especially Premium)  |
-| Managed Disks       |  🟡  | Unattached disks incurring storage costs           |
-| Public IP Addresses |  🟡  | Unused static IPs that continue billing            |
-| Network Interfaces  |  🟡  | NICs not attached to VMs or Private Endpoints      |
-| Private Endpoints   |  🟡  | Misconfigured or unused Private Endpoints          |
-| Storage Accounts    |  🟡  | Storage accounts with minimal activity             |
-| Container Apps      |  🟡  | Not running, zero replicas, low resource usage     |
-| Static Web Apps     |  🟢  | No traffic or very low usage patterns              |
-| Azure Advisor       |  ⚪  | Reserved Instance and Savings Plan opportunities   |
+| Resource Type       | Risk | What It Detects                                                   |
+| :------------------ | :--: | :---------------------------------------------------------------- |
+| Virtual Machines    |  🔴  | VMs that are deallocated or severely underutilized                |
+| App Service Plans   |  🔴  | Empty or underutilized plans (especially Premium)                 |
+| Managed Disks       |  🟡  | Unattached disks incurring storage costs                          |
+| Public IP Addresses |  🟡  | Unused static IPs that continue billing                           |
+| Network Interfaces  |  🟡  | NICs not attached to VMs or Private Endpoints                     |
+| Private Endpoints   |  🟡  | Misconfigured or unused Private Endpoints                         |
+| Storage Accounts    |  🟡  | Storage accounts with minimal activity                            |
+| Container Apps      |  🟡  | Not running, zero replicas, low resource usage                    |
+| Static Web Apps     |  🟢  | No traffic or very low usage patterns                             |
+| Azure Advisor       |  ⚪  | Reserved Instance and Savings Plan opportunities                  |
+| AZQR report         |  ⚪  | Billable orphans and free cleanup candidates from `--azqr-report` |
 
 **Risk Levels:** 🔴 High · 🟡 Medium · 🟢 Low · ⚪ Varies
 
@@ -454,6 +459,9 @@ npx @pagopa/dx-cli savemoney --config config.yaml --format lint
 
 # Filter to a specific environment
 npx @pagopa/dx-cli savemoney --config config.yaml --tags env=prod
+
+# Merge an AZQR report (run `azqr scan --mask=false --json` first)
+npx @pagopa/dx-cli savemoney --config config.yaml --azqr-report azqr_action_plan.json
 
 # Verbose output for debugging
 npx @pagopa/dx-cli savemoney --config config.yaml --verbose

--- a/packages/savemoney/README.md
+++ b/packages/savemoney/README.md
@@ -102,6 +102,7 @@ The tool analyzes the following Azure resource types with specific detection met
 | **Storage Accounts**    | Metrics                 | 🟡 Medium | Very low transaction count (<10 per days in timespan)                                                                                                       |
 | **Static Web Apps**     | Metrics                 |  🟢 Low   | No traffic data available, Very low site hits (<100 requests in 30 days), Very low data transfer (<1MB in 30 days)                                          |
 | **Azure Advisor**       | Advisor API             | ⚪ Varies | Reserved Instance and Savings Plan opportunities, right-sizing suggestions, and other Cost recommendations — with estimated monthly savings where available |
+| **AZQR report**         | `--azqr-report` JSON    | ⚪ Varies | Optional. Billable orphans (cost) and free orphaned resources such as empty subnets or unattached NSGs (cleanup candidates) parsed from an AZQR scan        |
 
 #### Pricing Coverage
 
@@ -160,6 +161,7 @@ The tool requires the following configuration:
 | `verbose`           | `boolean`                |    ❌    | `false`      | Enable detailed logging for each resource analyzed                        |
 | `filterTags`        | `Record<string, string>` |    ❌    | -            | Only analyze resources matching **all** the specified tag key-value pairs |
 | `thresholds`        | `Thresholds`             |    ❌    | see below    | Override the default numeric thresholds used during analysis              |
+| `azqrReportPath`    | `string`                 |    ❌    | -            | Path to an AZQR `--json` report to ingest (see AZQR Report Ingestion)     |
 
 #### Output Formats
 
@@ -327,6 +329,52 @@ const config = await loadConfig(); // Will read from env vars
 const reports = await azure.analyzeAzureResources(config);
 await azure.generateReport(reports, "json");
 ```
+
+#### AZQR Report Ingestion
+
+SaveMoney can enrich a live scan with an [AZQR](https://github.com/Azure/azqr)
+(`azqr scan --json`) report. Provide its path either with the `--azqr-report
+<path>` CLI flag or via the `azure.azqrReportPath` YAML key (the CLI flag takes
+precedence when both are set): the FinOps-relevant resources from the report's
+`impacted` section are merged into the normal output as findings tagged with the
+`[azqr]` source.
+
+```bash
+# Generate the AZQR report first (disable masking so resource IDs match)
+azqr scan --subscription-id <sub-id> --json --mask=false
+
+# Feed it into SaveMoney alongside the live scan
+dx savemoney --azqr-report ./azqr_action_plan.json
+```
+
+Or persist the path in the YAML config:
+
+```yaml
+azure:
+  subscriptionIds:
+    - xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx
+  azqrReportPath: ./azqr_action_plan.json
+```
+
+Notes:
+
+- **Disable masking.** AZQR masks subscription IDs by default
+  (`/subscriptions/xxxxxxxx-…/`). Masked IDs cannot be matched to live
+  resources, so findings would appear as separate stub entries. SaveMoney logs
+  a warning when it detects a masked report; re-run AZQR with `--mask=false`.
+- **Noise reduction.** Rows are classified into two buckets and everything else
+  (security, reliability, high-availability best practices) is dropped:
+  - **Cost opportunities** (`cost` category): rows AZQR categorises as `Cost`,
+    plus orphaned/unassociated **billable** resources (public IPs, NAT gateways,
+    application gateways, App Service plans, SQL elastic pools, load balancers,
+    DDoS plans, VNet gateways, managed disks/snapshots).
+  - **Cleanup candidates** (`operationalExcellence` category, low severity):
+    orphaned **free** resources flagged by AZQR's `AOR` (Azure Orphan Resources)
+    checks — empty subnets, unattached NSGs, orphan API connections, unconnected
+    private endpoints. They carry no direct cost but are worth removing after
+    verifying they are unused.
+- AZQR carries no monetary estimate, so these findings have no per-finding
+  saving amount; they surface as opportunities to review.
 
 ## AWS (Coming Soon)
 

--- a/packages/savemoney/src/azure/__tests__/azqr.test.ts
+++ b/packages/savemoney/src/azure/__tests__/azqr.test.ts
@@ -1,0 +1,238 @@
+/**
+ * Tests for the AZQR ingestion module.
+ *
+ * Cover the behaviours CES-2192 requires:
+ * 1. `parseAzqrReport` validates the JSON shape (accept valid, reject invalid).
+ * 2. `isAzqrReportMasked` detects AZQR's default subscription-ID masking.
+ * 3. `classifyAzqrRow` / `azqrImpactedToFindings` promote billable waste as
+ *    `cost`, orphaned free resources as `cleanup` candidates, and drop
+ *    security / reliability / best-practice noise.
+ * 4. Impact → severity mapping and inventory enrichment.
+ */
+
+import { describe, expect, it } from "vitest";
+
+import {
+  type AzqrImpactedRow,
+  azqrImpactedToFindings,
+  classifyAzqrRow,
+  isAzqrReportMasked,
+  parseAzqrReport,
+} from "../azqr.js";
+
+const REAL_SUB = "ec285037-c673-4f58-b594-d7c480da4e8b";
+const MASKED_SUB = "xxxxxxxx-xxxx-xxxx-xxxx-xxxxx0da4e8b";
+
+function impactedRow(
+  overrides: Partial<AzqrImpactedRow> = {},
+): AzqrImpactedRow {
+  return {
+    category: "Security",
+    impact: "Medium",
+    recommendation: "Some best practice",
+    resourceId: resourceId(
+      REAL_SUB,
+      "microsoft.network/networksecuritygroups",
+      "nsg",
+    ),
+    resourceType: "microsoft.network/networksecuritygroups",
+    source: "APRL",
+    ...overrides,
+  };
+}
+
+/** An orphaned (AOR) resource row of the given type. */
+function orphanRow(
+  resourceType: string,
+  overrides: Partial<AzqrImpactedRow> = {},
+): AzqrImpactedRow {
+  return impactedRow({
+    category: "Governance",
+    resourceId: resourceId(REAL_SUB, resourceType, "res"),
+    resourceType,
+    source: "AOR",
+    ...overrides,
+  });
+}
+
+function resourceId(sub: string, type: string, name: string): string {
+  return `/subscriptions/${sub}/resourcegroups/rg/providers/${type}/${name}`;
+}
+
+describe("parseAzqrReport", () => {
+  it("accepts a valid report and defaults missing arrays", () => {
+    const report = parseAzqrReport({ impacted: [impactedRow()] });
+    expect(report.impacted).toHaveLength(1);
+    expect(report.inventory).toEqual([]);
+  });
+
+  it("strips unknown top-level sections", () => {
+    const report = parseAzqrReport({
+      advisor: [{ anything: true }],
+      impacted: [],
+      recommendations: [{ foo: "bar" }],
+    });
+    expect(report.impacted).toEqual([]);
+  });
+
+  it("throws with a cause when an impacted row misses required fields", () => {
+    expect(() => parseAzqrReport({ impacted: [{ impact: "High" }] })).toThrow(
+      /Invalid AZQR report/,
+    );
+  });
+});
+
+describe("isAzqrReportMasked", () => {
+  it("detects masked subscription IDs in resource IDs", () => {
+    const report = parseAzqrReport({
+      impacted: [
+        impactedRow({
+          resourceId: resourceId(
+            MASKED_SUB,
+            "microsoft.network/publicipaddresses",
+            "pip",
+          ),
+        }),
+      ],
+    });
+    expect(isAzqrReportMasked(report)).toBe(true);
+  });
+
+  it("returns false when IDs carry the real subscription GUID", () => {
+    const report = parseAzqrReport({ impacted: [impactedRow()] });
+    expect(isAzqrReportMasked(report)).toBe(false);
+  });
+});
+
+describe("classifyAzqrRow", () => {
+  it("classifies rows AZQR categorises as Cost as cost", () => {
+    expect(classifyAzqrRow(impactedRow({ category: "Cost" }))).toBe("cost");
+  });
+
+  it("classifies orphaned billable resources as cost", () => {
+    expect(
+      classifyAzqrRow(
+        orphanRow("microsoft.network/publicipaddresses", {
+          recommendation: "Public IPs not attached to any resource",
+        }),
+      ),
+    ).toBe("cost");
+  });
+
+  it("classifies orphaned free resources (NSG, subnet, …) as cleanup", () => {
+    expect(
+      classifyAzqrRow(
+        orphanRow("microsoft.network/networksecuritygroups", {
+          recommendation:
+            "Network Security Groups not attached to any network interface or subnet",
+        }),
+      ),
+    ).toBe("cleanup");
+  });
+
+  it("drops non-orphan security / reliability best-practice rows", () => {
+    expect(
+      classifyAzqrRow(
+        impactedRow({
+          category: "Security",
+          recommendation: "Enable diagnostic settings",
+          resourceType: "microsoft.web/serverfarms",
+        }),
+      ),
+    ).toBeNull();
+  });
+
+  it("does not promote orphan-sounding text unless the AOR source tags it", () => {
+    expect(
+      classifyAzqrRow(
+        impactedRow({
+          category: "Governance",
+          recommendation: "Public IPs not attached to any resource",
+          resourceType: "microsoft.network/publicipaddresses",
+          source: "APRL",
+        }),
+      ),
+    ).toBeNull();
+  });
+});
+
+describe("azqrImpactedToFindings", () => {
+  it("maps billable orphans to cost findings and drops non-orphan noise", () => {
+    const report = parseAzqrReport({
+      impacted: [
+        orphanRow("microsoft.web/serverfarms", {
+          impact: "High",
+          recommendation: "App Service plans without hosting Apps",
+          recommendationId: "app-service-empty",
+          resourceId: resourceId(REAL_SUB, "microsoft.web/serverfarms", "asp"),
+        }),
+        impactedRow(), // non-orphan APRL noise → dropped
+      ],
+    });
+
+    const findings = azqrImpactedToFindings(report);
+
+    expect(findings).toHaveLength(1);
+    expect(findings[0]).toMatchObject({
+      category: "cost",
+      code: "azqr.app-service-empty",
+      severity: "high",
+      source: "azqr",
+    });
+    expect(findings[0].estimatedMonthlySavings).toBeUndefined();
+    expect(findings[0].recommendedAction).toContain("Review the resource");
+  });
+
+  it("maps orphaned free resources to low-severity cleanup candidates", () => {
+    const report = parseAzqrReport({
+      impacted: [
+        orphanRow("microsoft.network/virtualnetworks", {
+          impact: "Medium",
+          recommendation: "Subnets without Connected Devices or Delegation",
+          recommendationId: "empty-subnet",
+        }),
+      ],
+    });
+
+    const [finding] = azqrImpactedToFindings(report);
+    expect(finding).toMatchObject({
+      category: "operationalExcellence",
+      code: "azqr.empty-subnet",
+      severity: "low",
+      source: "azqr",
+    });
+    expect(finding.recommendedAction).toContain("no direct cost");
+  });
+
+  it("enriches the reason with inventory SKU / location when available", () => {
+    const id = resourceId(REAL_SUB, "microsoft.network/natgateways", "nat");
+    const report = parseAzqrReport({
+      impacted: [
+        orphanRow("microsoft.network/natgateways", {
+          recommendation: "NAT Gateways not attached to any subnet",
+          resourceId: id,
+        }),
+      ],
+      inventory: [
+        { location: "italynorth", resourceId: id, skuName: "Standard" },
+      ],
+    });
+
+    const [finding] = azqrImpactedToFindings(report);
+    expect(finding.reason).toContain("Standard");
+    expect(finding.reason).toContain("italynorth");
+  });
+
+  it("defaults severity to low for unknown impact on cost rows", () => {
+    const report = parseAzqrReport({
+      impacted: [
+        impactedRow({
+          category: "Cost",
+          impact: undefined,
+          resourceType: "microsoft.compute/disks",
+        }),
+      ],
+    });
+    expect(azqrImpactedToFindings(report)[0].severity).toBe("low");
+  });
+});

--- a/packages/savemoney/src/azure/__tests__/config.test.ts
+++ b/packages/savemoney/src/azure/__tests__/config.test.ts
@@ -48,6 +48,7 @@ describe("loadConfig", () => {
     expect(result.preferredLocation).toBe("italynorth");
     expect(result.sources).toEqual(["advisor", "custom"]);
     expect(result.timespanDays).toBe(30);
+    expect(result.azqrReportPath).toBeUndefined();
   });
 
   it("applies sources defaults when loading from the environment", async () => {
@@ -90,6 +91,7 @@ describe("loadConfig", () => {
     expect(result.preferredLocation).toBe("westeurope");
     expect(result.sources).toEqual(["custom"]);
     expect(result.timespanDays).toBe(60);
+    expect(result.azqrReportPath).toBe("./azqr_action_plan.json");
 
     expect(result.thresholds?.vm.cpuPercent).toBe(5);
     expect(result.thresholds?.vm.networkInBytesPerDay).toBe(10485760);

--- a/packages/savemoney/src/azure/__tests__/fixtures/full-override.yaml
+++ b/packages/savemoney/src/azure/__tests__/fixtures/full-override.yaml
@@ -3,6 +3,7 @@ azure:
     - xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx
     - yyyyyyyy-yyyy-yyyy-yyyy-yyyyyyyyyyyy
   preferredLocation: westeurope
+  azqrReportPath: ./azqr_action_plan.json
   sources:
     - custom
   timespanDays: 60

--- a/packages/savemoney/src/azure/analyzer.ts
+++ b/packages/savemoney/src/azure/analyzer.ts
@@ -50,6 +50,11 @@ import {
   createDefaultSubscriptionAnalyzers,
   type SubscriptionAnalyzer,
 } from "./analyzers/index.js";
+import {
+  azqrImpactedToFindings,
+  isAzqrReportMasked,
+  loadAzqrReport,
+} from "./azqr.js";
 import { PricingClient, PricingService } from "./pricing/index.js";
 import { matchesTags, type MetricsCache } from "./utils.js";
 
@@ -171,6 +176,12 @@ export async function analyzeAzureResources(
         verbose: config.verbose ?? false,
       });
     }
+  }
+
+  // Ingest an AZQR (`azqr scan --json`) report when provided, merging its
+  // FinOps-relevant `impacted` rows into the aggregated reports as findings.
+  if (config.azqrReportPath) {
+    await ingestAzqrReport(config.azqrReportPath, allReports, logger);
   }
 
   // Sort to make the output more readable:
@@ -431,6 +442,42 @@ async function collectTaggedResourceIds(args: {
 
 function hasTagFilter(filterTags: Map<string, string> | undefined): boolean {
   return Boolean(filterTags && filterTags.size > 0);
+}
+
+/**
+ * Loads an AZQR report, filters it down to FinOps opportunities and merges the
+ * resulting findings into the aggregated reports. Runs once per invocation
+ * (the report is subscription-agnostic), building a global index from every
+ * report collected during the live scan so AZQR findings attach to their
+ * resource when present or create a stub otherwise.
+ *
+ * When the report is still masked, findings cannot match live resource IDs, so
+ * a warning advises re-running AZQR with `--mask=false`.
+ */
+async function ingestAzqrReport(
+  azqrReportPath: string,
+  reports: AzureDetailedResourceReport[],
+  logger: ReturnType<typeof getLogger>,
+): Promise<void> {
+  const report = await loadAzqrReport(azqrReportPath);
+  if (isAzqrReportMasked(report)) {
+    logger.warn(
+      "AZQR report has masked subscription IDs: findings may not match live" +
+        " resources and can appear as separate stub entries. Re-run with" +
+        " `azqr scan --mask=false` for accurate merging.",
+    );
+  }
+
+  const findings = azqrImpactedToFindings(report);
+  const reportsById = new Map<string, AzureDetailedResourceReport>(
+    reports.map((r) => [(r.resource.id ?? "").toLowerCase(), r]),
+  );
+  for (const finding of findings) {
+    mergeFinding(finding, reports, reportsById);
+  }
+  logger.info(
+    `AZQR: merged ${findings.length} finding(s) from ${azqrReportPath}`,
+  );
 }
 
 function isResourceScopedFinding(resourceId: string): boolean {

--- a/packages/savemoney/src/azure/azqr.ts
+++ b/packages/savemoney/src/azure/azqr.ts
@@ -1,0 +1,270 @@
+/**
+ * AZQR report ingestion.
+ *
+ * Parses an AZQR (`azqr scan --json`) report and turns its `impacted`
+ * resources into the unified `Finding` model (`source: "azqr"`), keeping only
+ * the rows that carry FinOps signal so the SaveMoney output is not flooded with
+ * security / reliability / high-availability best-practice noise. Promoted rows
+ * fall into two classes (see {@link classifyAzqrRow}):
+ *
+ * - **cost** (`category: "cost"`): billable waste — rows AZQR categorises as
+ *   `Cost`, or orphaned resources whose type actually incurs cost (public IPs,
+ *   NAT gateways, application gateways, …).
+ * - **cleanup** (`category: "operationalExcellence"`): orphaned *free* resources
+ *   (empty subnets, unattached NSGs, orphan API connections, …). They carry no
+ *   direct cost but are cleanup candidates worth investigating.
+ *
+ * Orphans are detected via AZQR's `AOR` (Azure Orphan Resources) check source
+ * rather than fragile recommendation-text matching.
+ *
+ * The AZQR CLI masks subscription IDs by default (e.g.
+ * `/subscriptions/xxxxxxxx-…/`). Masked IDs do not match the real resource IDs
+ * produced by a live scan, so masked findings cannot be merged onto their
+ * resources — {@link isAzqrReportMasked} lets the orchestrator warn and advise
+ * re-running with `azqr scan --mask=false`.
+ *
+ * Scope note (CES-2192 / Fase 1): only `impacted` rows are ingested, enriched
+ * with `inventory` metadata when available. AZQR `advisor` rows are ignored to
+ * avoid duplicating SaveMoney's own Azure Advisor cost query.
+ */
+
+import { readFile } from "node:fs/promises";
+import { z } from "zod";
+
+import type { CostRisk } from "../types.js";
+
+import { type Finding } from "../finding.js";
+
+/** A single `impacted` row from an AZQR JSON report (fields we consume). */
+const azqrImpactedRowSchema = z.object({
+  category: z.string().optional(),
+  impact: z.string().optional(),
+  learn: z.string().optional(),
+  recommendation: z.string(),
+  recommendationId: z.string().optional(),
+  resourceGroup: z.string().optional(),
+  resourceId: z.string(),
+  resourceName: z.string().optional(),
+  resourceType: z.string().optional(),
+  source: z.string().optional(),
+  subscriptionId: z.string().optional(),
+  subscriptionName: z.string().optional(),
+});
+
+/** A single `inventory` row from an AZQR JSON report (used for enrichment). */
+const azqrInventoryRowSchema = z.object({
+  location: z.string().optional(),
+  resourceId: z.string(),
+  resourceName: z.string().optional(),
+  resourceType: z.string().optional(),
+  skuName: z.string().optional(),
+  skuTier: z.string().optional(),
+  subscriptionId: z.string().optional(),
+});
+
+/**
+ * Lenient top-level schema. AZQR reports carry many sections we do not use
+ * (`advisor`, `defender`, `recommendations`, …); unknown keys are stripped and
+ * missing arrays default to empty so a partial/older report still parses.
+ */
+const azqrReportSchema = z.object({
+  impacted: z.array(azqrImpactedRowSchema).default([]),
+  inventory: z.array(azqrInventoryRowSchema).default([]),
+});
+
+export type AzqrImpactedRow = z.infer<typeof azqrImpactedRowSchema>;
+export type AzqrInventoryRow = z.infer<typeof azqrInventoryRowSchema>;
+export type AzqrReport = z.infer<typeof azqrReportSchema>;
+
+/**
+ * Azure resource types whose orphaned/unassociated instances actually incur
+ * cost. AZQR's `AOR` (Azure Orphan Resources) check mixes these billable
+ * resources with free config-hygiene ones (NSGs, subnets, orphan API
+ * connections, private endpoints, …): the former are classified as `cost`
+ * opportunities, the latter as `cleanup` candidates.
+ */
+const BILLABLE_ORPHAN_RESOURCE_TYPES: ReadonlySet<string> = new Set([
+  "microsoft.compute/disks",
+  "microsoft.compute/snapshots",
+  "microsoft.network/applicationgateways",
+  "microsoft.network/ddosprotectionplans",
+  "microsoft.network/frontdoorwebapplicationfirewallpolicies",
+  "microsoft.network/loadbalancers",
+  "microsoft.network/natgateways",
+  "microsoft.network/publicipaddresses",
+  "microsoft.network/virtualnetworkgateways",
+  "microsoft.sql/servers/elasticpools",
+  "microsoft.web/serverfarms",
+]);
+
+/**
+ * AZQR's check source for orphaned resources (the Azure Orphan Resources
+ * project). Every `impacted` row tagged with it is a provisioned-but-unused
+ * resource, so it is a reliable, text-independent orphan marker.
+ */
+const ORPHAN_CHECK_SOURCE = "aor";
+
+/** AZQR masks subscription GUID segments with runs of `x`. */
+const MASK_MARKER = "xxxxxxxx";
+
+/** How a promoted AZQR row is classified for reporting. */
+export type AzqrOpportunityKind = "cleanup" | "cost";
+
+const COST_REMEDIATION =
+  "Review the resource and remove or right-size it if it is no longer needed to stop incurring cost.";
+
+const CLEANUP_REMEDIATION =
+  "Orphaned resource with no direct cost. Verify it is unused, then remove it to reduce clutter and management overhead.";
+
+/**
+ * Converts the promoted `impacted` rows of an AZQR report into findings.
+ * AZQR carries no monetary estimate, so `estimatedMonthlySavings` is left
+ * unset. Billable rows render as `cost` opportunities (keeping AZQR's impact as
+ * severity); orphaned free resources render as low-severity
+ * `operationalExcellence` cleanup candidates. All carry an `[azqr]` badge.
+ */
+export function azqrImpactedToFindings(report: AzqrReport): Finding[] {
+  const inventoryById = new Map(
+    report.inventory.map((row) => [row.resourceId.toLowerCase(), row]),
+  );
+  const findings: Finding[] = [];
+  for (const row of report.impacted) {
+    const kind = classifyAzqrRow(row);
+    if (kind === null) continue;
+    const inventory = inventoryById.get(row.resourceId.toLowerCase());
+    const cleanup = kind === "cleanup";
+    const remediation = cleanup ? CLEANUP_REMEDIATION : COST_REMEDIATION;
+    findings.push({
+      category: cleanup ? "operationalExcellence" : "cost",
+      code: row.recommendationId
+        ? `azqr.${row.recommendationId}`
+        : "azqr.impacted",
+      reason: buildReason(row, inventory),
+      recommendedAction: row.learn
+        ? `${remediation} Learn more: ${row.learn}`
+        : remediation,
+      resourceId: row.resourceId,
+      severity: cleanup ? "low" : mapAzqrImpact(row.impact),
+      source: "azqr",
+    });
+  }
+  return findings;
+}
+
+/**
+ * Classifies an `impacted` row for FinOps reporting, or returns `null` to drop
+ * it as noise.
+ *
+ * - `"cost"` — AZQR categorises the row as a cost item, or it is an orphaned
+ *   resource of a billable type (real savings potential).
+ * - `"cleanup"` — an orphaned resource of a *free* type (empty subnets,
+ *   unattached NSGs, orphan API connections, …): no direct cost, but a cleanup
+ *   candidate worth investigating.
+ * - `null` — everything else (security, reliability, high-availability and
+ *   other best-practice rows) is treated as noise and dropped.
+ *
+ * Orphans are identified by AZQR's `AOR` check source, not by matching the
+ * recommendation text.
+ */
+export function classifyAzqrRow(
+  row: AzqrImpactedRow,
+): AzqrOpportunityKind | null {
+  if ((row.category ?? "").toLowerCase().includes("cost")) {
+    return "cost";
+  }
+  if ((row.source ?? "").toLowerCase() !== ORPHAN_CHECK_SOURCE) {
+    return null;
+  }
+  const resourceType = (row.resourceType ?? "").toLowerCase();
+  return BILLABLE_ORPHAN_RESOURCE_TYPES.has(resourceType) ? "cost" : "cleanup";
+}
+
+/**
+ * Detects whether the report still carries AZQR's default subscription-ID
+ * masking. Masked resource IDs cannot be matched against a live scan, so the
+ * caller should advise re-running with `azqr scan --mask=false`.
+ */
+export function isAzqrReportMasked(report: AzqrReport): boolean {
+  return report.impacted.some(
+    (row) =>
+      row.resourceId.includes(MASK_MARKER) ||
+      (row.subscriptionId?.includes(MASK_MARKER) ?? false),
+  );
+}
+
+/**
+ * Reads and parses an AZQR JSON report from disk.
+ *
+ * @throws Error when the file cannot be read or is not valid AZQR JSON; the
+ *         underlying failure is preserved as `cause`.
+ */
+export async function loadAzqrReport(filePath: string): Promise<AzqrReport> {
+  let content: string;
+  try {
+    content = await readFile(filePath, "utf8");
+  } catch (error) {
+    throw new Error(`Cannot read AZQR report at "${filePath}"`, {
+      cause: error,
+    });
+  }
+
+  let json: unknown;
+  try {
+    json = JSON.parse(content);
+  } catch (error) {
+    throw new Error(`AZQR report at "${filePath}" is not valid JSON`, {
+      cause: error,
+    });
+  }
+
+  return parseAzqrReport(json);
+}
+
+/**
+ * Validates and parses an unknown value as an AZQR report.
+ *
+ * @throws Error (with the zod issue as `cause`) when the shape is invalid.
+ */
+export function parseAzqrReport(raw: unknown): AzqrReport {
+  const result = azqrReportSchema.safeParse(raw);
+  if (!result.success) {
+    throw new Error(`Invalid AZQR report: ${result.error.message}`, {
+      cause: result.error,
+    });
+  }
+  return result.data;
+}
+
+/**
+ * Builds the finding reason from the AZQR recommendation, appending SKU / tier
+ * / location context from the matching `inventory` row when available.
+ */
+function buildReason(
+  row: AzqrImpactedRow,
+  inventory: AzqrInventoryRow | undefined,
+): string {
+  const base = row.recommendation.trim();
+  const sentence = base.endsWith(".") ? base : `${base}.`;
+  const context: string[] = [];
+  if (inventory?.skuName) context.push(inventory.skuName);
+  if (inventory?.skuTier && inventory.skuTier !== inventory.skuName) {
+    context.push(inventory.skuTier);
+  }
+  if (inventory?.location) context.push(inventory.location);
+  return context.length > 0 ? `${sentence} (${context.join(", ")})` : sentence;
+}
+
+/**
+ * Maps AZQR/APRL `impact` (`High` | `Medium` | `Low`) onto the SaveMoney
+ * `CostRisk` scale, defaulting to `low` for unknown values.
+ */
+function mapAzqrImpact(impact: string | undefined): CostRisk {
+  switch (impact?.toLowerCase()) {
+    case "high":
+      return "high";
+    case "medium":
+      return "medium";
+    default:
+      return "low";
+  }
+}

--- a/packages/savemoney/src/azure/config.ts
+++ b/packages/savemoney/src/azure/config.ts
@@ -42,6 +42,7 @@ export async function loadAzureConfig(
       const rawYaml = yaml.load(raw);
       const parsed = ConfigSchema.parse(rawYaml);
       return {
+        azqrReportPath: parsed.azure.azqrReportPath,
         concurrency: parsed.azure.concurrency,
         preferredLocation: parsed.azure.preferredLocation,
         sources: parsed.azure.sources,

--- a/packages/savemoney/src/azure/types.ts
+++ b/packages/savemoney/src/azure/types.ts
@@ -18,6 +18,14 @@ import type {
  */
 export type AzureConfig = BaseConfig & {
   /**
+   * Optional path to an AZQR (`azqr scan --json`) report. When set, the
+   * orchestrator ingests its `impacted` resources, filters them down to
+   * FinOps-relevant opportunities and merges them into the run output as
+   * findings with `source: "azqr"`. Can be set via YAML (`azure.azqrReportPath`)
+   * or the CLI `--azqr-report` flag, which takes precedence.
+   */
+  azqrReportPath?: string;
+  /**
    * Maximum number of resources analyzed in parallel within a single
    * subscription. Defaults to 8 when not provided. Set to 1 for a fully
    * sequential run (useful for debugging or to be gentler on quotas).

--- a/packages/savemoney/src/finding.ts
+++ b/packages/savemoney/src/finding.ts
@@ -78,9 +78,10 @@ export type FindingCategory =
  *
  * - `custom`  → emitted by a savemoney analyzer plugin
  * - `advisor` → fetched from Azure Advisor recommendations
+ * - `azqr`    → ingested from an AZQR (`azqr scan --json`) report
  * - `aws`     → reserved for future AWS Trusted Advisor / Compute Optimizer
  */
-export type FindingSource = "advisor" | "aws" | "custom";
+export type FindingSource = "advisor" | "aws" | "azqr" | "custom";
 
 /**
  * Monetary value associated with a finding, when known.

--- a/packages/savemoney/src/schema.ts
+++ b/packages/savemoney/src/schema.ts
@@ -110,6 +110,12 @@ const AzureSourceSchema = z.enum(AZURE_SOURCE_VALUES);
 const AzureSectionSchema = z
   .object({
     /**
+     * Optional path to an AZQR (`azqr scan --json`) report. When set, its
+     * FinOps-relevant impacted resources are merged into the analysis. The
+     * `--azqr-report` CLI flag, when provided, overrides this value.
+     */
+    azqrReportPath: z.string().optional(),
+    /**
      * Maximum number of resources analyzed in parallel within a single
      * subscription. Defaults to 8 when not provided.
      */


### PR DESCRIPTION
## What
SaveMoney can now ingest an `azqr scan --json` report and merge its FinOps-relevant resources into the normal
scan output.

## Why
AZQR already runs orphan/waste checks across Azure resources DX doesn't otherwise scan. Reusing that data lets SaveMoney surface additional cost and cleanup opportunities without re-implementing those checks.

## How
- New `azure/azqr.ts` module: validates the report with zod, then classifies each `impacted` row via AZQR's `source: "AOR"` (Azure Orphan Resources) marker:
  - **Cost**: rows AZQR categorises as `Cost`, or orphaned *billable* resources (public IPs, NAT gateways, App Service plans, managed disks, …).
  - **Cleanup candidates**: orphaned *free* resources (empty subnets, unattached NSGs, orphan API connections, unconnected private endpoints): reported as low-severity `operationalExcellence` findings, no direct cost.
  - Everything else (security/reliability/HA best-practice noise) is dropped.
- Only the `impacted` section is ingested: `advisor` rows are skipped since SaveMoney's own Azure Advisor query already covers Cost recommendations with real savings estimates.
- Findings merge onto the matching live resource when found, or synthesize a standalone AZQR finding otherwise; a warning is logged if the report still has masked subscription IDs (`azqr scan --mask=false` fixes it).
- New CLI flag `--azqr-report <path>`, plus an equivalent `azure.azqrReportPath` YAML config key (CLI flag takes precedence).

## Example
Use the command:
```bash
azqr scan --subscription-id 0000000-0000-0000-0000-0000000000 --mask=false --json
```
To obtain as result the AZQR action plan in json format (e.g. `azqr_action_plan_2026_07_21_T150509.json`).

Pass to this PR branch and build locally the DX CLI, then run the savemoney scan:
```bash
pnpm nx build @pagopa/dx-cli --skip-nx-cache

# When prompted use the same subscription id used for the azqr report
node ./apps/cli/bin/index.js savemoney --azqr-report ./azqr_action_plan_2026_07_21_T150509.json --format lint  > savemoney_2026_07_21.md 
```
At the end you will obtain a file with the entire report with savemoney custom resources, advisor suggestion and azqr cost reports.

For example in the middle:

<img width="849" height="148" alt="image" src="https://github.com/user-attachments/assets/cc61e3dd-efee-42a1-a228-1a966761bed7" />

And as final summary result:

```
Summary: 1475 issues found  (62 high, 549 medium, 864 low)
Sources: 18 advisor, 30 azqr, 1427 custom
Estimated monthly cost at risk (custom): €30.75
Estimated monthly savings (advisor): $410.15, €10,757.00
```

Resolves: CES-2192