### PR TITLE
Replace deprecated tsdown option

### DIFF
--- a/packages/nx-dx-docker-plugin/tsdown.config.mts
+++ b/packages/nx-dx-docker-plugin/tsdown.config.mts
@@ -11,7 +11,7 @@ import { defineConfig } from "tsdown";
 // have this problem.
 export default defineConfig({
   deps: {
-    skipNodeModulesBundle: true,
+    neverBundle: true,
   },
   dts: false,
   entry: {

--- a/packages/nx-terraform-plugin/tsdown.config.ts
+++ b/packages/nx-terraform-plugin/tsdown.config.ts
@@ -2,7 +2,10 @@ import { defineConfig } from "tsdown";
 
 export default defineConfig({
   deps: {
-    skipNodeModulesBundle: true,
+    // @pagopa/dx-tasks is a workspace-only devDependency: it must be inlined
+    // because it is not installable as a runtime dependency of this plugin.
+    alwaysBundle: [/^@pagopa\/dx-tasks(\/|$)/],
+    neverBundle: true,
   },
   dts: false,
   entry: {


### PR DESCRIPTION
## Why

The build currently emits a deprecation warning because tsdown no longer recommends `deps.skipNodeModulesBundle`. Leaving the deprecated option in place creates noisy CI output and risks future incompatibility when the option is removed.

## Changes

- Replace `skipNodeModulesBundle` with the supported `neverBundle` option in both plugin configurations.
- Explicitly keep `@pagopa/dx-tasks` bundled for the Terraform plugin because it is a workspace-only development dependency and is not available as a runtime package after publication.

## Validation

- Built both plugins successfully without the deprecation warning.
- Passed lint, typecheck, and tests for both plugins.