### PR TITLE
Add OTEL_SERVICE_NAME environment variable

### DIFF
--- a/.nx/version-plans/version-plan-1785916632956.md
+++ b/.nx/version-plans/version-plan-1785916632956.md
@@ -1,0 +1,5 @@
+---
+azure_container_app: minor
+---
+
+Add OTEL_SERVICE_NAME environment variable to set the service name in Open Telemetry sessions

--- a/infra/modules/azure_container_app/container_app.tf
+++ b/infra/modules/azure_container_app/container_app.tf
@@ -1,5 +1,5 @@
 resource "azurerm_container_app" "this" {
-  name                         = provider::dx::resource_name(merge(var.environment, { resource_type = "container_app" }))
+  name                         = local.container_app_name
   container_app_environment_id = var.container_app_environment_id
   resource_group_name          = var.resource_group_name
   revision_mode                = local.revision_mode
@@ -103,7 +103,7 @@ resource "azurerm_container_app" "this" {
         memory = local.memory_size
 
         dynamic "env" {
-          for_each = container.value.app_settings
+          for_each = merge({ OTEL_SERVICE_NAME = local.container_app_name }, container.value.app_settings)
 
           content {
             name  = env.key

--- a/infra/modules/azure_container_app/locals.tf
+++ b/infra/modules/azure_container_app/locals.tf
@@ -1,4 +1,6 @@
 locals {
+  container_app_name = provider::dx::resource_name(merge(var.environment, { resource_type = "container_app" }))
+
   tags = merge(var.tags, { ModuleSource = "DX", ModuleVersion = try(jsondecode(file("${path.module}/package.json")).version, "unknown"), ModuleName = try(jsondecode(file("${path.module}/package.json")).name, "unknown") })
 
   use_cases = {

--- a/infra/modules/azure_container_app/tests/unit.tftest.hcl
+++ b/infra/modules/azure_container_app/tests/unit.tftest.hcl
@@ -522,8 +522,9 @@ run "container_app_app_settings" {
       {
         image = "nginx:latest"
         app_settings = {
-          "KEY_ONE" = "value_one"
-          "KEY_TWO" = "value_two"
+          "KEY_ONE"           = "value_one"
+          "KEY_TWO"           = "value_two"
+          "OTEL_SERVICE_NAME" = "caller-value"
         }
         liveness_probe = {
           path = "/"
@@ -536,15 +537,23 @@ run "container_app_app_settings" {
     condition = length([
       for env in azurerm_container_app.this.template[0].container[0].env :
       env if env.secret_name == null
-    ]) == 2
-    error_message = "Two non-secret environment variables must be created from app_settings"
+    ]) == 3
+    error_message = "Two app_settings variables and OTEL_SERVICE_NAME must be created"
   }
 
   assert {
     condition = alltrue([
       for env in azurerm_container_app.this.template[0].container[0].env :
-      contains(["KEY_ONE", "KEY_TWO"], env.name) if env.secret_name == null
+      contains(["KEY_ONE", "KEY_TWO", "OTEL_SERVICE_NAME"], env.name) if env.secret_name == null
     ])
     error_message = "Environment variable names must match app_settings keys"
+  }
+
+  assert {
+    condition = one([
+      for env in azurerm_container_app.this.template[0].container[0].env :
+      env.value if env.name == "OTEL_SERVICE_NAME"
+    ]) == "caller-value"
+    error_message = "A manually configured OTEL_SERVICE_NAME must override the Container App name"
   }
 }


### PR DESCRIPTION
Introduce the OTEL_SERVICE_NAME environment variable to configure the service name in Open Telemetry sessions. Update the container app settings to include this variable and adjust assertions to ensure its presence and correct value.

Close CES-2233