### PR TITLE
Publish self-hosted-runner image from release pipeline

### DIFF
--- a/.github/workflows/validate-v2.yaml
+++ b/.github/workflows/validate-v2.yaml
@@ -127,10 +127,6 @@ jobs:
       - name: Run code quality checks on affected projects
         run: pnpm validate
 
-      - name: Run Docker build on affected projects
-        if: ${{ github.event_name == 'pull_request' }}
-        run: pnpm nx affected -t docker:build --outputStyle=stream-without-prefixes
-
   get-environments:
     name: Get GitHub Environments for Infrastructure
     needs: gate

--- a/.github/workflows/validate-v2.yaml
+++ b/.github/workflows/validate-v2.yaml
@@ -127,6 +127,10 @@ jobs:
       - name: Run code quality checks on affected projects
         run: pnpm validate
 
+      - name: Run Docker build on affected projects
+        if: ${{ github.event_name == 'pull_request' }}
+        run: pnpm nx affected -t docker:build --outputStyle=stream-without-prefixes
+
   get-environments:
     name: Get GitHub Environments for Infrastructure
     needs: gate

--- a/.nx/version-plans/version-plan-1785847367728.md
+++ b/.nx/version-plans/version-plan-1785847367728.md
@@ -1,0 +1,5 @@
+---
+self-hosted-runner: patch
+---
+
+Mark self-hosted-runner as public to publish the Docker image in release pipeline.

--- a/containers/self-hosted-runner/project.json
+++ b/containers/self-hosted-runner/project.json
@@ -9,6 +9,7 @@
   },
   "$schema": "../../node_modules/nx/schemas/project-schema.json",
   "name": "self-hosted-runner",
+  "tags": ["container:public"],
   "release": {
     "version": {
       "currentVersionResolver": "disk",


### PR DESCRIPTION
Mark `self-hosted-runner` as a public project for release filtering and add a patch Version Plan.

Changes:
- Add `container:public` tag in `containers/self-hosted-runner/project.json`

Why:
- `nx-release` publish step filters projects through `isPublicProject`; without a `public`/`*:public` tag, `self-hosted-runner` is skipped even when present in Version Packages PR metadata.
- This PR ensures the next Version Packages flow includes the project in publish and pushes `ghcr.io/pagopa/dx-github-self-hosted-runner` tags.