### PR TITLE
Adopt mise in DX runner

### DIFF
--- a/.github/workflows/validate-v2.yaml
+++ b/.github/workflows/validate-v2.yaml
@@ -66,7 +66,7 @@ jobs:
 
   static-review:
     name: Static Review
-    runs-on: ubuntu-24.04
+    runs-on: self-hosted
     needs: gate
     if: ${{ needs.gate.outputs.run == 'true' }}
     permissions:
@@ -79,6 +79,21 @@ jobs:
         with:
           fetch-depth: 0
           filter: tree:0
+
+      - name: Detect mise configuration
+        id: mise
+        shell: bash
+        run: |
+          if command -v mise >/dev/null && [ -f "$GITHUB_WORKSPACE/mise.toml" ]; then
+            echo "enabled=true" >> "$GITHUB_OUTPUT"
+            echo "version=$(mise --version | cut -d ' ' -f 1)" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Setup repository tools
+        if: ${{ steps.mise.outputs.enabled == 'true' }}
+        uses: jdx/mise-action@7e36c90d9ab29c415a2384db3006f3ec8a8cc654 # v4.2.4
+        with:
+          version: ${{ steps.mise.outputs.version }}
 
       - name: Setup Node.js
         uses: pagopa/dx/.github/actions/node-setup@main

--- a/.github/workflows/validate-v2.yaml
+++ b/.github/workflows/validate-v2.yaml
@@ -66,7 +66,7 @@ jobs:
 
   static-review:
     name: Static Review
-    runs-on: self-hosted
+    runs-on: ubuntu-24.04
     needs: gate
     if: ${{ needs.gate.outputs.run == 'true' }}
     permissions:
@@ -79,21 +79,6 @@ jobs:
         with:
           fetch-depth: 0
           filter: tree:0
-
-      - name: Detect mise configuration
-        id: mise
-        shell: bash
-        run: |
-          if command -v mise >/dev/null && [ -f "$GITHUB_WORKSPACE/mise.toml" ]; then
-            echo "enabled=true" >> "$GITHUB_OUTPUT"
-            echo "version=$(mise --version | cut -d ' ' -f 1)" >> "$GITHUB_OUTPUT"
-          fi
-
-      - name: Setup repository tools
-        if: ${{ steps.mise.outputs.enabled == 'true' }}
-        uses: jdx/mise-action@7e36c90d9ab29c415a2384db3006f3ec8a8cc654 # v4.2.4
-        with:
-          version: ${{ steps.mise.outputs.version }}
 
       - name: Setup Node.js
         uses: pagopa/dx/.github/actions/node-setup@main

--- a/.nx/version-plans/version-plan-1785831540678.md
+++ b/.nx/version-plans/version-plan-1785831540678.md
@@ -1,0 +1,5 @@
+---
+self-hosted-runner: patch
+---
+
+Add mise to the DX self-hosted runner image and move cloud CLI provisioning to repository mise configurations

--- a/containers/self-hosted-runner/Dockerfile
+++ b/containers/self-hosted-runner/Dockerfile
@@ -10,6 +10,9 @@ ARG MISE_SHA256=961b1fcc78830e861ab887abd19d9b961478bcf252e37881fdd61c81388308d4
 
 LABEL base_runner_digest=${RUNNER_DIGEST}
 
+ENV MISE_DATA_DIR=/home/runner/.local/share/mise
+ENV PATH="${MISE_DATA_DIR}/bin:${PATH}"
+
 USER root
 RUN printf 'Acquire::Retries "5";\nAcquire::http::Timeout "30";\nAcquire::https::Timeout "30";\n' \
     > /etc/apt/apt.conf.d/80network-retries && \
@@ -21,11 +24,13 @@ RUN printf 'Acquire::Retries "5";\nAcquire::http::Timeout "30";\nAcquire::https:
 FROM base AS mise
 ARG MISE_VERSION
 ARG MISE_SHA256
+RUN mkdir -p "${MISE_DATA_DIR}/bin"
 RUN curl --fail --location --retry 5 --retry-all-errors --connect-timeout 30 \
         "https://github.com/jdx/mise/releases/download/v${MISE_VERSION}/mise-v${MISE_VERSION}-linux-x64" \
-        --output /usr/local/bin/mise && \
-    echo "${MISE_SHA256}  /usr/local/bin/mise" | sha256sum --check --strict && \
-    chmod +x /usr/local/bin/mise
+        --output "${MISE_DATA_DIR}/bin/mise" && \
+    echo "${MISE_SHA256}  ${MISE_DATA_DIR}/bin/mise" | sha256sum --check --strict && \
+    chmod +x "${MISE_DATA_DIR}/bin/mise" && \
+    chown -R runner:runner "${MISE_DATA_DIR}"
 
 # === Stage 3: Install Node.js ===
 FROM mise AS nodejs

--- a/containers/self-hosted-runner/Dockerfile
+++ b/containers/self-hosted-runner/Dockerfile
@@ -5,6 +5,8 @@ ARG RUNNER_DIGEST
 FROM ghcr.io/actions/actions-runner${RUNNER_DIGEST:+@${RUNNER_DIGEST}} AS base
 
 ARG RUNNER_DIGEST
+ARG MISE_VERSION=2026.8.1
+ARG MISE_SHA256=961b1fcc78830e861ab887abd19d9b961478bcf252e37881fdd61c81388308d4
 
 LABEL base_runner_digest=${RUNNER_DIGEST}
 
@@ -15,36 +17,25 @@ RUN printf 'Acquire::Retries "5";\nAcquire::http::Timeout "30";\nAcquire::https:
     zip wget xz-utils && \
     apt-get clean && rm -rf /var/lib/apt/lists/*
 
-# === Stage 2: Install Node.js ===
-FROM base AS nodejs
+# === Stage 2: Install mise ===
+FROM base AS mise
+ARG MISE_VERSION
+ARG MISE_SHA256
+RUN curl --fail --location --retry 5 --retry-all-errors --connect-timeout 30 \
+        "https://github.com/jdx/mise/releases/download/v${MISE_VERSION}/mise-v${MISE_VERSION}-linux-x64" \
+        --output /usr/local/bin/mise && \
+    echo "${MISE_SHA256}  /usr/local/bin/mise" | sha256sum --check --strict && \
+    chmod +x /usr/local/bin/mise
+
+# === Stage 3: Install Node.js ===
+FROM mise AS nodejs
 ENV NODE_VERSION=20.12.2
 RUN curl -fsSL https://nodejs.org/dist/v${NODE_VERSION}/node-v${NODE_VERSION}-linux-x64.tar.xz | \
     tar -xJ -C /usr/local --strip-components=1 && \
     corepack enable
 
-# === Stage 3: Install Azure CLI ===
-FROM nodejs AS azure
-RUN set -eux; \
-        for attempt in 1 2 3; do \
-            if curl --fail --location --retry 5 --retry-all-errors --connect-timeout 30 \
-                https://aka.ms/InstallAzureCLIDeb --output /tmp/install-azure-cli.sh && \
-                bash /tmp/install-azure-cli.sh; then \
-                rm -f /tmp/install-azure-cli.sh; \
-                exit 0; \
-            fi; \
-            rm -f /tmp/install-azure-cli.sh; \
-            echo "Azure CLI installation attempt ${attempt} failed; retrying." >&2; \
-        done; \
-        exit 1
-
-# === Stage 4: Install AWS CLI ===
-FROM azure AS aws
-RUN curl "https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip" -o "awscliv2.zip" && \
-    unzip -q awscliv2.zip && ./aws/install && \
-    rm -rf awscliv2.zip aws
-
-# === Stage 5: Cleanup ===
-FROM aws AS cleanup
+# === Stage 4: Cleanup ===
+FROM nodejs AS cleanup
 
 RUN apt-get remove -y xz-utils && \
     apt-get autoremove -y && \
@@ -58,8 +49,7 @@ FROM cleanup AS final
 
 RUN node --version && \
     npm --version && \
-    az --version && \
-    aws --version
+    mise --version
 
 COPY entrypoint.sh /entrypoint.sh
 RUN chmod +x /entrypoint.sh

--- a/containers/self-hosted-runner/README.md
+++ b/containers/self-hosted-runner/README.md
@@ -6,8 +6,7 @@ This is a Dockerfile for building a self-hosted GitHub runner provided by DX. Th
 
 - **Up‑to‑date GitHub runner** – based on the official `ghcr.io/actions/runner:<version>` image.
 - **Node.js**: Installs Node.js (v20.12.2) and enables Corepack for package management.
-- **Azure CLI**: Includes the Azure CLI for managing Azure resources.
-- **AWS CLI**: Includes the AWS CLI for managing AWS resources.
+- **mise**: Installs repository-specific development tools declared in `mise.toml`.
 - **Graceful cleanup** – the runner unregisters itself from GitHub on container shutdown, avoiding “ghost” runners.
 
 ## Entrypoint
@@ -34,5 +33,4 @@ The image includes basic tests to verify the installation of key tools:
 
 - Node.js (`node --version`)
 - npm (`npm --version`)
-- Azure CLI (`az --version`)
-- AWS CLI (`aws --version`)
+- mise (`mise --version`)

--- a/mise.toml
+++ b/mise.toml
@@ -11,6 +11,7 @@ jq = "1.8"
 node = { version = "24.14", postinstall = "corepack enable" }
 "npm:nx" = "22.7"
 pre-commit = "4.6"
+python = { version = "3.14.6", postinstall = "python -m ensurepip --upgrade" }
 qdns = "latest"
 ripgrep = "latest"
 shellcheck = "0.11"


### PR DESCRIPTION
## Summary

- install `mise` in the DX self-hosted runner image with checksum verification
- place the binary in `jdx/mise-action`'s default data directory so workflows reuse it instead of downloading it again
- move AWS CLI and Azure CLI provisioning from the image to repository `mise.toml` configurations
- add Python with `ensurepip` to the DX repository toolchain; ShellCheck was already managed by `mise`
- migrate `static-review` to the DX runner as an end-to-end pilot
- install repository tools through the official pinned `mise` action only when `mise` is in `PATH` and a root `mise.toml` exists
- add a patch version plan for the runner image

## Validation

- built the self-hosted runner image through Nx
- verified the runner user finds `mise` in the action-compatible path and can install tools there
- verified `mise` installs Python/pip, ShellCheck, AWS CLI, and Azure CLI inside the runner image

The remaining compatible `pagopa/dx` workflows will be migrated to the DX runner in a follow-up pull request after validating this pilot.

Part of CES-2228