### PR TITLE
Use self-hosted runner for static review job

### DIFF
--- a/.github/workflows/validate-v2.yaml
+++ b/.github/workflows/validate-v2.yaml
@@ -66,7 +66,7 @@ jobs:
 
   static-review:
     name: Static Review
-    runs-on: ubuntu-24.04
+    runs-on: self-hosted
     needs: gate
     if: ${{ needs.gate.outputs.run == 'true' }}
     permissions:


### PR DESCRIPTION
⚠️ This change is an experiment, to see if Nx local cache rehydration works on
self-hosted runners.

Currently, we use a GitHub Runner for this kind of job, but Nx faces issues when
restoring the cache because it does not recognizex the machine (since it binds
each cache artifact to a machine ID, which depends on the runner hardware)
