### PR TITLE
Prevent legacy Terraform scanner references

### DIFF
--- a/.devcontainer/templates/node/.devcontainer/devcontainer.json
+++ b/.devcontainer/templates/node/.devcontainer/devcontainer.json
@@ -7,7 +7,6 @@
     "ghcr.io/devcontainers/features/terraform:1": {
       "version": "${templateOption:terraformVersion}",
       "tflint": "latest",
-      "installTFsec": false,
       "installTerraformDocs": true
     },
     "ghcr.io/pagopa/devcontainer-features/trivy:1": {},

--- a/.devcontainer/templates/node/.devcontainer/devcontainer.json
+++ b/.devcontainer/templates/node/.devcontainer/devcontainer.json
@@ -7,6 +7,7 @@
     "ghcr.io/devcontainers/features/terraform:1": {
       "version": "${templateOption:terraformVersion}",
       "tflint": "latest",
+      "installTFsec": false,
       "installTerraformDocs": true
     },
     "ghcr.io/pagopa/devcontainer-features/trivy:1": {},

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -16,6 +16,12 @@ repos:
         language: script
         pass_filenames: false
         verbose: true
+      - id: legacy_scanner_reference_check
+        name: Prevent legacy Terraform scanner references
+        entry: infra/scripts/check-legacy-scanner-reference.sh
+        language: script
+        pass_filenames: false
+        always_run: true
   - repo: https://github.com/antonbabenko/pre-commit-terraform
     rev: v1.105.0
     hooks:

--- a/infra/scripts/check-legacy-scanner-reference.sh
+++ b/infra/scripts/check-legacy-scanner-reference.sh
@@ -3,7 +3,7 @@
 set -euo pipefail
 
 if matches=$(git grep -n -i -e 'tfsec' -- . ':(exclude)infra/scripts/check-legacy-scanner-reference.sh'); then
-  echo "Legacy Terraform scanner references were found:"
+  echo "Deprecated tfsec references detected. Please use Trivy instead. Matches found:"
   echo "$matches"
   exit 1
 fi

--- a/infra/scripts/check-legacy-scanner-reference.sh
+++ b/infra/scripts/check-legacy-scanner-reference.sh
@@ -1,0 +1,9 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+if matches=$(git grep -n -i -e 'tfsec' -- . ':(exclude)infra/scripts/check-legacy-scanner-reference.sh'); then
+  echo "Legacy Terraform scanner references were found:"
+  echo "$matches"
+  exit 1
+fi


### PR DESCRIPTION
## Summary
- Add a pre-commit guard that rejects new tfsec references.
- Keep the guard itself excluded from the scan because it contains the detection pattern.

## Validation
- ShellCheck passed.
- The guard correctly failed on a temporary legacy annotation and passed after cleanup.

Depends on #2022.