### PR TITLE
Revert "Use self-hosted runner for static review job (#2025)"

### DIFF
--- a/.github/workflows/validate-v2.yaml
+++ b/.github/workflows/validate-v2.yaml
@@ -66,7 +66,7 @@ jobs:
 
   static-review:
     name: Static Review
-    runs-on: self-hosted
+    runs-on: ubuntu-24.04
     needs: gate
     if: ${{ needs.gate.outputs.run == 'true' }}
     permissions:


### PR DESCRIPTION
This reverts commit f1d91c3ec677d192682bd15f2f8437ac69de410f.

The self-hosted runner worked as expected with Nx, but the self-hosted runner image doesn't have all the tool this repo require installed.
We'll made this runner change permanent once we will move to the DX self-hosted runner image.
