### PR TITLE
Extend cross-source finding dedup to custom analyzer sentences

### DIFF
--- a/.nx/version-plans/version-plan-1785763254761.md
+++ b/.nx/version-plans/version-plan-1785763254761.md
@@ -1,0 +1,9 @@
+---
+"@pagopa/dx-savemoney": patch
+---
+
+Extend cross-source finding deduplication to custom analyzer sentences.
+
+The per-resource analyzers already split their concatenated `reason` string into one `Finding` per sentence, but every sentence shared the generic `code: "custom.unknown"` and had no `recommendationId`, so two custom findings describing the same problem on the same resource were never collapsed.
+
+Sentences that match a known template now get a stable, per-sentence `custom.<id>` identity (e.g. `custom.disk.unattached`, `custom.low-cpu-usage`), following the same convention as `advisor.<id>`/`azqr.<id>`. This lets the existing (already source-agnostic) `foldDuplicateFinding` collapse duplicate custom findings, not just cross-source ones. Sentences with no known template are unaffected: they keep `code: "custom.unknown"` and no `recommendationId`, and are never collapsed on guesswork.

--- a/packages/savemoney/README.md
+++ b/packages/savemoney/README.md
@@ -396,8 +396,13 @@ available monetary estimate, and gains a short note recording the corroborating
 source (e.g. `Also flagged by azqr as an orphaned resource.`). This keeps a
 resource on a single line of the report while preserving its provenance.
 
-Only findings that carry a `recommendationId` participate: custom analyzer
-sentences have no stable identifier and are never collapsed on guesswork.
+Only findings that carry a `recommendationId` participate. Custom analyzer
+sentences with a known template (e.g. `Disk is unattached.`, `Very low CPU
+usage (...)`) get a stable `custom.<id>` identity, so two custom findings
+describing the same problem on the same resource collapse just like a
+custom/advisor pair would. Sentences that match no known template keep
+`code: "custom.unknown"` and no `recommendationId`, and are never collapsed on
+guesswork.
 
 #### Cost vs Governance Findings
 

--- a/packages/savemoney/src/azure/__tests__/finding-code.test.ts
+++ b/packages/savemoney/src/azure/__tests__/finding-code.test.ts
@@ -1,0 +1,128 @@
+/**
+ * Unit tests for stable per-sentence custom finding codes.
+ *
+ * These codes are what lets `foldDuplicateFinding` collapse two custom
+ * findings that describe the same problem on the same resource, so the tests
+ * focus on: known sentences get a stable identity, identical wording shared
+ * across resource types collapses onto one code, and anything the table
+ * doesn't recognise (or that already has an identity, or isn't "custom") is
+ * left untouched.
+ */
+
+import { describe, expect, it } from "vitest";
+
+import type { Finding } from "../../finding.js";
+
+import { assignCustomFindingCodes } from "../finding-code.js";
+
+const RESOURCE_ID =
+  "/subscriptions/sub1/resourceGroups/rg1/providers/Microsoft.Compute/disks/disk1";
+
+function customFinding(
+  reason: string,
+  overrides: Partial<Finding> = {},
+): Finding {
+  return {
+    category: "cost",
+    code: "custom.unknown",
+    reason,
+    resourceId: RESOURCE_ID,
+    severity: "low",
+    source: "custom",
+    ...overrides,
+  };
+}
+
+describe("assignCustomFindingCodes", () => {
+  it.each([
+    ["Disk is unattached.", "custom.disk.unattached"],
+    [
+      "NIC not attached to any VM or private endpoint.",
+      "custom.nic.unattached",
+    ],
+    ["No public IP assigned.", "custom.nic.no-public-ip"],
+    [
+      "Private Endpoint has no private link service connections configured.",
+      "custom.private-endpoint.no-connections",
+    ],
+    ["Container App is not running.", "custom.container-app.not-running"],
+    ["App Service Plan has no apps deployed.", "custom.app-service.no-apps"],
+    [
+      "Public IP not associated with any resource.",
+      "custom.public-ip.unassociated",
+    ],
+    ["Static IP not in use.", "custom.public-ip.static-unused"],
+    [
+      "Very low transaction count (2.00 avg/day).",
+      "custom.storage.low-transactions",
+    ],
+    ["VM is deallocated.", "custom.vm.deallocated"],
+    ["VM is stopped.", "custom.vm.stopped"],
+    ["Low CPU usage (avg 1.23%).", "custom.vm.low-cpu-usage"],
+    ["Low network traffic (0.50 MB/day avg).", "custom.vm.low-network-traffic"],
+    [
+      "No traffic data available in 30 days.",
+      "custom.static-site.no-traffic-data",
+    ],
+    [
+      "Very low site traffic (3 requests in 30 days).",
+      "custom.static-site.low-traffic",
+    ],
+    [
+      "Very low data transfer (0.01 MB in 30 days).",
+      "custom.static-site.low-data-transfer",
+    ],
+    ["Resource ID is missing.", "custom.missing-resource-id"],
+    ["Could not retrieve detailed NIC information.", "custom.lookup-failed"],
+    ["No tags found.", "custom.missing-tags"],
+  ])("assigns %j the stable code %j", (reason, expectedCode) => {
+    const [finding] = assignCustomFindingCodes([customFinding(reason)]);
+    expect(finding.code).toBe(expectedCode);
+    expect(finding.recommendationId).toBe(expectedCode);
+  });
+
+  it.each([
+    ["Very low CPU usage (12.34%).", "App Service Plan"],
+    ["Very low CPU usage (0.5000 cores).", "Container App"],
+  ])(
+    "shares one code across resource types for identical wording: %j (%s)",
+    (reason) => {
+      const [finding] = assignCustomFindingCodes([customFinding(reason)]);
+      expect(finding.recommendationId).toBe("custom.low-cpu-usage");
+    },
+  );
+
+  it("gives two different resources' identical sentences the same recommendationId, enabling a later fold within a resource but not across resources", () => {
+    const [a, b] = assignCustomFindingCodes([
+      customFinding("Very low network traffic (1.00 MB/day avg)."),
+      customFinding("Very low network traffic (2.00 MB/day avg)."),
+    ]);
+
+    expect(a.recommendationId).toBe("custom.low-network-traffic");
+    expect(b.recommendationId).toBe("custom.low-network-traffic");
+  });
+
+  it("leaves unrecognised sentences unchanged", () => {
+    const finding = customFinding("Something entirely unexpected happened.");
+
+    expect(assignCustomFindingCodes([finding])).toEqual([finding]);
+  });
+
+  it("leaves non-custom findings unchanged", () => {
+    const finding = customFinding("Disk is unattached.", {
+      code: "advisor.some-id",
+      recommendationId: "advisor.some-id",
+      source: "advisor",
+    });
+
+    expect(assignCustomFindingCodes([finding])).toEqual([finding]);
+  });
+
+  it("does not overwrite a finding that already has a recommendationId", () => {
+    const finding = customFinding("Disk is unattached.", {
+      recommendationId: "custom.already-set",
+    });
+
+    expect(assignCustomFindingCodes([finding])).toEqual([finding]);
+  });
+});

--- a/packages/savemoney/src/azure/__tests__/finding-dedup.test.ts
+++ b/packages/savemoney/src/azure/__tests__/finding-dedup.test.ts
@@ -222,4 +222,29 @@ describe("foldDuplicateFinding", () => {
       ),
     ).toBe(false);
   });
+
+  // Custom analyzer sentences with a known template carry a stable
+  // recommendationId too (see finding-code.ts), so two custom findings for
+  // the same problem must collapse just like a custom/advisor pair does.
+  it("folds two custom findings sharing a stable recommendation id", () => {
+    const report = mkReport([
+      mkFinding({
+        code: "custom.disk.unattached",
+        recommendationId: "custom.disk.unattached",
+      }),
+    ]);
+
+    const folded = foldDuplicateFinding(
+      mkFinding({
+        code: "custom.disk.unattached",
+        recommendationId: "custom.disk.unattached",
+      }),
+      report,
+    );
+
+    expect(folded).toBe(true);
+    expect(report.findings).toHaveLength(1);
+    // Same-source fold: no corroboration note is appended.
+    expect(report.findings?.[0].reason).toBe("Disk is unattached.");
+  });
 });

--- a/packages/savemoney/src/azure/analyzer.ts
+++ b/packages/savemoney/src/azure/analyzer.ts
@@ -62,6 +62,7 @@ import {
   NO_ANALYZER_REASON,
   unpreferredLocationReason,
 } from "./finding-category.js";
+import { assignCustomFindingCodes } from "./finding-code.js";
 import { foldDuplicateFinding } from "./finding-dedup.js";
 import { PricingClient, PricingService } from "./pricing/index.js";
 import { matchesTags, type MetricsCache } from "./utils.js";
@@ -591,9 +592,8 @@ async function runPerResourceAnalysis(args: {
 
       if (analysis.suspectedUnused) {
         const reason = analysis.reason || "No specific findings.";
-        const report: AzureDetailedResourceReport = {
-          analysis: { ...analysis, reason },
-          findings: categorizeCustomFindings(
+        const findings = assignCustomFindingCodes(
+          categorizeCustomFindings(
             findingsFromAnalysisResult({
               reason,
               resourceId: resource.id ?? "",
@@ -601,8 +601,20 @@ async function runPerResourceAnalysis(args: {
               source: "custom",
             }),
           ),
+        );
+        const report: AzureDetailedResourceReport = {
+          analysis: { ...analysis, reason },
+          findings: [],
           resource,
         };
+        // Fold sentences that share a stable recommendationId so e.g. two
+        // "Very low CPU usage" hits on the same resource collapse into one
+        // row instead of appearing as separate findings.
+        for (const finding of findings) {
+          if (!foldDuplicateFinding(finding, report)) {
+            report.findings?.push(finding);
+          }
+        }
         reports.push(report);
         const idKey = (resource.id ?? "").toLowerCase();
         if (idKey) reportsById.set(idKey, report);

--- a/packages/savemoney/src/azure/finding-category.ts
+++ b/packages/savemoney/src/azure/finding-category.ts
@@ -9,14 +9,17 @@
  * missing tags or a failed detail lookup — statements that carry no billable
  * waste and would suggest a "saving" that does not exist.
  *
- * This module separates the two: governance / diagnostic sentences are reported
- * as `operationalExcellence`, leaving `cost` to mean "actual billable waste".
- * The distinction is also what makes cross-source deduplication safe (see
- * `finding-dedup.ts`): a resource flagged only for missing tags is not evidence
- * that it is wasted, so it must not absorb the corresponding AZQR orphan row.
+ * This module separates the two: governance / diagnostic sentences are
+ * reported as `operationalExcellence`, leaving `cost` to mean "actual billable
+ * waste". The distinction is also what makes cross-source deduplication safe
+ * (see `finding-dedup.ts`): a resource flagged only for missing tags is not
+ * evidence that it is wasted, so it must not absorb the corresponding AZQR
+ * orphan row.
  *
  * The generic reason strings are defined here and consumed by `analyzer.ts`, so
- * the classifier cannot drift from the text it has to recognise.
+ * the classifier cannot drift from the text it has to recognise. `finding-code.ts`
+ * reuses the same constants to assign a stable per-sentence `recommendationId`,
+ * so both classifiers stay in sync with the actual analyzer output.
  */
 
 import type { Finding, FindingCategory } from "../finding.js";
@@ -33,10 +36,10 @@ export const NO_ANALYZER_REASON =
  * an Azure detail lookup fails (e.g. "Could not retrieve detailed NIC
  * information."). They report a gap in the scan, not a cost opportunity.
  */
-const DETAIL_LOOKUP_FAILURE_PREFIX = "could not retrieve detailed";
+export const DETAIL_LOOKUP_FAILURE_PREFIX = "could not retrieve detailed";
 
 /** Prefix of the reason emitted when a resource sits outside the target region. */
-const UNPREFERRED_LOCATION_REASON = "Resource not in preferred location";
+export const UNPREFERRED_LOCATION_REASON = "Resource not in preferred location";
 
 /**
  * Re-categorises the findings produced from a custom analyzer's `reason`

--- a/packages/savemoney/src/azure/finding-code.ts
+++ b/packages/savemoney/src/azure/finding-code.ts
@@ -1,0 +1,148 @@
+/**
+ * Stable per-sentence identity for custom (live-scan) analyzer findings.
+ *
+ * `Finding.recommendationId` powers cross-source dedup, but custom analyzer
+ * sentences were deliberately excluded from it: every sentence produced by
+ * `findingsFromAnalysisResult` shared the generic `code: "custom.unknown"`
+ * and had no stable identifier, so two different sentences could never be
+ * told apart safely.
+ *
+ * This module closes that gap for the sentences whose wording is known ahead
+ * of time: each per-resource analyzer in `azure/resources/` builds its
+ * `reason` string from a fixed set of templates (e.g. "Disk is unattached.",
+ * "VM is deallocated."). This module recognises those templates by a
+ * case-insensitive prefix match on the (already sentence-split) `reason` and
+ * assigns both `code` and `recommendationId` to a stable `custom.<id>` value,
+ * following the same convention as `advisor.<recommendationTypeId>` /
+ * `azqr.<recommendationId>`. That is what lets `foldDuplicateFinding`
+ * (`finding-dedup.ts`) — whose matching is already identity-based and
+ * source-agnostic — collapse two custom findings that describe the same
+ * problem on the same resource.
+ *
+ * A handful of sentences are worded identically by more than one resource
+ * type (e.g. App Service Plan and Container App both emit "Very low CPU usage
+ * (…)."). Those intentionally share one generic code: dedup only ever
+ * compares findings within the same `resourceId`, and a resource can't be two
+ * types at once, so the shared code cannot cause a false merge across
+ * unrelated resources.
+ *
+ * Sentences that don't match any known template are left untouched — they
+ * keep `code: "custom.unknown"` and no `recommendationId`, exactly like
+ * before, so genuinely unrecognised text is never merged on a guess.
+ */
+
+import type { Finding } from "../finding.js";
+
+import {
+  DETAIL_LOOKUP_FAILURE_PREFIX,
+  MISSING_TAGS_REASON,
+  NO_ANALYZER_REASON,
+  UNPREFERRED_LOCATION_REASON,
+} from "./finding-category.js";
+
+/** Shared prefix for every stable custom finding id, mirroring `advisor.<id>` / `azqr.<id>`. */
+const CODE_PREFIX = "custom.";
+
+/**
+ * Ordered `(normalized reason prefix, code suffix)` pairs. Evaluated
+ * top-to-bottom; the first match wins. Prefixes are matched against the
+ * trimmed, lower-cased `reason`, so the dynamic suffixes analyzers append
+ * (percentages, byte counts, durations, …) never break the match.
+ */
+const REASON_CODES: readonly (readonly [string, string])[] = [
+  // Generic — emitted by (almost) every per-resource analyzer.
+  ["resource id is missing.", "missing-resource-id"],
+  [DETAIL_LOOKUP_FAILURE_PREFIX, "lookup-failed"],
+  [MISSING_TAGS_REASON.toLowerCase(), "missing-tags"],
+  [NO_ANALYZER_REASON.toLowerCase(), "no-analyzer"],
+  [UNPREFERRED_LOCATION_REASON.toLowerCase(), "unpreferred-location"],
+
+  // Managed Disk (azure/resources/disk.ts)
+  ["disk is unattached.", "disk.unattached"],
+
+  // Network Interface (azure/resources/nic.ts)
+  ["nic not attached to any vm or private endpoint.", "nic.unattached"],
+  ["no public ip assigned.", "nic.no-public-ip"],
+
+  // Private Endpoint (azure/resources/private-endpoint.ts)
+  [
+    "private endpoint has no private link service connections configured.",
+    "private-endpoint.no-connections",
+  ],
+  [
+    "private endpoint has rejected or disconnected connections.",
+    "private-endpoint.rejected-connection",
+  ],
+  [
+    "private endpoint has no network interfaces attached.",
+    "private-endpoint.no-nics",
+  ],
+  [
+    "private endpoint is not associated with a subnet.",
+    "private-endpoint.no-subnet",
+  ],
+
+  // Container App (azure/resources/container-app.ts)
+  ["container app is not running.", "container-app.not-running"],
+  ["container app has 0 replicas configured.", "container-app.zero-replicas"],
+
+  // App Service Plan (azure/resources/app-service.ts)
+  ["app service plan has no apps deployed.", "app-service.no-apps"],
+  [
+    "premium tier with low resource utilization.",
+    "app-service.premium-underutilized",
+  ],
+
+  // Public IP (azure/resources/public-ip.ts)
+  ["public ip not associated with any resource.", "public-ip.unassociated"],
+  ["static ip not in use.", "public-ip.static-unused"],
+
+  // Storage Account (azure/resources/storage.ts)
+  ["very low transaction count (", "storage.low-transactions"],
+
+  // Virtual Machine (azure/resources/vm.ts) — worded distinctly ("Low ...",
+  // no "Very") from the shared "Very low ..." family below.
+  ["vm is deallocated.", "vm.deallocated"],
+  ["vm is stopped.", "vm.stopped"],
+  ["low cpu usage (avg", "vm.low-cpu-usage"],
+  ["low network traffic (", "vm.low-network-traffic"],
+
+  // Static Web App (azure/resources/static-web-app.ts)
+  ["no traffic data available in", "static-site.no-traffic-data"],
+  ["very low site traffic (", "static-site.low-traffic"],
+  ["very low data transfer (", "static-site.low-data-transfer"],
+
+  // Shared across resource types whose analyzers phrase the same signal with
+  // identical text — see module doc. App Service Plan + Container App for
+  // CPU/memory; Container App + Public IP for network traffic.
+  ["very low cpu usage (", "low-cpu-usage"],
+  ["very low memory usage (", "low-memory-usage"],
+  ["very low network traffic (", "low-network-traffic"],
+];
+
+/**
+ * Assigns a stable `code`/`recommendationId` to every custom finding whose
+ * `reason` matches a known sentence template, so equivalent sentences about
+ * the same resource collapse via `foldDuplicateFinding` instead of appearing
+ * as separate rows.
+ *
+ * Leaves untouched: non-`"custom"` findings, and findings that already carry
+ * a `recommendationId` (nothing to add) or whose `reason` matches no known
+ * template (stays `"custom.unknown"`, ungrouped — the same fallback behaviour
+ * as before this module existed).
+ */
+export function assignCustomFindingCodes(findings: Finding[]): Finding[] {
+  return findings.map((finding) => {
+    if (finding.source !== "custom" || finding.recommendationId) {
+      return finding;
+    }
+    const code = stableCodeFor(finding.reason);
+    return code ? { ...finding, code, recommendationId: code } : finding;
+  });
+}
+
+function stableCodeFor(reason: string): string | undefined {
+  const normalized = reason.trim().toLowerCase();
+  const match = REASON_CODES.find(([prefix]) => normalized.startsWith(prefix));
+  return match ? `${CODE_PREFIX}${match[1]}` : undefined;
+}

--- a/packages/savemoney/src/azure/finding-dedup.ts
+++ b/packages/savemoney/src/azure/finding-dedup.ts
@@ -3,18 +3,24 @@
  *
  * SaveMoney observes the same subscription through three lenses: the custom
  * live-scan analyzers, Azure Advisor, and an optional AZQR report. They
- * overlap — an unattached disk is waste no matter who reports it — so without
- * deduplication the same resource could appear several times in the output,
- * once per source.
+ * overlap — an unattached disk is waste no matter who reports it — so the
+ * same resource could otherwise appear several times in the output, once per
+ * source. This also folds duplicate sentences emitted by the custom analyzers
+ * themselves (e.g. the same resource triggering the same "Very low CPU usage"
+ * template twice), since the matching below is source-agnostic.
  *
  * Findings are unified on the `resourceId + recommendationId` key. Sources
  * normalise `recommendationId` onto a shared vocabulary whenever one exists:
  * orphaned resources use {@link orphanRecommendationId} regardless of who
  * detected them, which is what lets an AZQR `AOR` row collapse onto the
- * Advisor or custom finding for the same resource. The surviving finding is the
- * one carrying the monetary estimate (only Advisor and the pricing-enriched
- * custom analyzers have one — AZQR reports no amounts at all), annotated with
- * the corroborating source so the extra provenance is not lost.
+ * Advisor or custom finding for the same resource. Custom analyzer sentences
+ * with a known template get a stable `custom.<id>` identity from
+ * `finding-code.ts`; sentences with no known template keep
+ * `code: "custom.unknown"` and no `recommendationId`, so they are never
+ * collapsed on guesswork. The surviving finding is the one carrying the
+ * monetary estimate (only Advisor and the pricing-enriched custom analyzers
+ * have one — AZQR reports no amounts at all), annotated with the
+ * corroborating source so the extra provenance is not lost.
  */
 
 import type { Finding, FindingSource } from "../finding.js";
@@ -113,9 +119,9 @@ function corroborationNote(
  *    problem — it exists — so the live finding, which can carry a monetary
  *    estimate, supersedes the static one.
  *
- * Findings without a `recommendationId` never match: sources that cannot
- * identify their recommendations (today the sentence-level custom findings)
- * must not be collapsed on guesswork.
+ * Findings without a `recommendationId` never match: sentences whose text
+ * matches no known template (still `code: "custom.unknown"`, see
+ * `finding-code.ts`) must not be collapsed on guesswork.
  */
 function findDuplicateFinding(
   incoming: Finding,


### PR DESCRIPTION
Extends the finding deduplication introduced for Advisor/AZQR/custom sources to also cover duplicate sentences produced by the custom (live-scan) analyzers themselves.

Previously, every sentence emitted by the per-resource analyzers (`disk.ts`, `vm.ts`, `container-app.ts`, etc.) shared the generic `code: "custom.unknown"` and had no `recommendationId`, so two custom findings describing the same problem on the same resource could never be collapsed — the existing dedup logic deliberately skips findings without a
`recommendationId` to avoid merging unrelated sentences on a guess.

Sentences that match a known template now get a stable, per-sentence `custom.<id>` identity (e.g. `custom.disk.unattached`, `custom.low-cpu-usage`), following the same `<source>.<id>` convention
already used by `advisor.<id>` and `azqr.<id>`. This lets the existing (already source-agnostic) fold logic collapse duplicate custom findings too, not just cross-source ones. Sentences with no known template are unaffected: they keep `code: "custom.unknown"` and no `recommendationId`, and are still never collapsed on guesswork.

Depends on #2026

Resolves: CES-2227