### PR TITLE
Remove unused tfsec tooling

### DIFF
--- a/.devcontainer/templates/node/.devcontainer/devcontainer.json
+++ b/.devcontainer/templates/node/.devcontainer/devcontainer.json
@@ -7,7 +7,6 @@
     "ghcr.io/devcontainers/features/terraform:1": {
       "version": "${templateOption:terraformVersion}",
       "tflint": "latest",
-      "installTFsec": false,
       "installTerraformDocs": true
     },
     "ghcr.io/pagopa/devcontainer-features/trivy:1": {},

--- a/.devcontainer/templates/node/.devcontainer/devcontainer.json
+++ b/.devcontainer/templates/node/.devcontainer/devcontainer.json
@@ -7,7 +7,7 @@
     "ghcr.io/devcontainers/features/terraform:1": {
       "version": "${templateOption:terraformVersion}",
       "tflint": "latest",
-      "installTFsec": true,
+      "installTFsec": false,
       "installTerraformDocs": true
     },
     "ghcr.io/pagopa/devcontainer-features/trivy:1": {},

--- a/mise.toml
+++ b/mise.toml
@@ -17,7 +17,6 @@ shellcheck = "0.11"
 terraform = "1.15"
 terraform-docs = "0.24"
 tflint = "0.63"
-tfsec = "1.28"
 trivy = "0.71"
 uv = "latest"
 


### PR DESCRIPTION
## Summary
- Remove the unused tfsec mise tool.
- Remove the obsolete tfsec option from the Terraform devcontainer feature.
- Keep Trivy as the supported Terraform misconfiguration scanner.

## Validation
- JSON configuration validation passed.
- No legacy scanner references remain in the toolchain configuration.

This is the first PR in the Trivy migration stack.