### PR TITLE
Deduplicate findings and separate governance from cost

### DIFF
--- a/.nx/version-plans/version-plan-1785249132426.md
+++ b/.nx/version-plans/version-plan-1785249132426.md
@@ -1,0 +1,22 @@
+---
+'@pagopa/dx-savemoney': patch
+---
+
+Deduplicate findings across sources and separate governance from cost.
+
+Findings are now unified on a `resourceId + recommendationId` key: the new
+optional `Finding.recommendationId` normalises each source's native identifier
+onto a shared vocabulary (`orphan.<resourceType>` for orphaned resources,
+`advisor.<recommendationTypeId>` for Azure Advisor, `azqr.<recommendationId>`
+for the remaining AZQR rows). When an AZQR row collides with a finding already
+reported by the live scan or by Azure Advisor for the same resource, the row is
+dropped and the surviving finding keeps the highest severity and the only
+available monetary estimate, gaining a note that records the corroborating
+source. Findings without a `recommendationId` are never collapsed.
+
+Governance and diagnostic observations from the custom analyzers — missing
+tags, a resource outside the preferred location, an unsupported resource type,
+a failed detail lookup — are reported as `operationalExcellence` instead of
+`cost`, so the `cost` category means billable waste only. The direct Azure
+Advisor Cost query is unchanged: it remains the source of per-finding
+`estimatedMonthlySavings`.

--- a/packages/savemoney/README.md
+++ b/packages/savemoney/README.md
@@ -77,6 +77,7 @@ yarn add @pagopa/dx-savemoney
 - **Intelligent Detection**: Uses Azure Monitor metrics (e.g. CPU, network traffic, transactions) to scientifically identify inactive resources.
 - **Azure Advisor Integration**: Fetches Cost recommendations directly from Azure Advisor, including Reserved Instance and Savings Plan opportunities with estimated monthly savings.
 - **Orphaned Resource Identification**: Detects commonly "forgotten" resources like unattached disks, unassociated public IPs, and unused network interfaces.
+- **Cross-Source Deduplication**: Findings reported by more than one source (live scan, Azure Advisor, AZQR) are collapsed onto a single entry, keeping the one that carries the monetary estimate.
 - **Flexible Reporting**: Offers multiple output formats:
   - `table`: A human-readable summary for the terminal.
   - `json`: Standard format for integration with other tools.
@@ -122,6 +123,9 @@ All resources are also checked for:
 
 - **Missing tags**: Resources without tags are flagged as potentially unmanaged
 - **Location mismatch**: Resources not in the preferred location are reported
+
+Both are governance signals, not billable waste, so they are reported under the
+`operationalExcellence` category and never carry a saving estimate.
 
 ### Prerequisites
 
@@ -375,6 +379,35 @@ Notes:
     verifying they are unused.
 - AZQR carries no monetary estimate, so these findings have no per-finding
   saving amount; they surface as opportunities to review.
+- **Cross-source deduplication.** An AZQR row is dropped when the live scan
+  already reports the same problem on the same resource (see below).
+
+#### Cross-Source Deduplication
+
+The three sources overlap: an unattached disk is waste whether it is spotted by
+the live analyzers, by Azure Advisor, or by AZQR. Findings are therefore
+unified on the `resourceId + recommendationId` key, where `recommendationId` is
+normalised onto a shared vocabulary — orphaned resources become
+`orphan.<resourceType>` regardless of which source detected them.
+
+When an AZQR row collides with an already-collected finding, the AZQR row is
+dropped and the surviving finding keeps the highest severity, the only
+available monetary estimate, and gains a short note recording the corroborating
+source (e.g. `Also flagged by azqr as an orphaned resource.`). This keeps a
+resource on a single line of the report while preserving its provenance.
+
+Only findings that carry a `recommendationId` participate: custom analyzer
+sentences have no stable identifier and are never collapsed on guesswork.
+
+#### Cost vs Governance Findings
+
+The `cost` category means "money is being wasted". Governance and diagnostic
+observations from the custom analyzers — missing tags, a resource outside the
+preferred location, an unsupported resource type, a failed detail lookup — are
+reported as `operationalExcellence` instead, and never carry a saving estimate.
+Besides keeping the FinOps signal clean, this is what makes deduplication safe:
+a resource flagged only for missing tags is not evidence of waste, so it does
+not absorb the corresponding AZQR orphan row.
 
 ## AWS (Coming Soon)
 

--- a/packages/savemoney/src/azure/__tests__/azqr.test.ts
+++ b/packages/savemoney/src/azure/__tests__/azqr.test.ts
@@ -235,4 +235,48 @@ describe("azqrImpactedToFindings", () => {
     });
     expect(azqrImpactedToFindings(report)[0].severity).toBe("low");
   });
+
+  it("gives orphaned resources the shared cross-source recommendation id", () => {
+    const report = parseAzqrReport({
+      impacted: [
+        orphanRow("Microsoft.Compute/disks", {
+          recommendation: "Managed Disks not attached",
+          recommendationId: "orphan-disk",
+        }),
+      ],
+    });
+
+    expect(azqrImpactedToFindings(report)[0].recommendationId).toBe(
+      "orphan.microsoft.compute/disks",
+    );
+  });
+
+  it("namespaces the native recommendation id of non-orphan rows", () => {
+    const report = parseAzqrReport({
+      impacted: [
+        impactedRow({
+          category: "Cost",
+          recommendationId: "aprl-1234",
+          resourceType: "microsoft.compute/disks",
+        }),
+      ],
+    });
+
+    expect(azqrImpactedToFindings(report)[0].recommendationId).toBe(
+      "azqr.aprl-1234",
+    );
+  });
+
+  it("leaves the recommendation id unset when the row carries none", () => {
+    const report = parseAzqrReport({
+      impacted: [
+        impactedRow({
+          category: "Cost",
+          resourceType: "microsoft.compute/disks",
+        }),
+      ],
+    });
+
+    expect(azqrImpactedToFindings(report)[0].recommendationId).toBeUndefined();
+  });
 });

--- a/packages/savemoney/src/azure/__tests__/azqr.test.ts
+++ b/packages/savemoney/src/azure/__tests__/azqr.test.ts
@@ -1,7 +1,7 @@
 /**
  * Tests for the AZQR ingestion module.
  *
- * Cover the behaviours CES-2192 requires:
+ * Cover:
  * 1. `parseAzqrReport` validates the JSON shape (accept valid, reject invalid).
  * 2. `isAzqrReportMasked` detects AZQR's default subscription-ID masking.
  * 3. `classifyAzqrRow` / `azqrImpactedToFindings` promote billable waste as

--- a/packages/savemoney/src/azure/__tests__/finding-category.test.ts
+++ b/packages/savemoney/src/azure/__tests__/finding-category.test.ts
@@ -1,5 +1,5 @@
 /**
- * Unit tests for the categorisation of custom analyzer reasons (CES-2193).
+ * Unit tests for the categorisation of custom analyzer reasons.
  *
  * The per-resource analyzers describe governance observations and billable
  * waste in the same `reason` string, so the classifier is what keeps the

--- a/packages/savemoney/src/azure/__tests__/finding-category.test.ts
+++ b/packages/savemoney/src/azure/__tests__/finding-category.test.ts
@@ -1,0 +1,68 @@
+/**
+ * Unit tests for the categorisation of custom analyzer reasons (CES-2193).
+ *
+ * The per-resource analyzers describe governance observations and billable
+ * waste in the same `reason` string, so the classifier is what keeps the
+ * `cost` category meaning "money is being wasted".
+ */
+
+import { describe, expect, it } from "vitest";
+
+import type { Finding } from "../../finding.js";
+
+import {
+  categorizeCustomFindings,
+  MISSING_TAGS_REASON,
+  NO_ANALYZER_REASON,
+  unpreferredLocationReason,
+} from "../finding-category.js";
+
+const RESOURCE_ID =
+  "/subscriptions/sub1/resourceGroups/rg1/providers/Microsoft.Compute/disks/disk1";
+
+function categorize(reason: string): Finding["category"] {
+  const [finding] = categorizeCustomFindings([customFinding(reason)]);
+  return finding.category;
+}
+
+function customFinding(reason: string): Finding {
+  return {
+    category: "cost",
+    code: "custom.unknown",
+    reason,
+    resourceId: RESOURCE_ID,
+    severity: "low",
+    source: "custom",
+  };
+}
+
+describe("categorizeCustomFindings", () => {
+  it.each([
+    MISSING_TAGS_REASON,
+    NO_ANALYZER_REASON,
+    unpreferredLocationReason("italynorth"),
+    "Could not retrieve detailed NIC information.",
+  ])("reports %j as operational excellence, not cost", (reason) => {
+    expect(categorize(reason)).toBe("operationalExcellence");
+  });
+
+  it.each([
+    "Disk is unattached.",
+    "VM is deallocated.",
+    "Public IP is not associated with any resource.",
+  ])("keeps %j as a cost finding", (reason) => {
+    expect(categorize(reason)).toBe("cost");
+  });
+
+  it("preserves every other field of the finding", () => {
+    const finding = {
+      ...customFinding(MISSING_TAGS_REASON),
+      recommendedAction: "Add the required tags.",
+      severity: "medium" as const,
+    };
+
+    expect(categorizeCustomFindings([finding])).toEqual([
+      { ...finding, category: "operationalExcellence" },
+    ]);
+  });
+});

--- a/packages/savemoney/src/azure/__tests__/finding-dedup.test.ts
+++ b/packages/savemoney/src/azure/__tests__/finding-dedup.test.ts
@@ -1,5 +1,5 @@
 /**
- * Unit tests for cross-source finding deduplication (CES-2193).
+ * Unit tests for cross-source finding deduplication.
  *
  * The same waste can be reported by AZQR, Azure Advisor and the custom
  * analyzers at once. These tests pin down when the incoming finding collapses

--- a/packages/savemoney/src/azure/__tests__/finding-dedup.test.ts
+++ b/packages/savemoney/src/azure/__tests__/finding-dedup.test.ts
@@ -1,0 +1,225 @@
+/**
+ * Unit tests for cross-source finding deduplication (CES-2193).
+ *
+ * The same waste can be reported by AZQR, Azure Advisor and the custom
+ * analyzers at once. These tests pin down when the incoming finding collapses
+ * onto an existing one, and what the surviving finding is expected to carry.
+ */
+
+import { describe, expect, it } from "vitest";
+
+import type { Finding } from "../../finding.js";
+import type { AzureDetailedResourceReport } from "../types.js";
+
+import {
+  foldDuplicateFinding,
+  orphanRecommendationId,
+} from "../finding-dedup.js";
+
+const RESOURCE_ID =
+  "/subscriptions/sub1/resourceGroups/rg1/providers/Microsoft.Compute/disks/disk1";
+
+const ORPHAN_DISK = orphanRecommendationId("Microsoft.Compute/disks");
+
+function mkFinding(overrides: Partial<Finding> = {}): Finding {
+  return {
+    category: "cost",
+    code: "custom.unknown",
+    reason: "Disk is unattached.",
+    resourceId: RESOURCE_ID,
+    severity: "low",
+    source: "custom",
+    ...overrides,
+  };
+}
+
+function mkReport(findings: Finding[]): AzureDetailedResourceReport {
+  return {
+    analysis: {
+      costRisk: "low",
+      reason: findings.map((finding) => finding.reason).join(" "),
+      suspectedUnused: true,
+    },
+    findings,
+    resource: {
+      id: RESOURCE_ID,
+      name: "disk1",
+      type: "Microsoft.Compute/disks",
+    },
+  };
+}
+
+describe("orphanRecommendationId", () => {
+  it("normalises the resource type so sources share one identity", () => {
+    expect(ORPHAN_DISK).toBe("orphan.microsoft.compute/disks");
+  });
+});
+
+describe("foldDuplicateFinding", () => {
+  it("keeps findings without a recommendation id separate", () => {
+    const report = mkReport([mkFinding({ reason: "No tags found." })]);
+
+    expect(foldDuplicateFinding(mkFinding(), report)).toBe(false);
+    expect(report.findings).toHaveLength(1);
+  });
+
+  it("folds a finding sharing the same recommendation id", () => {
+    const report = mkReport([
+      mkFinding({ recommendationId: ORPHAN_DISK, source: "advisor" }),
+    ]);
+
+    const folded = foldDuplicateFinding(
+      mkFinding({
+        recommendationId: ORPHAN_DISK.toUpperCase(),
+        source: "azqr",
+      }),
+      report,
+    );
+
+    expect(folded).toBe(true);
+    expect(report.findings).toHaveLength(1);
+  });
+
+  it("folds an AZQR orphan row onto the live cost finding for the same resource", () => {
+    const report = mkReport([mkFinding()]);
+
+    const folded = foldDuplicateFinding(
+      mkFinding({
+        recommendationId: ORPHAN_DISK,
+        severity: "high",
+        source: "azqr",
+      }),
+      report,
+    );
+
+    expect(folded).toBe(true);
+    expect(report.findings?.[0]).toMatchObject({
+      reason:
+        "Disk is unattached. Also flagged by azqr as an orphaned resource.",
+      severity: "high",
+      source: "custom",
+    });
+  });
+
+  it("adopts the canonical identity of the finding it absorbs", () => {
+    const report = mkReport([mkFinding()]);
+
+    foldDuplicateFinding(
+      mkFinding({ recommendationId: ORPHAN_DISK, source: "azqr" }),
+      report,
+    );
+
+    expect(report.findings?.[0].recommendationId).toBe(ORPHAN_DISK);
+  });
+
+  it("records the corroborating source in the per-resource summary too", () => {
+    const report = mkReport([mkFinding()]);
+
+    foldDuplicateFinding(
+      mkFinding({
+        recommendationId: ORPHAN_DISK,
+        severity: "high",
+        source: "azqr",
+      }),
+      report,
+    );
+
+    expect(report.analysis).toMatchObject({
+      costRisk: "high",
+      reason:
+        "Disk is unattached. Also flagged by azqr as an orphaned resource.",
+    });
+  });
+
+  it("keeps the monetary estimate of whichever finding carries one", () => {
+    const report = mkReport([mkFinding({ recommendationId: ORPHAN_DISK })]);
+
+    foldDuplicateFinding(
+      mkFinding({
+        estimatedMonthlySavings: { amount: 12.5, currency: "EUR" },
+        recommendationId: ORPHAN_DISK,
+        source: "azqr",
+      }),
+      report,
+    );
+
+    expect(report.findings?.[0].estimatedMonthlySavings).toEqual({
+      amount: 12.5,
+      currency: "EUR",
+    });
+  });
+
+  it("does not fold an orphan row onto a governance-only finding", () => {
+    const report = mkReport([
+      mkFinding({
+        category: "operationalExcellence",
+        reason: "No tags found.",
+      }),
+    ]);
+
+    const folded = foldDuplicateFinding(
+      mkFinding({ recommendationId: ORPHAN_DISK, source: "azqr" }),
+      report,
+    );
+
+    expect(folded).toBe(false);
+    expect(report.analysis.reason).toBe("No tags found.");
+  });
+
+  it("does not fold an orphan row onto another static-report finding", () => {
+    const report = mkReport([
+      mkFinding({ recommendationId: "azqr.other", source: "azqr" }),
+    ]);
+
+    expect(
+      foldDuplicateFinding(
+        mkFinding({ recommendationId: ORPHAN_DISK, source: "azqr" }),
+        report,
+      ),
+    ).toBe(false);
+  });
+
+  it("does not annotate same-source duplicates", () => {
+    const report = mkReport([
+      mkFinding({ recommendationId: ORPHAN_DISK, source: "azqr" }),
+    ]);
+
+    foldDuplicateFinding(
+      mkFinding({ recommendationId: ORPHAN_DISK, source: "azqr" }),
+      report,
+    );
+
+    expect(report.findings?.[0].reason).toBe("Disk is unattached.");
+    expect(report.analysis.reason).toBe("Disk is unattached.");
+  });
+
+  it("does not annotate the same corroboration twice", () => {
+    const report = mkReport([mkFinding()]);
+    const azqrRow = () =>
+      mkFinding({ recommendationId: ORPHAN_DISK, source: "azqr" });
+
+    foldDuplicateFinding(azqrRow(), report);
+    const foldedAgain = foldDuplicateFinding(azqrRow(), report);
+
+    expect(foldedAgain).toBe(true);
+    expect(report.findings).toHaveLength(1);
+    expect(report.findings?.[0].reason).toBe(
+      "Disk is unattached. Also flagged by azqr as an orphaned resource.",
+    );
+    expect(report.analysis.reason).toBe(
+      "Disk is unattached. Also flagged by azqr as an orphaned resource.",
+    );
+  });
+
+  it("leaves reports without collected findings untouched", () => {
+    const report = mkReport([]);
+    delete report.findings;
+
+    expect(
+      foldDuplicateFinding(
+        mkFinding({ recommendationId: ORPHAN_DISK, source: "azqr" }),
+        report,
+      ),
+    ).toBe(false);
+  });
+});

--- a/packages/savemoney/src/azure/analyzer.ts
+++ b/packages/savemoney/src/azure/analyzer.ts
@@ -37,8 +37,9 @@ import type { AzureConfig, AzureDetailedResourceReport } from "./types.js";
 import { findingsFromAnalysisResult } from "../finding.js";
 import {
   type AnalysisResult,
-  type CostRisk,
+  COST_RISK_ORDER,
   DEFAULT_THRESHOLDS,
+  maxCostRisk,
   mergeResults,
   type Thresholds,
 } from "../types.js";
@@ -55,12 +56,17 @@ import {
   isAzqrReportMasked,
   loadAzqrReport,
 } from "./azqr.js";
+import {
+  categorizeCustomFindings,
+  MISSING_TAGS_REASON,
+  NO_ANALYZER_REASON,
+  unpreferredLocationReason,
+} from "./finding-category.js";
+import { foldDuplicateFinding } from "./finding-dedup.js";
 import { PricingClient, PricingService } from "./pricing/index.js";
 import { matchesTags, type MetricsCache } from "./utils.js";
 
 const DEFAULT_CONCURRENCY = 8;
-
-const RISK_ORDER: Record<CostRisk, number> = { high: 0, low: 2, medium: 1 };
 
 /**
  * Analyzes resources in every configured Azure subscription and returns
@@ -195,7 +201,10 @@ export async function analyzeAzureResources(
     if (aSub !== bSub) return aSub ? 1 : -1;
     if (a.analysis.costRisk === b.analysis.costRisk)
       return (a.resource.name ?? "").localeCompare(b.resource.name ?? "");
-    return RISK_ORDER[a.analysis.costRisk] - RISK_ORDER[b.analysis.costRisk];
+    return (
+      COST_RISK_ORDER[a.analysis.costRisk] -
+      COST_RISK_ORDER[b.analysis.costRisk]
+    );
   });
 
   return allReports;
@@ -236,7 +245,7 @@ export async function analyzeResource(
   // Generic check: lack of tags is a common sign of unmanaged resources.
   if (!resource.tags || Object.keys(resource.tags).length === 0) {
     result.suspectedUnused = true;
-    result.reason += "No tags found. ";
+    result.reason += `${MISSING_TAGS_REASON} `;
   }
 
   const ctx: AnalyzerContext = {
@@ -261,7 +270,7 @@ export async function analyzeResource(
   }
 
   if (!matched) {
-    result.reason += "No specific analysis for this resource type. ";
+    result.reason += `${NO_ANALYZER_REASON} `;
   }
 
   // Generic check for location
@@ -269,7 +278,7 @@ export async function analyzeResource(
     resource.location &&
     !resource.location.toLowerCase().includes(preferredLocation.toLowerCase())
   ) {
-    result.reason += `Resource not in preferred location (${preferredLocation}). `;
+    result.reason += `${unpreferredLocationReason(preferredLocation)} `;
   }
 
   return { ...result, reason: result.reason.trim() };
@@ -294,10 +303,7 @@ export function mergeFinding(
     // don't produce "Sentence one.Sentence two." when the existing reason is
     // already trimmed (i.e. has no trailing separator space).
     existing.analysis = {
-      costRisk:
-        RISK_ORDER[existing.analysis.costRisk] <= RISK_ORDER[added.costRisk]
-          ? existing.analysis.costRisk
-          : added.costRisk,
+      costRisk: maxCostRisk(existing.analysis.costRisk, added.costRisk),
       estimatedMonthlySavings: existing.analysis.estimatedMonthlySavings,
       reason:
         existing.analysis.reason && added.reason
@@ -451,6 +457,11 @@ function hasTagFilter(filterTags: Map<string, string> | undefined): boolean {
  * report collected during the live scan so AZQR findings attach to their
  * resource when present or create a stub otherwise.
  *
+ * Findings that duplicate what a live source already reported for the same
+ * resource are folded into the existing finding instead of being appended, so
+ * an orphaned resource seen by both AZQR and Advisor/custom analyzers shows up
+ * once — on the entry that carries the monetary estimate.
+ *
  * When the report is still masked, findings cannot match live resource IDs, so
  * a warning advises re-running AZQR with `--mask=false`.
  */
@@ -472,11 +483,22 @@ async function ingestAzqrReport(
   const reportsById = new Map<string, AzureDetailedResourceReport>(
     reports.map((r) => [(r.resource.id ?? "").toLowerCase(), r]),
   );
+  let merged = 0;
+  let deduplicated = 0;
   for (const finding of findings) {
+    const existing = reportsById.get(finding.resourceId.toLowerCase());
+    if (existing && foldDuplicateFinding(finding, existing)) {
+      deduplicated++;
+      continue;
+    }
     mergeFinding(finding, reports, reportsById);
+    merged++;
   }
   logger.info(
-    `AZQR: merged ${findings.length} finding(s) from ${azqrReportPath}`,
+    `AZQR: merged ${merged} finding(s) from ${azqrReportPath}` +
+      (deduplicated > 0
+        ? `, ${deduplicated} deduplicated onto existing findings`
+        : ""),
   );
 }
 
@@ -571,12 +593,14 @@ async function runPerResourceAnalysis(args: {
         const reason = analysis.reason || "No specific findings.";
         const report: AzureDetailedResourceReport = {
           analysis: { ...analysis, reason },
-          findings: findingsFromAnalysisResult({
-            reason,
-            resourceId: resource.id ?? "",
-            severity: analysis.costRisk,
-            source: "custom",
-          }),
+          findings: categorizeCustomFindings(
+            findingsFromAnalysisResult({
+              reason,
+              resourceId: resource.id ?? "",
+              severity: analysis.costRisk,
+              source: "custom",
+            }),
+          ),
           resource,
         };
         reports.push(report);

--- a/packages/savemoney/src/azure/analyzers/__tests__/advisor.test.ts
+++ b/packages/savemoney/src/azure/analyzers/__tests__/advisor.test.ts
@@ -365,3 +365,63 @@ describe("createAdvisorAnalyzer — filtering", () => {
     expect(findings[0].reason).toBe("Azure Advisor cost recommendation.");
   });
 });
+
+describe("createAdvisorAnalyzer — cross-source identity", () => {
+  it("namespaces the recommendation type id of resource-level findings", async () => {
+    const analyzer = createAdvisorAnalyzer({
+      build: () =>
+        makeFakeClient([
+          {
+            category: "Cost",
+            impact: "High",
+            recommendationTypeId: "right-size-vm",
+            resourceMetadata: { resourceId: RID1 },
+            shortDescription: { problem: "p" },
+          },
+        ]),
+    });
+
+    const findings = await analyzer.analyze(makeCtx());
+
+    expect(findings[0].recommendationId).toBe("advisor.right-size-vm");
+  });
+
+  it("namespaces the recommendation type id of subscription-level findings", async () => {
+    const SUB_URI = "/subscriptions/00000000-0000-0000-0000-000000000000";
+    const analyzer = createAdvisorAnalyzer({
+      build: () =>
+        makeFakeClient([
+          {
+            category: "Cost",
+            extendedProperties: { savingsAmount: "50", savingsCurrency: "EUR" },
+            impact: "High",
+            recommendationTypeId: "vm-ri",
+            resourceMetadata: { resourceId: SUB_URI },
+            shortDescription: { problem: "Buy VM reserved instance" },
+          },
+        ]),
+    });
+
+    const findings = await analyzer.analyze(makeCtx());
+
+    expect(findings[0].recommendationId).toBe("advisor.vm-ri");
+  });
+
+  it("leaves the recommendation id unset when Advisor reports no type", async () => {
+    const analyzer = createAdvisorAnalyzer({
+      build: () =>
+        makeFakeClient([
+          {
+            category: "Cost",
+            impact: "Low",
+            resourceMetadata: { resourceId: RID1 },
+            shortDescription: { problem: "p" },
+          },
+        ]),
+    });
+
+    const findings = await analyzer.analyze(makeCtx());
+
+    expect(findings[0].recommendationId).toBeUndefined();
+  });
+});

--- a/packages/savemoney/src/azure/analyzers/advisor.ts
+++ b/packages/savemoney/src/azure/analyzers/advisor.ts
@@ -153,6 +153,18 @@ function addToSubGroups(
   }
 }
 
+/**
+ * Namespaced canonical identity of an Advisor recommendation. Combined with the
+ * resource ID it is the deduplication key that lets the same problem reported
+ * by another source collapse onto this finding. Left unset when Advisor does
+ * not report a type ID, so unrelated recommendations are never merged.
+ */
+function advisorRecommendationId(
+  recommendationTypeId: string | undefined,
+): string | undefined {
+  return recommendationTypeId ? `advisor.${recommendationTypeId}` : undefined;
+}
+
 function buildResourceFinding(
   rec: RecommendationInfo,
   savings: undefined | { amount: number; currency: string },
@@ -168,6 +180,7 @@ function buildResourceFinding(
     code: `advisor.${rec.recommendationTypeId ?? "unknown"}`,
     estimatedMonthlySavings: savings,
     reason: enrichReason(problem, props),
+    recommendationId: advisorRecommendationId(rec.recommendationTypeId),
     recommendedAction: rec.shortDescription?.solution,
     resourceId: rawResourceId,
     severity: mapImpact(rec.impact),
@@ -202,6 +215,7 @@ function createSubGroup(
       category: "cost",
       code: `advisor.${typeKey}`,
       reason,
+      recommendationId: advisorRecommendationId(rec.recommendationTypeId),
       recommendedAction: rec.shortDescription?.solution,
       resourceId,
       severity: mapImpact(rec.impact),

--- a/packages/savemoney/src/azure/azqr.ts
+++ b/packages/savemoney/src/azure/azqr.ts
@@ -23,9 +23,9 @@
  * resources — {@link isAzqrReportMasked} lets the orchestrator warn and advise
  * re-running with `azqr scan --mask=false`.
  *
- * Scope note (CES-2192 / Fase 1): only `impacted` rows are ingested, enriched
- * with `inventory` metadata when available. AZQR `advisor` rows are ignored to
- * avoid duplicating SaveMoney's own Azure Advisor cost query.
+ * Scope note: only `impacted` rows are ingested, enriched with `inventory`
+ * metadata when available. AZQR `advisor` rows are ignored to avoid
+ * duplicating SaveMoney's own Azure Advisor cost query.
  */
 
 import { readFile } from "node:fs/promises";

--- a/packages/savemoney/src/azure/azqr.ts
+++ b/packages/savemoney/src/azure/azqr.ts
@@ -34,6 +34,7 @@ import { z } from "zod";
 import type { CostRisk } from "../types.js";
 
 import { type Finding } from "../finding.js";
+import { orphanRecommendationId } from "./finding-dedup.js";
 
 /** A single `impacted` row from an AZQR JSON report (fields we consume). */
 const azqrImpactedRowSchema = z.object({
@@ -140,6 +141,7 @@ export function azqrImpactedToFindings(report: AzqrReport): Finding[] {
         ? `azqr.${row.recommendationId}`
         : "azqr.impacted",
       reason: buildReason(row, inventory),
+      recommendationId: canonicalRecommendationId(row),
       recommendedAction: row.learn
         ? `${remediation} Learn more: ${row.learn}`
         : remediation,
@@ -172,7 +174,7 @@ export function classifyAzqrRow(
   if ((row.category ?? "").toLowerCase().includes("cost")) {
     return "cost";
   }
-  if ((row.source ?? "").toLowerCase() !== ORPHAN_CHECK_SOURCE) {
+  if (!isOrphanRow(row)) {
     return null;
   }
   const resourceType = (row.resourceType ?? "").toLowerCase();
@@ -252,6 +254,28 @@ function buildReason(
   }
   if (inventory?.location) context.push(inventory.location);
   return context.length > 0 ? `${sentence} (${context.join(", ")})` : sentence;
+}
+
+/**
+ * Canonical identity of the problem a row describes, used to deduplicate it
+ * against findings coming from other sources.
+ *
+ * Orphaned resources (AZQR's `AOR` check) map onto the shared
+ * `orphan.<resourceType>` vocabulary, so the same waste reported by Azure
+ * Advisor or by a custom analyzer collapses onto a single finding. Every other
+ * row keeps AZQR's own recommendation ID, namespaced so it can only ever match
+ * another AZQR row.
+ */
+function canonicalRecommendationId(row: AzqrImpactedRow): string | undefined {
+  if (isOrphanRow(row) && row.resourceType) {
+    return orphanRecommendationId(row.resourceType);
+  }
+  return row.recommendationId ? `azqr.${row.recommendationId}` : undefined;
+}
+
+/** Whether the row comes from AZQR's Azure Orphan Resources check. */
+function isOrphanRow(row: AzqrImpactedRow): boolean {
+  return (row.source ?? "").toLowerCase() === ORPHAN_CHECK_SOURCE;
 }
 
 /**

--- a/packages/savemoney/src/azure/finding-category.ts
+++ b/packages/savemoney/src/azure/finding-category.ts
@@ -9,9 +9,9 @@
  * missing tags or a failed detail lookup — statements that carry no billable
  * waste and would suggest a "saving" that does not exist.
  *
- * CES-2193 separates the two: governance / diagnostic sentences are reported as
- * `operationalExcellence`, leaving `cost` to mean "actual billable waste". The
- * distinction is also what makes cross-source deduplication safe (see
+ * This module separates the two: governance / diagnostic sentences are reported
+ * as `operationalExcellence`, leaving `cost` to mean "actual billable waste".
+ * The distinction is also what makes cross-source deduplication safe (see
  * `finding-dedup.ts`): a resource flagged only for missing tags is not evidence
  * that it is wasted, so it must not absorb the corresponding AZQR orphan row.
  *

--- a/packages/savemoney/src/azure/finding-category.ts
+++ b/packages/savemoney/src/azure/finding-category.ts
@@ -1,0 +1,72 @@
+/**
+ * Categorisation of the reasons emitted by the custom (live-scan) Azure
+ * analyzers.
+ *
+ * The per-resource analyzers describe everything they observe in a single
+ * concatenated `reason` string, which `findingsFromAnalysisResult` then splits
+ * into one `Finding` per sentence. Historically every sentence was labelled
+ * `category: "cost"`, including governance and diagnostic observations such as
+ * missing tags or a failed detail lookup — statements that carry no billable
+ * waste and would suggest a "saving" that does not exist.
+ *
+ * CES-2193 separates the two: governance / diagnostic sentences are reported as
+ * `operationalExcellence`, leaving `cost` to mean "actual billable waste". The
+ * distinction is also what makes cross-source deduplication safe (see
+ * `finding-dedup.ts`): a resource flagged only for missing tags is not evidence
+ * that it is wasted, so it must not absorb the corresponding AZQR orphan row.
+ *
+ * The generic reason strings are defined here and consumed by `analyzer.ts`, so
+ * the classifier cannot drift from the text it has to recognise.
+ */
+
+import type { Finding, FindingCategory } from "../finding.js";
+
+/** Reason emitted when a resource carries no tags at all. */
+export const MISSING_TAGS_REASON = "No tags found.";
+
+/** Reason emitted when no analyzer plugin supports the resource type. */
+export const NO_ANALYZER_REASON =
+  "No specific analysis for this resource type.";
+
+/**
+ * Prefix of the diagnostic sentences emitted by the per-resource analyzers when
+ * an Azure detail lookup fails (e.g. "Could not retrieve detailed NIC
+ * information."). They report a gap in the scan, not a cost opportunity.
+ */
+const DETAIL_LOOKUP_FAILURE_PREFIX = "could not retrieve detailed";
+
+/** Prefix of the reason emitted when a resource sits outside the target region. */
+const UNPREFERRED_LOCATION_REASON = "Resource not in preferred location";
+
+/**
+ * Re-categorises the findings produced from a custom analyzer's `reason`
+ * string, so governance and diagnostic sentences stop being reported as cost
+ * opportunities.
+ */
+export function categorizeCustomFindings(findings: Finding[]): Finding[] {
+  return findings.map((finding) => ({
+    ...finding,
+    category: categorizeCustomReason(finding.reason),
+  }));
+}
+
+/** Builds the reason emitted when a resource sits outside the target region. */
+export function unpreferredLocationReason(preferredLocation: string): string {
+  return `${UNPREFERRED_LOCATION_REASON} (${preferredLocation}).`;
+}
+
+/**
+ * Classifies a single custom analyzer sentence.
+ *
+ * @returns `"operationalExcellence"` for governance / diagnostic statements,
+ *          `"cost"` for everything else (the analyzers' actual waste signals).
+ */
+function categorizeCustomReason(reason: string): FindingCategory {
+  const normalized = reason.trim().toLowerCase();
+  const isNonCost =
+    normalized.startsWith(MISSING_TAGS_REASON.toLowerCase()) ||
+    normalized.startsWith(NO_ANALYZER_REASON.toLowerCase()) ||
+    normalized.startsWith(UNPREFERRED_LOCATION_REASON.toLowerCase()) ||
+    normalized.startsWith(DETAIL_LOOKUP_FAILURE_PREFIX);
+  return isNonCost ? "operationalExcellence" : "cost";
+}

--- a/packages/savemoney/src/azure/finding-dedup.ts
+++ b/packages/savemoney/src/azure/finding-dedup.ts
@@ -1,0 +1,145 @@
+/**
+ * Cross-source deduplication of findings.
+ *
+ * SaveMoney observes the same subscription through three lenses: the custom
+ * live-scan analyzers, Azure Advisor, and an optional AZQR report. They
+ * overlap — an unattached disk is waste no matter who reports it — and before
+ * CES-2193 the same resource could therefore appear several times in the
+ * output, once per source.
+ *
+ * Findings are unified on the `resourceId + recommendationId` key. Sources
+ * normalise `recommendationId` onto a shared vocabulary whenever one exists:
+ * orphaned resources use {@link orphanRecommendationId} regardless of who
+ * detected them, which is what lets an AZQR `AOR` row collapse onto the
+ * Advisor or custom finding for the same resource. The surviving finding is the
+ * one carrying the monetary estimate (only Advisor and the pricing-enriched
+ * custom analyzers have one — AZQR reports no amounts at all), annotated with
+ * the corroborating source so the extra provenance is not lost.
+ */
+
+import type { Finding, FindingSource } from "../finding.js";
+import type { AzureDetailedResourceReport } from "./types.js";
+
+import { maxCostRisk } from "../types.js";
+
+/** Sources that observe the live subscription, as opposed to a static report. */
+const LIVE_SOURCES: ReadonlySet<FindingSource> = new Set(["advisor", "custom"]);
+
+/**
+ * Canonical identity prefix for "this resource is provisioned but unused".
+ * Shared by every source so orphan findings deduplicate across them.
+ */
+const ORPHAN_RECOMMENDATION_PREFIX = "orphan.";
+
+/**
+ * Folds `incoming` into an existing finding of `report` when both describe the
+ * same problem, so the resource is reported once instead of once per source.
+ *
+ * The surviving finding keeps the highest severity and the only available
+ * monetary estimate, and records the corroborating source both in its own
+ * reason and in the legacy per-resource `analysis` summary, so the `lint`,
+ * `json` and `table` formats all keep the provenance.
+ *
+ * @returns `true` when the finding was folded and must not be appended.
+ */
+export function foldDuplicateFinding(
+  incoming: Finding,
+  report: AzureDetailedResourceReport,
+): boolean {
+  const findings = report.findings;
+  if (!findings) {
+    return false;
+  }
+  const surviving = findDuplicateFinding(incoming, findings);
+  if (!surviving) {
+    return false;
+  }
+  const note = corroborationNote(surviving, incoming);
+  findings[findings.indexOf(surviving)] = {
+    ...surviving,
+    estimatedMonthlySavings:
+      surviving.estimatedMonthlySavings ?? incoming.estimatedMonthlySavings,
+    reason: note ? `${surviving.reason.trimEnd()} ${note}` : surviving.reason,
+    recommendationId: surviving.recommendationId ?? incoming.recommendationId,
+    severity: maxCostRisk(surviving.severity, incoming.severity),
+  };
+  report.analysis = {
+    ...report.analysis,
+    costRisk: maxCostRisk(report.analysis.costRisk, incoming.severity),
+    reason: note
+      ? `${report.analysis.reason.trimEnd()} ${note}`.trim()
+      : report.analysis.reason,
+  };
+  return true;
+}
+
+/**
+ * Builds the canonical identity of an orphaned resource of the given type,
+ * e.g. `orphan.microsoft.compute/disks`.
+ */
+export function orphanRecommendationId(resourceType: string): string {
+  return `${ORPHAN_RECOMMENDATION_PREFIX}${resourceType.toLowerCase()}`;
+}
+
+/**
+ * Short sentence appended to the surviving finding so the reader still sees
+ * that a second source flagged the same resource. Omitted for same-source
+ * duplicates, where there is no extra provenance to record, and when the same
+ * note is already there — repeated rows must corroborate, not accumulate.
+ */
+function corroborationNote(
+  surviving: Finding,
+  incoming: Finding,
+): string | undefined {
+  if (surviving.source === incoming.source) {
+    return undefined;
+  }
+  const note = isOrphanRecommendation(incoming.recommendationId)
+    ? `Also flagged by ${incoming.source} as an orphaned resource.`
+    : `Also flagged by ${incoming.source}.`;
+  return surviving.reason.includes(note) ? undefined : note;
+}
+
+/**
+ * Returns the already-collected finding that covers the same problem as
+ * `incoming`, or `undefined` when the incoming finding is genuinely new.
+ *
+ * Two findings describe the same problem when either:
+ *
+ * 1. they share the exact canonical identity (`recommendationId`) on the same
+ *    resource — a true duplicate, e.g. the same AZQR row ingested twice; or
+ * 2. `incoming` reports the resource as orphaned and a live source already
+ *    reported billable waste on it. An orphaned resource has a single cost
+ *    problem — it exists — so the live finding, which can carry a monetary
+ *    estimate, supersedes the static one.
+ *
+ * Findings without a `recommendationId` never match: sources that cannot
+ * identify their recommendations (today the sentence-level custom findings)
+ * must not be collapsed on guesswork.
+ */
+function findDuplicateFinding(
+  incoming: Finding,
+  existing: readonly Finding[],
+): Finding | undefined {
+  const identity = incoming.recommendationId?.toLowerCase();
+  if (!identity) {
+    return undefined;
+  }
+  const sameIdentity = existing.find(
+    (candidate) => candidate.recommendationId?.toLowerCase() === identity,
+  );
+  if (sameIdentity) {
+    return sameIdentity;
+  }
+  if (!isOrphanRecommendation(incoming.recommendationId)) {
+    return undefined;
+  }
+  return existing.find(
+    (candidate) =>
+      candidate.category === "cost" && LIVE_SOURCES.has(candidate.source),
+  );
+}
+
+function isOrphanRecommendation(recommendationId: string | undefined): boolean {
+  return (recommendationId ?? "").startsWith(ORPHAN_RECOMMENDATION_PREFIX);
+}

--- a/packages/savemoney/src/azure/finding-dedup.ts
+++ b/packages/savemoney/src/azure/finding-dedup.ts
@@ -3,9 +3,9 @@
  *
  * SaveMoney observes the same subscription through three lenses: the custom
  * live-scan analyzers, Azure Advisor, and an optional AZQR report. They
- * overlap — an unattached disk is waste no matter who reports it — and before
- * CES-2193 the same resource could therefore appear several times in the
- * output, once per source.
+ * overlap — an unattached disk is waste no matter who reports it — so without
+ * deduplication the same resource could appear several times in the output,
+ * once per source.
  *
  * Findings are unified on the `resourceId + recommendationId` key. Sources
  * normalise `recommendationId` onto a shared vocabulary whenever one exists:

--- a/packages/savemoney/src/finding.ts
+++ b/packages/savemoney/src/finding.ts
@@ -105,10 +105,8 @@ export type Money = {
 /**
  * Aggregate view: one resource with the list of findings emitted for it.
  *
- * This is the type future report generators should consume. The current
- * report layer still works on `AzureDetailedResourceReport`; a helper
- * (`legacyReportFromResourceReport`) bridges the two until the report
- * layer is migrated.
+ * This is the type future report generators should consume; the current
+ * report layer still works on `AzureDetailedResourceReport`.
  */
 export type ResourceReport<TResource = unknown> = {
   findings: Finding[];

--- a/packages/savemoney/src/finding.ts
+++ b/packages/savemoney/src/finding.ts
@@ -16,7 +16,8 @@ import type { CostRisk } from "./types.js";
  * A single, atomic observation about a resource.
  *
  * One resource can produce multiple findings (e.g. "no tags" + "low CPU").
- * Findings are designed to be deduplicated by `(resourceId, source, code)`.
+ * Findings are deduplicated on `(resourceId, recommendationId)` — see
+ * {@link Finding.recommendationId}.
  */
 export type Finding = {
   /**
@@ -27,8 +28,8 @@ export type Finding = {
   /**
    * Stable machine-readable identifier for the kind of finding, e.g.
    * `vm.deallocated`, `disk.unattached`, `advisor.right-size-vm`.
-   * Used for deduplication and grouping. Free-form for now to keep the
-   * adapter from existing analyzers cheap; can be tightened later.
+   * Free-form and source-specific: use `recommendationId` for
+   * deduplication across sources.
    */
   code: string;
   /**
@@ -42,6 +43,19 @@ export type Finding = {
    * legacy `AnalysisResult.reason` field.
    */
   reason: string;
+  /**
+   * Canonical, source-independent identity of the underlying problem.
+   * Together with `resourceId` it forms the deduplication key, so the same
+   * waste reported by different sources collapses into a single finding
+   * (see `azure/finding-dedup.ts`).
+   *
+   * Producers normalise it whenever a shared vocabulary exists — orphaned
+   * resources use `orphan.<resourceType>` regardless of the source that
+   * detected them — and fall back to their native recommendation ID
+   * otherwise. Left unset when the source has no stable identifier: such
+   * findings are never deduplicated.
+   */
+  recommendationId?: string;
   /**
    * Optional, machine-friendly hint about how to remediate. For Advisor
    * this typically maps to `shortDescription.solution`.

--- a/packages/savemoney/src/types.ts
+++ b/packages/savemoney/src/types.ts
@@ -29,6 +29,13 @@ export type BaseConfig = {
 
 export type CostRisk = "high" | "low" | "medium";
 
+/** Cost risk ordering, from the most to the least severe. */
+export const COST_RISK_ORDER: Record<CostRisk, number> = {
+  high: 0,
+  low: 2,
+  medium: 1,
+};
+
 /**
  * Configurable thresholds used during resource analysis.
  * Derived from `ThresholdsSchema` — the schema is the single source of truth.
@@ -40,6 +47,15 @@ export type { Thresholds } from "./schema.js";
  * `ThresholdsSchema`, which applies all schema-defined defaults.
  */
 export const DEFAULT_THRESHOLDS = ThresholdsSchema.parse({});
+
+/**
+ * Returns the more severe of two cost risks. Used whenever two observations
+ * about the same resource (or the same problem seen by two sources) are
+ * combined, so severity never degrades silently.
+ */
+export function maxCostRisk(a: CostRisk, b: CostRisk): CostRisk {
+  return COST_RISK_ORDER[a] <= COST_RISK_ORDER[b] ? a : b;
+}
 
 /**
  * Merges analysis results, preserving existing reasons and combining suspectedUnused flags.


### PR DESCRIPTION
## What
Unifies findings from AZQR, Azure Advisor and the live-scan custom analyzers on a `resourceId + recommendationId` key, and separates governance/diagnostic observations from actual billable waste.

## Why
The same waste (e.g. an unattached disk) could be reported once per source, inflating the report and making the FinOps signal noisy. Governance findings (missing tags, wrong location, ...) were also tagged `category: "cost"`, suggesting a "saving" that doesn't exist and risking false dedup matches.

## How
- `Finding` gains an optional `recommendationId`, normalised onto a shared vocabulary: `orphan.<resourceType>` for orphaned resources (any source),  `advisor.<recommendationTypeId>`, `azqr.<recommendationId>`.
- New `azure/finding-dedup.ts`: `foldDuplicateFinding` collapses an incoming AZQR finding onto an already-collected one for the same resource, keeping max severity + the only available monetary estimate, and annotating the corroborating source (`Also flagged by azqr as an orphaned resource.`). Applied during `ingestAzqrReport`. Findings without a `recommendationId` (all custom sentence-level findings today) never participate - no guesswork dedup.
- New `azure/finding-category.ts`: custom analyzer sentences about missing tags, unpreferred location, unsupported resource type, or a failed detail lookup are now `operationalExcellence` instead of `cost`.
- The Azure Advisor Cost query (`Category eq 'Cost'`) is unchanged - it remains the only source of `estimatedMonthlySavings`.

## Testing
`pnpm nx run-many -t test typecheck lint build format:check -p @pagopa/dx-savemoney @pagopa/dx-cli` - all green, 186 tests in savemoney (+26).

Or local usage:

```bash
pnpm nx build @pagopa/dx-cli --skip-nx-cache
azqr scan --subscription-id 0000 --mask=false --json
node ./apps/cli/bin/index.js savemoney --azqr-report ./azqr_action_plan_xxxx_yy_zz_T123456.json --format lint > savemoney_result.md
```

Example result:
<kbd>
  <img width="770" height="537" alt="image" src="https://github.com/user-attachments/assets/4cae4114-4201-47e0-b0d6-ff61a6b6dfae" />
</kbd>

Resolves: CES-2193