### PR TITLE
Remove nx/docker plugin need

### DIFF
--- a/.nx/version-plans/version-plan-1785251431634.md
+++ b/.nx/version-plans/version-plan-1785251431634.md
@@ -1,0 +1,5 @@
+---
+'@pagopa/nx-dx-docker-plugin': patch
+---
+
+Infer Docker run targets without Nx Docker release prompts.

--- a/apps/website/docs/containers/nx-docker-release.md
+++ b/apps/website/docs/containers/nx-docker-release.md
@@ -5,8 +5,8 @@ sidebar_position: 2
 # Release Docker images with the Nx Docker plugin
 
 This page describes `@pagopa/nx-dx-docker-plugin`, the Nx plugin that infers
-`docker:build` and `docker:push` targets for every project with a `Dockerfile`,
-regardless of its language or framework.
+`docker:build`, `docker:push`, and `docker:run` targets for every project with
+a `Dockerfile`, regardless of its language or framework.
 
 ## When to use this guide
 
@@ -20,39 +20,34 @@ Use this guide if your repository:
 - prefers DX conventions and inferred metadata over workspace-specific plugin
   configuration
 
-## Why not `@nx/docker`'s release configuration alone
+## Why use the DX plugin alone
 
-`@nx/docker` provides Nx Release integration and the `docker:run` convenience
-target, but its generated build and publish targets do not provide the full OCI
-metadata and tag aliases required by DX repositories.
+`@pagopa/nx-dx-docker-plugin` owns every inferred Docker target. It adds OCI
+labels and annotations, reproducible build flags, multi-platform builds, the DX
+tag strategy, and a local `docker:run` workflow.
 
-`@pagopa/nx-dx-docker-plugin` owns `docker:build` and `docker:push`, adding OCI
-labels and annotations, reproducible build flags, multi-platform builds, and the
-DX tag strategy. For projects configured with
-`nx.release.docker.repositoryName`, it also replaces the Docker release
-publisher so a release pushes the primary semver tag and its aliases.
+Do not register `@nx/docker` alongside this plugin. Its Docker Release
+integration treats Docker targets as release-versioning inputs and can prompt
+for an interactive `production` or `hotfix` scheme. The DX plugin uses
+`container-image` target metadata instead, so `nx release` does not enter that
+interactive flow. For projects configured with `nx.release.docker.repositoryName`,
+the plugin adds a custom publisher that pushes the primary semver tag and its
+aliases.
 
 ## nx.json configuration
 
-Install and configure both plugins with:
+Install and configure the plugin with:
 
 ```bash
 pnpm nx add @pagopa/nx-dx-docker-plugin
 ```
 
-The generator registers both plugins, in this order (`@nx/docker` first, then
-`@pagopa/nx-dx-docker-plugin`). For a manual configuration, use:
+The generator registers `@pagopa/nx-dx-docker-plugin`. For a manual
+configuration, use:
 
 ```json
 {
   "plugins": [
-    {
-      "plugin": "@nx/docker",
-      "options": {
-        "buildTarget": "docker:build",
-        "runTarget": "docker:run"
-      }
-    },
     {
       "plugin": "@pagopa/nx-dx-docker-plugin",
       "options": {
@@ -64,9 +59,6 @@ The generator registers both plugins, in this order (`@nx/docker` first, then
   ]
 }
 ```
-
-Plugin order matters: register the DX plugin after `@nx/docker` so its inferred
-`docker:build` target wins.
 
 While no options are strictly required since they all have default values, they
 can still be fully customized when the inferred DX conventions do not fit. The
@@ -91,6 +83,8 @@ For every project with a `Dockerfile`, the plugin infers:
 - **`docker:build`** — builds the image, tagging it with the strategy described
   below
 - **`docker:push`** — pushes the built tags to the configured `registry`
+- **`docker:run`** — builds the image if needed, then runs its local untagged
+  alias
 
 Application compilation and packaging stay inside the Dockerfile. The plugin
 does not assume Node.js, pnpm, or any application framework.
@@ -100,6 +94,7 @@ Run them like any other Nx target:
 ```bash
 pnpm nx run my-project:docker:build
 pnpm nx run my-project:docker:push
+pnpm nx run my-project:docker:run -- --port 3000:3000
 ```
 
 When running inside a GitHub Actions job, `docker:build`, `docker:push` and
@@ -173,23 +168,12 @@ that version. No package manifest or temporary version file is needed.
 
 ## Nx Release configuration
 
-Use the semantic version produced by Nx version actions as the Docker version:
-
-```json
-{
-  "release": {
-    "docker": {
-      "registryUrl": "ghcr.io",
-      "versionSchemes": {
-        "production": "{versionActionsVersion}"
-      }
-    }
-  }
-}
-```
-
-This keeps Git release tags, package versions, and Docker image versions
-aligned.
+Do not configure `release.docker.versionSchemes` or an `@nx/docker` plugin for
+this flow. The DX publisher reads the version produced by Nx from the project's
+`package.json`, or `project.json` `metadata.version` for a container-only
+project, then derives the Docker aliases itself. This keeps Git release tags,
+package versions, and Docker image versions aligned without interactive scheme
+selection.
 
 ## Tag strategy
 

--- a/apps/website/docs/containers/nx-docker-release.md
+++ b/apps/website/docs/containers/nx-docker-release.md
@@ -5,8 +5,8 @@ sidebar_position: 2
 # Release Docker images with the Nx Docker plugin
 
 This page describes `@pagopa/nx-dx-docker-plugin`, the Nx plugin that infers
-`docker:build`, `docker:push`, and `docker:run` targets for every project with
-a `Dockerfile`, regardless of its language or framework.
+`docker:build`, `docker:push`, and `docker:run` targets for every project with a
+`Dockerfile`, regardless of its language or framework.
 
 ## When to use this guide
 
@@ -30,9 +30,9 @@ Do not register `@nx/docker` alongside this plugin. Its Docker Release
 integration treats Docker targets as release-versioning inputs and can prompt
 for an interactive `production` or `hotfix` scheme. The DX plugin uses
 `container-image` target metadata instead, so `nx release` does not enter that
-interactive flow. For projects configured with `nx.release.docker.repositoryName`,
-the plugin adds a custom publisher that pushes the primary semver tag and its
-aliases.
+interactive flow. For projects configured with
+`nx.release.docker.repositoryName`, the plugin adds a custom publisher that
+pushes the primary semver tag and its aliases.
 
 ## nx.json configuration
 

--- a/nx.json
+++ b/nx.json
@@ -124,10 +124,15 @@
       }
     },
     {
-      "plugin": "@nx/docker",
+      "plugin": "@pagopa/nx-terraform-plugin",
+      "include": ["infra/**"],
       "options": {
-        "buildTarget": "docker:build",
-        "runTarget": "docker:run"
+        "publish": {
+          "mode": "github",
+          "github": {
+            "owner": "pagopa-dx"
+          }
+        }
       }
     },
     {
@@ -147,8 +152,7 @@
               "${{ env.TAG_NAME }}"
             ]
           }
-        },
-        "runTarget": "docker:run"
+        }
       }
     }
   ],

--- a/packages/nx-dx-docker-plugin/README.md
+++ b/packages/nx-dx-docker-plugin/README.md
@@ -1,8 +1,8 @@
 # Nx DX Docker Plugin
 
-`@pagopa/nx-dx-docker-plugin` is an Nx plugin that extends `@nx/docker` with workspace-wide Docker conventions.
+`@pagopa/nx-dx-docker-plugin` is an Nx plugin that infers Docker targets with workspace-wide Docker conventions.
 
-It keeps the standard Docker target inference provided by Nx, then enriches the inferred targets with:
+It provides the Docker target inference with:
 
 - automatic Docker build context selection
 - automatic `--file` resolution relative to the selected build context
@@ -30,9 +30,14 @@ yarn add -D @pagopa/nx-dx-docker-plugin
 
 Then register it in `nx.json`.
 
+Do not register `@nx/docker` alongside this plugin. The DX plugin infers the
+complete Docker target set itself, including `docker:run`. Keeping the upstream
+plugin out prevents Nx Release from treating those targets as Docker release
+versioning inputs and prompting for a `production` or `hotfix` scheme.
+
 ## Configure The Plugin
 
-No plugin options are required when the default target names inferred by `@nx/docker` are acceptable.
+No plugin options are required when the default target names are acceptable.
 
 Minimal configuration:
 
@@ -77,10 +82,9 @@ Plugin options in `nx.json` are all optional.
 
 The plugin accepts these optional parameters:
 
-- `buildTarget`: same contract supported by `@nx/docker`. Use it to customize the inferred Docker build target name or pass supported upstream target options.
+- `buildTarget`: customizes the inferred Docker build target name and build options.
 - `buildTarget.metadata.tags`: optional tag descriptors preserved on the inferred Docker build target for downstream tooling or workspace-specific release flows.
 - `buildTarget.metadata.labels`: optional additional labels expressed as `key=value` entries. They are appended after the automatic OCI labels, so repeated keys can override the defaults.
-- `runTarget`: same contract supported by `@nx/docker`, used for the inferred Docker run target.
 - `dockerImageAuthors`: value used for the `org.opencontainers.image.authors` OCI label. When omitted, the plugin tries to use the GitHub organization or owner extracted from the workspace `origin` remote. If that information is unavailable, it falls back to `PagoPA`.
 
 The plugin does not require any mandatory custom parameters.
@@ -93,17 +97,22 @@ The plugin applies these defaults even when they are not declared in `nx.json`:
 - OCI labels are generated automatically from project metadata and workspace Git metadata.
 - optional metadata tags and labels are attached to the inferred Docker build target.
 - Projects configured for Docker release publishing get a custom `nx-release-publish` target.
-- target option objects without an explicit `name` are normalized to `docker:build` or `docker:run` before they are passed to `@nx/docker`
+- target option objects without an explicit `name` are normalized to `docker:build`
 
 ### `docker:run` Behavior
 
-The plugin does not rewrite the inferred Docker run target.
+The plugin infers `docker:run` directly. It depends on `docker:build` and runs
+the local, untagged image produced by that target. This preserves the standard
+`nx run <project>:docker:run -- --port 3000:3000` workflow without activating
+Nx's experimental Docker release versioning.
 
-- discovery of the run target is still delegated to `@nx/docker`
-- the optional `runTarget` plugin option keeps the same public contract as `@nx/docker`; this package only fills the default target name before delegating
-- once the target is inferred, the plugin leaves its command and options untouched
+### Nx Release Behavior
 
-This means the package owns Docker build normalization, metadata propagation, and publish behavior, while `docker:run` keeps the standard Nx Docker semantics.
+Do not configure `release.docker.versionSchemes` for this plugin. The inferred
+`nx-release-publish` target reads the version produced by Nx from `package.json`
+or `project.json` `metadata.version`, then derives semver aliases itself. This
+keeps Docker publishing non-interactive while preserving the project's Nx
+release version as the source of truth.
 
 ## How Target Inference Works
 

--- a/packages/nx-dx-docker-plugin/dist/docker-image-DJPPGLZP.js
+++ b/packages/nx-dx-docker-plugin/dist/docker-image-DJPPGLZP.js
@@ -7,9 +7,8 @@ let semver = require("semver");
 
 //#region src/docker-image.ts
 /**
-* Mirrors `@nx/docker`'s own default image slug so the `docker:run` target
-* it generates (`docker run {args} {imageRef}`) keeps working against the
-* bare (untagged) image this plugin also produces.
+* Path-derived local image slug used by this plugin's `docker:run` target.
+* It matches the bare (untagged) image produced by `docker:build`.
 */
 const getProjectSlug = (projectRoot) => projectRoot.replace(/^[\\/]/, "").replace(/[\\/\s]+/g, "-").toLowerCase();
 /**
@@ -47,11 +46,9 @@ const getImageName = (registry, imageNamePrefix, projectDisplayName, repositoryN
 * `getProjectDisplayName`), so this still degrades gracefully for
 * non-JS Docker projects.
 *
-* Deliberately independent of `getProjectSlug`, which stays purely
-* path-based because it also has to match `@nx/docker`'s own local image
-* ref for its generated `docker:run` target (see `getProjectNameFromPath`
-* in `@nx/docker`'s plugin) — changing that would break `docker run`
-* against the image this plugin builds.
+* Deliberately independent of `getProjectSlug`, which remains path-based
+* for the locally tagged image consumed by this plugin's `docker:run`
+* target.
 */
 const getImageSlug = (projectDisplayName) => slugifyRef(projectDisplayName.replace(/^@/, ""));
 /**

--- a/packages/nx-dx-docker-plugin/dist/docker-run-DXXchtdL.js
+++ b/packages/nx-dx-docker-plugin/dist/docker-run-DXXchtdL.js
@@ -1,4 +1,4 @@
-const require_docker_image = require('./docker-image-DgdWlpzQ.js');
+const require_docker_image = require('./docker-image-DJPPGLZP.js');
 let node_child_process = require("node:child_process");
 let zod_v4 = require("zod/v4");
 let node_fs = require("node:fs");

--- a/packages/nx-dx-docker-plugin/dist/executors/docker-build/docker-build.js
+++ b/packages/nx-dx-docker-plugin/dist/executors/docker-build/docker-build.js
@@ -1,4 +1,4 @@
-const require_docker_run = require('../../docker-run-ZIlMVKaY.js');
+const require_docker_run = require('../../docker-run-DXXchtdL.js');
 
 //#region src/executors/docker-build/schema.ts
 const dockerBuildExecutorSchema = require_docker_run.dockerRunOptionsSchema;

--- a/packages/nx-dx-docker-plugin/dist/executors/docker-push/docker-push.js
+++ b/packages/nx-dx-docker-plugin/dist/executors/docker-push/docker-push.js
@@ -1,4 +1,4 @@
-const require_docker_run = require('../../docker-run-ZIlMVKaY.js');
+const require_docker_run = require('../../docker-run-DXXchtdL.js');
 
 //#region src/executors/docker-push/schema.ts
 const dockerPushExecutorSchema = require_docker_run.dockerRunOptionsSchema;

--- a/packages/nx-dx-docker-plugin/dist/executors/release-publish/release-publish.js
+++ b/packages/nx-dx-docker-plugin/dist/executors/release-publish/release-publish.js
@@ -1,6 +1,6 @@
 Object.defineProperties(exports, { __esModule: { value: true }, [Symbol.toStringTag]: { value: 'Module' } });
-const require_docker_image = require('../../docker-image-DgdWlpzQ.js');
-const require_docker_run = require('../../docker-run-ZIlMVKaY.js');
+const require_docker_image = require('../../docker-image-DJPPGLZP.js');
+const require_docker_run = require('../../docker-run-DXXchtdL.js');
 let zod_v4 = require("zod/v4");
 let node_path = require("node:path");
 let node_fs_promises = require("node:fs/promises");

--- a/packages/nx-dx-docker-plugin/dist/generators/init/generator.js
+++ b/packages/nx-dx-docker-plugin/dist/generators/init/generator.js
@@ -1,20 +1,12 @@
 let _nx_devkit = require("@nx/devkit");
 
 //#region src/generators/init/generator.ts
-const nxDockerPlugin = {
-	options: {
-		buildTarget: "docker:build",
-		runTarget: "docker:run"
-	},
-	plugin: "@nx/docker"
-};
 const dxDockerPlugin = { plugin: "@pagopa/nx-dx-docker-plugin" };
 const getPluginName = (plugin) => typeof plugin === "string" ? plugin : plugin.plugin;
 const hasPlugin = (plugins, pluginName) => plugins.some((plugin) => getPluginName(plugin) === pluginName);
 async function initGenerator(tree) {
 	(0, _nx_devkit.updateJson)(tree, "nx.json", (nxJson) => {
-		const plugins = [...nxJson.plugins ?? []];
-		if (!hasPlugin(plugins, "@nx/docker")) plugins.push(nxDockerPlugin);
+		const plugins = (nxJson.plugins ?? []).filter((plugin) => getPluginName(plugin) !== "@nx/docker");
 		if (!hasPlugin(plugins, "@pagopa/nx-dx-docker-plugin")) plugins.push(dxDockerPlugin);
 		return {
 			...nxJson,

--- a/packages/nx-dx-docker-plugin/dist/index.js
+++ b/packages/nx-dx-docker-plugin/dist/index.js
@@ -1,5 +1,5 @@
 Object.defineProperty(exports, Symbol.toStringTag, { value: 'Module' });
-const require_docker_image = require('./docker-image-DgdWlpzQ.js');
+const require_docker_image = require('./docker-image-DJPPGLZP.js');
 let node_child_process = require("node:child_process");
 let zod_v4 = require("zod/v4");
 let _nx_devkit = require("@nx/devkit");
@@ -125,12 +125,9 @@ const getProjectJson = (workspaceRoot, projectRoot) => {
 	return (0, node_fs.existsSync)(projectJsonPath) ? (0, _nx_devkit.readJsonFile)(projectJsonPath) : null;
 };
 /**
-* Detects the *official* Nx Docker release flow's per-project override
+* Detects a per-project Docker release override
 * (`nx.release.docker.repositoryName` in package.json). Projects using it
-* get their `nx-release-publish` target overridden to also push the
-* dynamic alias tags (see executors/release-publish), since
-* `@nx/docker:release-publish` on its own only ever pushes a single
-* version-only tag.
+* get an `nx-release-publish` target that pushes the dynamic alias tags.
 */
 const getDockerRepositoryNameOverride = (workspaceRoot, projectRoot) => {
 	const packageJsonPath = (0, node_path.join)(workspaceRoot, projectRoot, "package.json");
@@ -167,6 +164,15 @@ const createDockerReleaseNodes = (projectRoot, options, context) => {
 	};
 	targets[options.buildTargetName] = buildDockerBuildTarget(dockerRunOptions);
 	targets[options.pushTargetName] = buildDockerPushTarget(dockerRunOptions, options.buildTargetName);
+	targets["docker:run"] = {
+		command: `docker run {args} ${require_docker_image.getProjectSlug(projectRoot)}`,
+		dependsOn: [options.buildTargetName],
+		metadata: {
+			description: "Run this project's locally built Docker image",
+			technologies: ["container-image"]
+		},
+		options: { cwd: projectRoot }
+	};
 	if (getDockerRepositoryNameOverride(context.workspaceRoot, projectRoot) !== null) targets["nx-release-publish"] = {
 		executor: "@pagopa/nx-dx-docker-plugin:release-publish",
 		metadata: {

--- a/packages/nx-dx-docker-plugin/generators.json
+++ b/packages/nx-dx-docker-plugin/generators.json
@@ -3,7 +3,7 @@
     "init": {
       "implementation": "./dist/generators/init/generator.js",
       "schema": "./src/generators/init/schema.json",
-      "description": "Registers the DX Docker plugin and its @nx/docker base plugin."
+      "description": "Registers the DX Docker plugin."
     }
   }
 }

--- a/packages/nx-dx-docker-plugin/src/__tests__/index.test.ts
+++ b/packages/nx-dx-docker-plugin/src/__tests__/index.test.ts
@@ -14,8 +14,11 @@ vi.mock("@nx/devkit", async (importOriginal) => ({
   readJsonFile: vi.fn(),
 }));
 
+import type { DockerPluginOptions } from "../options.ts";
+
 import { getBuildLayoutOverrides } from "../docker-build-layout.ts";
 import { buildDockerPushTarget } from "../docker-targets.ts";
+import { createDockerReleaseNodes } from "../index.ts";
 
 describe("getBuildLayoutOverrides", () => {
   beforeEach(() => {
@@ -89,5 +92,44 @@ describe("buildDockerPushTarget", () => {
     const target = buildDockerPushTarget(options, "docker:build");
 
     expect(target.options).toEqual(options);
+  });
+});
+
+describe("createDockerReleaseNodes", () => {
+  it("infers docker:run without the Nx Docker release technology", () => {
+    vi.mocked(readJsonFile).mockReturnValue({});
+
+    const options: DockerPluginOptions = {
+      buildTargetName: "docker:build",
+      defaultBranch: "main",
+      imageAuthors: "PagoPA",
+      imageNamePrefix: "pagopa/dx",
+      imageUrl: "https://github.com/pagopa/dx",
+      platform: "linux/amd64",
+      pushTargetName: "docker:push",
+      registry: "ghcr.io",
+    };
+
+    const nodes = createDockerReleaseNodes("apps/my-app", options, {
+      workspaceRoot: "/workspace",
+    });
+
+    expect(
+      nodes.projects["apps/my-app"].targets?.["docker:build"]?.metadata,
+    ).toMatchObject({ technologies: ["container-image"] });
+
+    expect(
+      nodes.projects["apps/my-app"].targets?.["docker:push"]?.metadata,
+    ).toMatchObject({ technologies: ["container-image"] });
+
+    expect(nodes.projects["apps/my-app"].targets?.["docker:run"]).toMatchObject(
+      {
+        command: "docker run {args} apps-my-app",
+        dependsOn: ["docker:build"],
+        metadata: {
+          technologies: ["container-image"],
+        },
+      },
+    );
   });
 });

--- a/packages/nx-dx-docker-plugin/src/docker-image.ts
+++ b/packages/nx-dx-docker-plugin/src/docker-image.ts
@@ -18,9 +18,8 @@ interface ProjectPackageJson {
 }
 
 /**
- * Mirrors `@nx/docker`'s own default image slug so the `docker:run` target
- * it generates (`docker run {args} {imageRef}`) keeps working against the
- * bare (untagged) image this plugin also produces.
+ * Path-derived local image slug used by this plugin's `docker:run` target.
+ * It matches the bare (untagged) image produced by `docker:build`.
  */
 export const getProjectSlug = (projectRoot: string): string =>
   projectRoot
@@ -76,11 +75,9 @@ export const getImageName = (
  * `getProjectDisplayName`), so this still degrades gracefully for
  * non-JS Docker projects.
  *
- * Deliberately independent of `getProjectSlug`, which stays purely
- * path-based because it also has to match `@nx/docker`'s own local image
- * ref for its generated `docker:run` target (see `getProjectNameFromPath`
- * in `@nx/docker`'s plugin) — changing that would break `docker run`
- * against the image this plugin builds.
+ * Deliberately independent of `getProjectSlug`, which remains path-based
+ * for the locally tagged image consumed by this plugin's `docker:run`
+ * target.
  */
 const getImageSlug = (projectDisplayName: string): string =>
   slugifyRef(projectDisplayName.replace(/^@/, ""));

--- a/packages/nx-dx-docker-plugin/src/docker-run.ts
+++ b/packages/nx-dx-docker-plugin/src/docker-run.ts
@@ -123,8 +123,8 @@ export const runDockerCommand = (
   ];
 
   if (mode === "build") {
-    // Untagged local alias kept for `@nx/docker`'s own `docker:run` target
-    // (`docker run {args} {imageRef}`). Only added for local builds: with
+    // Untagged local alias consumed by this plugin's `docker:run` target.
+    // Only added for local builds: with
     // `--push`, buildx pushes *every* `--tag`, and an unqualified name
     // resolves to `docker.io/library/...` (Docker Hub) rather than staying
     // local, which fails without Hub credentials/permissions.

--- a/packages/nx-dx-docker-plugin/src/docker-targets.ts
+++ b/packages/nx-dx-docker-plugin/src/docker-targets.ts
@@ -12,12 +12,11 @@
 // (see dx/actions/docker-build-push).
 //
 // This plugin owns the whole `docker:build`/`docker:push` targets (rather
-// than layering extra options on top of `@nx/docker`'s own inferred
+// rather than layering extra options on top of another plugin's inferred
 // targets) because Nx target-merging replaces an inferred target's
 // `options` wholesale, key-by-key, when a later-registered plugin also
-// contributes the same key — a plugin-ordering footgun this sidesteps by
-// keeping a single, fully self-contained source of truth. `@nx/docker` is
-// still registered in `nx.json` for the `docker:run` convenience target.
+// contributes the same key. Keeping the DX targets self-contained avoids
+// that ordering hazard.
 import type { TargetConfiguration } from "@nx/devkit";
 
 import type { DockerRunOptions } from "./docker-run.ts";

--- a/packages/nx-dx-docker-plugin/src/generators/init/generator.test.ts
+++ b/packages/nx-dx-docker-plugin/src/generators/init/generator.test.ts
@@ -5,24 +5,17 @@ import { describe, expect, it } from "vitest";
 import initGenerator from "./generator.ts";
 
 describe("initGenerator", () => {
-  it("registers the Docker plugins in the required order", async () => {
+  it("registers the DX Docker plugin", async () => {
     const tree = createTreeWithEmptyWorkspace();
 
     await initGenerator(tree);
 
     expect(readJson(tree, "nx.json").plugins).toEqual([
-      {
-        options: {
-          buildTarget: "docker:build",
-          runTarget: "docker:run",
-        },
-        plugin: "@nx/docker",
-      },
       { plugin: "@pagopa/nx-dx-docker-plugin" },
     ]);
   });
 
-  it("does not duplicate plugins already registered in nx.json", async () => {
+  it("removes the upstream Docker plugin and preserves the DX plugin", async () => {
     const tree = createTreeWithEmptyWorkspace();
     tree.write(
       "nx.json",
@@ -34,7 +27,6 @@ describe("initGenerator", () => {
     await initGenerator(tree);
 
     expect(readJson(tree, "nx.json").plugins).toEqual([
-      "@nx/docker",
       "@pagopa/nx-dx-docker-plugin",
     ]);
   });

--- a/packages/nx-dx-docker-plugin/src/generators/init/generator.ts
+++ b/packages/nx-dx-docker-plugin/src/generators/init/generator.ts
@@ -6,11 +6,11 @@ interface NxJsonConfiguration {
 }
 
 type NxPlugin =
+  | string
   | {
       readonly options?: Record<string, unknown>;
       readonly plugin: string;
-    }
-  | string;
+    };
 
 const dxDockerPlugin = {
   plugin: "@pagopa/nx-dx-docker-plugin",

--- a/packages/nx-dx-docker-plugin/src/generators/init/generator.ts
+++ b/packages/nx-dx-docker-plugin/src/generators/init/generator.ts
@@ -5,22 +5,14 @@ interface NxJsonConfiguration {
   readonly plugins?: NxPlugin[];
 }
 
-type NxPlugin = NxPluginConfiguration | string;
+type NxPlugin =
+  | {
+      readonly options?: Record<string, unknown>;
+      readonly plugin: string;
+    }
+  | string;
 
-interface NxPluginConfiguration {
-  readonly options?: Record<string, unknown>;
-  readonly plugin: string;
-}
-
-const nxDockerPlugin: NxPluginConfiguration = {
-  options: {
-    buildTarget: "docker:build",
-    runTarget: "docker:run",
-  },
-  plugin: "@nx/docker",
-};
-
-const dxDockerPlugin: NxPluginConfiguration = {
+const dxDockerPlugin = {
   plugin: "@pagopa/nx-dx-docker-plugin",
 };
 
@@ -32,10 +24,9 @@ const hasPlugin = (plugins: readonly NxPlugin[], pluginName: string): boolean =>
 
 export default async function initGenerator(tree: Tree): Promise<void> {
   updateJson<NxJsonConfiguration>(tree, "nx.json", (nxJson) => {
-    const plugins = [...(nxJson.plugins ?? [])];
-    if (!hasPlugin(plugins, "@nx/docker")) {
-      plugins.push(nxDockerPlugin);
-    }
+    const plugins = (nxJson.plugins ?? []).filter(
+      (plugin) => getPluginName(plugin) !== "@nx/docker",
+    );
     if (!hasPlugin(plugins, "@pagopa/nx-dx-docker-plugin")) {
       plugins.push(dxDockerPlugin);
     }

--- a/packages/nx-dx-docker-plugin/src/generators/init/schema.json
+++ b/packages/nx-dx-docker-plugin/src/generators/init/schema.json
@@ -2,7 +2,7 @@
   "$schema": "https://json-schema.org/schema",
   "version": 2,
   "title": "Initialize the DX Docker plugin",
-  "description": "Registers @nx/docker and @pagopa/nx-dx-docker-plugin in nx.json.",
+  "description": "Registers @pagopa/nx-dx-docker-plugin in nx.json.",
   "type": "object",
   "properties": {}
 }

--- a/packages/nx-dx-docker-plugin/src/index.ts
+++ b/packages/nx-dx-docker-plugin/src/index.ts
@@ -1,6 +1,5 @@
-// Nx plugin implementing RFC-DX-076's decision: `@nx/docker` remains the
-// official base plugin for the `docker:run` convenience target and the
-// `nx-release-publish` executor, while this plugin owns:
+// Nx plugin implementing RFC-DX-076's Docker target inference. This plugin
+// owns the build, push, run, and release-publish targets:
 //
 // - the `docker:build`/`docker:push` targets for every project with a
 //   Dockerfile, to reach feature parity with `docker/metadata-action`
@@ -18,7 +17,11 @@ import { existsSync } from "node:fs";
 import { dirname, join } from "node:path";
 
 import { getBuildLayoutOverrides } from "./docker-build-layout.ts";
-import { getImageName, getProjectDisplayName } from "./docker-image.ts";
+import {
+  getImageName,
+  getProjectDisplayName,
+  getProjectSlug,
+} from "./docker-image.ts";
 import {
   buildDockerBuildTarget,
   buildDockerPushTarget,
@@ -70,12 +73,9 @@ const getProjectJson = (
 };
 
 /**
- * Detects the *official* Nx Docker release flow's per-project override
+ * Detects a per-project Docker release override
  * (`nx.release.docker.repositoryName` in package.json). Projects using it
- * get their `nx-release-publish` target overridden to also push the
- * dynamic alias tags (see executors/release-publish), since
- * `@nx/docker:release-publish` on its own only ever pushes a single
- * version-only tag.
+ * get an `nx-release-publish` target that pushes the dynamic alias tags.
  */
 const getDockerRepositoryNameOverride = (
   workspaceRoot: string,
@@ -125,7 +125,7 @@ const getBuildImageRepositoryNameOverride = (
 export const createDockerReleaseNodes = (
   projectRoot: string,
   options: DockerPluginOptions,
-  context: CreateNodesContextV2,
+  context: Pick<CreateNodesContextV2, "workspaceRoot">,
 ) => {
   const targets: Record<string, TargetConfiguration> = {};
   const buildLayout = getBuildLayoutOverrides(
@@ -166,6 +166,18 @@ export const createDockerReleaseNodes = (
     dockerRunOptions,
     options.buildTargetName,
   );
+
+  targets["docker:run"] = {
+    command: `docker run {args} ${getProjectSlug(projectRoot)}`,
+    dependsOn: [options.buildTargetName],
+    metadata: {
+      description: "Run this project's locally built Docker image",
+      technologies: ["container-image"],
+    },
+    options: {
+      cwd: projectRoot,
+    },
+  };
 
   if (
     getDockerRepositoryNameOverride(context.workspaceRoot, projectRoot) !== null


### PR DESCRIPTION
Use the DX Docker plugin as the single owner of inferred Docker targets. It now provides `docker:run` directly, avoiding Nx Docker Release's interactive `production`/`hotfix` scheme prompt while preserving local run workflows.

Restore the Terraform Nx plugin configuration and align the plugin README and documentation site with the DX-only Docker setup.

Includes a patch Version Plan for `@pagopa/nx-dx-docker-plugin`.

Validation:
- `pnpm nx build @pagopa/nx-dx-docker-plugin --skipNxCache --outputStyle=static`
- `pnpm nx show project dx-metrics-import --json`
- `pnpm nx show project azure_storage_account --json`
- `pnpm exec prettier --check packages/nx-dx-docker-plugin/README.md apps/website/docs/containers/nx-docker-release.md`