### PR TITLE
Migrate Terraform ignores to Trivy

### DIFF
--- a/.devcontainer/templates/node/.devcontainer/devcontainer.json
+++ b/.devcontainer/templates/node/.devcontainer/devcontainer.json
@@ -7,7 +7,6 @@
     "ghcr.io/devcontainers/features/terraform:1": {
       "version": "${templateOption:terraformVersion}",
       "tflint": "latest",
-      "installTFsec": false,
       "installTerraformDocs": true
     },
     "ghcr.io/pagopa/devcontainer-features/trivy:1": {},

--- a/.devcontainer/templates/node/.devcontainer/devcontainer.json
+++ b/.devcontainer/templates/node/.devcontainer/devcontainer.json
@@ -7,6 +7,7 @@
     "ghcr.io/devcontainers/features/terraform:1": {
       "version": "${templateOption:terraformVersion}",
       "tflint": "latest",
+      "installTFsec": false,
       "installTerraformDocs": true
     },
     "ghcr.io/pagopa/devcontainer-features/trivy:1": {},

--- a/apps/website/docs/azure/networking/app-gateway-tls-cert.md
+++ b/apps/website/docs/azure/networking/app-gateway-tls-cert.md
@@ -34,7 +34,7 @@ resource "azurerm_key_vault" "this" {
 
   network_acls {
     bypass         = "AzureServices"
-    default_action = "Allow" #tfsec:ignore:AZU020
+    default_action = "Allow" #trivy:ignore:azure-keyvault-specify-network-acl
   }
 }
 

--- a/infra/modules/azure_core_infra/_modules/application_insights/appi.tf
+++ b/infra/modules/azure_core_infra/_modules/application_insights/appi.tf
@@ -16,8 +16,8 @@ resource "azurerm_application_insights" "appi" {
   tags = var.tags
 }
 
-#tfsec:ignore:AZU023
-#tfsec:ignore:AVD-AZU-0017
+#trivy:ignore:AZU-0017
+#trivy:ignore:AVD-AZU-0017
 resource "azurerm_key_vault_secret" "appinsights_instrumentation_key" {
   name         = "appinsights-instrumentation-key"
   value        = azurerm_application_insights.appi.instrumentation_key

--- a/infra/modules/azure_core_infra/_modules/application_insights/appi.tf
+++ b/infra/modules/azure_core_infra/_modules/application_insights/appi.tf
@@ -7,7 +7,7 @@ resource "azurerm_application_insights" "appi" {
   }))
   location             = var.location
   resource_group_name  = var.resource_group_name
-  disable_ip_masking   = !var.mask_ip_address
+  ip_masking_enabled   = var.mask_ip_address
   application_type     = "other"
   daily_data_cap_in_gb = var.daily_data_cap_in_gb
 

--- a/infra/modules/azure_core_infra/_modules/key_vault/kv.tf
+++ b/infra/modules/azure_core_infra/_modules/key_vault/kv.tf
@@ -1,5 +1,5 @@
-#tfsec:ignore:AVD-AZU-0013
-#tfsec:ignore:AVD-AZU-0016
+#trivy:ignore:AVD-AZU-0013
+#trivy:ignore:AVD-AZU-0016
 resource "azurerm_key_vault" "common" {
   name = provider::dx::resource_name(merge(
     var.naming_config,
@@ -20,7 +20,7 @@ resource "azurerm_key_vault" "common" {
 
   network_acls {
     bypass         = "AzureServices"
-    default_action = "Allow" #tfsec:ignore:AZU020
+    default_action = "Allow" #trivy:ignore:azure-keyvault-specify-network-acl
   }
 
   tags = var.tags

--- a/infra/modules/azure_cosmos_account/tests/setup/main.tf
+++ b/infra/modules/azure_cosmos_account/tests/setup/main.tf
@@ -58,7 +58,7 @@ resource "random_integer" "kv_instance" {
   max = 99
 }
 
-#tfsec:ignore:AVD-AZU-0013
+#trivy:ignore:AVD-AZU-0013
 resource "azurerm_key_vault" "kv" {
   name                          = provider::dx::resource_name(merge(var.environment, { resource_type = "key_vault", domain = "int", instance_number = random_integer.kv_instance.result }))
   location                      = azurerm_resource_group.sut.location

--- a/infra/modules/azure_storage_account/cmk.tf
+++ b/infra/modules/azure_storage_account/cmk.tf
@@ -1,5 +1,5 @@
 # Create a CMK key vault key if a key is not provided
-# tfsec:ignore:azure-keyvault-ensure-key-expiry
+# trivy:ignore:azure-keyvault-ensure-key-expiry
 resource "azurerm_key_vault_key" "key" {
   for_each     = (local.cmk_flags.kv && var.customer_managed_key.key_name == null ? toset(["kv"]) : toset([]))
   name         = provider::dx::resource_name(merge(local.naming_config, { resource_type = "customer_key_storage_account" }))

--- a/infra/modules/github_selfhosted_runner_on_container_app_jobs/examples/app_based/fixtures.tf
+++ b/infra/modules/github_selfhosted_runner_on_container_app_jobs/examples/app_based/fixtures.tf
@@ -58,8 +58,8 @@ resource "azurerm_container_app_environment" "runner" {
   tags = local.tags
 }
 
-#tfsec:ignore:AVD-AZU-0013
-#tfsec:ignore:AVD-AZU-0016
+#trivy:ignore:AVD-AZU-0013
+#trivy:ignore:AVD-AZU-0016
 resource "azurerm_key_vault" "test" {
   name                          = provider::dx::resource_name(merge(local.environment, { resource_type = "key_vault", instance_number = random_integer.kv_instance.result }))
   location                      = azurerm_resource_group.sut.location
@@ -79,9 +79,9 @@ resource "azurerm_role_assignment" "kv_admin" {
   principal_id         = data.azurerm_client_config.current.object_id
 }
 
-#tfsec:ignore:AVD-AZU-0015
-#tfsec:ignore:AVD-AZU-0016
-#tfsec:ignore:AVD-AZU-0017
+#trivy:ignore:AVD-AZU-0015
+#trivy:ignore:AVD-AZU-0016
+#trivy:ignore:AVD-AZU-0017
 resource "azurerm_key_vault_secret" "github_app_id" {
   name         = "github-runner-app-id"
   value        = local.github_app.id
@@ -89,9 +89,9 @@ resource "azurerm_key_vault_secret" "github_app_id" {
   depends_on   = [azurerm_role_assignment.kv_admin]
 }
 
-#tfsec:ignore:AVD-AZU-0015
-#tfsec:ignore:AVD-AZU-0016
-#tfsec:ignore:AVD-AZU-0017
+#trivy:ignore:AVD-AZU-0015
+#trivy:ignore:AVD-AZU-0016
+#trivy:ignore:AVD-AZU-0017
 resource "azurerm_key_vault_secret" "github_app_installation_id" {
   name         = "github-runner-app-installation-id"
   value        = local.github_app.installation_id
@@ -99,9 +99,9 @@ resource "azurerm_key_vault_secret" "github_app_installation_id" {
   depends_on   = [azurerm_role_assignment.kv_admin]
 }
 
-#tfsec:ignore:AVD-AZU-0015
-#tfsec:ignore:AVD-AZU-0016
-#tfsec:ignore:AVD-AZU-0017
+#trivy:ignore:AVD-AZU-0015
+#trivy:ignore:AVD-AZU-0016
+#trivy:ignore:AVD-AZU-0017
 resource "azurerm_key_vault_secret" "github_app_private_key" {
   name         = "github-runner-app-key"
   value        = local.github_app.private_key

--- a/infra/modules/github_selfhosted_runner_on_container_app_jobs/examples/pat_based/fixtures.tf
+++ b/infra/modules/github_selfhosted_runner_on_container_app_jobs/examples/pat_based/fixtures.tf
@@ -58,8 +58,8 @@ resource "azurerm_container_app_environment" "runner" {
   tags = local.tags
 }
 
-#tfsec:ignore:AVD-AZU-0013
-#tfsec:ignore:AVD-AZU-0016
+#trivy:ignore:AVD-AZU-0013
+#trivy:ignore:AVD-AZU-0016
 resource "azurerm_key_vault" "test" {
   name                          = provider::dx::resource_name(merge(local.environment, { resource_type = "key_vault", instance_number = random_integer.kv_instance.result }))
   location                      = azurerm_resource_group.sut.location
@@ -79,9 +79,9 @@ resource "azurerm_role_assignment" "kv_admin" {
   principal_id         = data.azurerm_client_config.current.object_id
 }
 
-#tfsec:ignore:AVD-AZU-0015
-#tfsec:ignore:AVD-AZU-0016
-#tfsec:ignore:AVD-AZU-0017
+#trivy:ignore:AVD-AZU-0015
+#trivy:ignore:AVD-AZU-0016
+#trivy:ignore:AVD-AZU-0017
 resource "azurerm_key_vault_secret" "runner_pat" {
   name         = "github-runner-pat"
   value        = local.github_runner_pat_placeholder

--- a/infra/modules/github_selfhosted_runner_on_container_app_jobs/tests/setup/main.tf
+++ b/infra/modules/github_selfhosted_runner_on_container_app_jobs/tests/setup/main.tf
@@ -103,9 +103,9 @@ resource "random_integer" "kv_instance" {
   max = 99
 }
 
-#tfsec:ignore:AVD-AZU-0013
-#tfsec:ignore:AVD-AZU-0016
-#tfsec:ignore:AVD-AZU-0017
+#trivy:ignore:AVD-AZU-0013
+#trivy:ignore:AVD-AZU-0016
+#trivy:ignore:AVD-AZU-0017
 resource "azurerm_key_vault" "test" {
   name = provider::dx::resource_name(
     merge(var.environment,
@@ -130,9 +130,9 @@ resource "azurerm_role_assignment" "kv_admin" {
   principal_id         = data.azurerm_client_config.current.object_id
 }
 
-#tfsec:ignore:AVD-AZU-0015
-#tfsec:ignore:AVD-AZU-0016
-#tfsec:ignore:AVD-AZU-0017
+#trivy:ignore:AVD-AZU-0015
+#trivy:ignore:AVD-AZU-0016
+#trivy:ignore:AVD-AZU-0017
 resource "azurerm_key_vault_secret" "pat" {
   name         = "github-runner-pat"
   value        = "ghp_test_dummy_value_for_integration_test"
@@ -140,8 +140,8 @@ resource "azurerm_key_vault_secret" "pat" {
   depends_on   = [azurerm_role_assignment.kv_admin]
 }
 
-#tfsec:ignore:AVD-AZU-0015
-#tfsec:ignore:AVD-AZU-0017
+#trivy:ignore:AVD-AZU-0015
+#trivy:ignore:AVD-AZU-0017
 resource "azurerm_key_vault_secret" "app_id" {
   name         = "github-runner-app-id"
   value        = "12345"
@@ -149,8 +149,8 @@ resource "azurerm_key_vault_secret" "app_id" {
   depends_on   = [azurerm_role_assignment.kv_admin]
 }
 
-#tfsec:ignore:AVD-AZU-0015
-#tfsec:ignore:AVD-AZU-0017
+#trivy:ignore:AVD-AZU-0015
+#trivy:ignore:AVD-AZU-0017
 resource "azurerm_key_vault_secret" "app_installation_id" {
   name         = "github-runner-app-installation-id"
   value        = "67890"
@@ -158,8 +158,8 @@ resource "azurerm_key_vault_secret" "app_installation_id" {
   depends_on   = [azurerm_role_assignment.kv_admin]
 }
 
-#tfsec:ignore:AVD-AZU-0015
-#tfsec:ignore:AVD-AZU-0017
+#trivy:ignore:AVD-AZU-0015
+#trivy:ignore:AVD-AZU-0017
 resource "azurerm_key_vault_secret" "app_key" {
   name         = "github-runner-app-key"
   value        = "dummy-rsa-key-for-integration-test"


### PR DESCRIPTION
## Summary
- Replace all Terraform `tfsec:ignore` annotations with `trivy:ignore`.
- Replace legacy Azure rule IDs with the IDs emitted by the current Trivy scanner.
- Preserve the existing suppression behavior.

## Validation
- Trivy 0.71 recognized the migrated suppressions in all affected Terraform targets.
- Targeted pre-commit checks passed.

Depends on #2021.