### PR TITLE
Support TSX Jest test files

### DIFF
--- a/.nx/version-plans/version-plan-1785245349259.md
+++ b/.nx/version-plans/version-plan-1785245349259.md
@@ -1,0 +1,5 @@
+---
+'@pagopa/eslint-config': patch
+---
+
+Support TSX test files in Jest configuration

--- a/packages/eslint-config/base.js
+++ b/packages/eslint-config/base.js
@@ -4,9 +4,9 @@ import prettier from "eslint-plugin-prettier/recommended";
 import tseslint from "typescript-eslint";
 
 export const TEST_FILES = [
-  "**/tests/**/*.{js,ts}",
-  "**/__tests__/**/*.{js,ts}",
-  "**/*.{test,spec}.{js,ts}",
+  "**/tests/**/*.{js,ts,tsx}",
+  "**/__tests__/**/*.{js,ts,tsx}",
+  "**/*.{test,spec}.{js,ts,tsx}",
 ];
 
 export default [


### PR DESCRIPTION
## Summary

- Extend shared test-file globs to include TSX files, so Jest rules apply to React Native tests.
- Add a patch version plan for `@pagopa/eslint-config`.

Related to https://github.com/pagopa/io-app/pull/8364