### PR TITLE
Fix module.register() deprecation warning in CLI

### DIFF
--- a/.nx/version-plans/version-plan-1785937676446.md
+++ b/.nx/version-plans/version-plan-1785937676446.md
@@ -1,0 +1,5 @@
+---
+'@pagopa/dx-cli': patch
+---
+
+Fix Node.js `module.register()` deprecation warning printed on every CLI invocation by using the synchronous `module.registerHooks()` API when the running Node.js version supports it, falling back to the previous behavior otherwise.

--- a/apps/cli/src/adapters/azure-monitor/import-in-the-middle-register-hooks.d.ts
+++ b/apps/cli/src/adapters/azure-monitor/import-in-the-middle-register-hooks.d.ts
@@ -1,16 +1,11 @@
 /**
  * Ambient module declaration for `import-in-the-middle/register-hooks.mjs`.
  *
- * The package ships `register-hooks.d.ts` (not `.d.mts`), which TypeScript's
- * `node16`/`nodenext` module resolution does not associate with the `.mjs`
- * implementation file, so the subpath import would otherwise be untyped.
+ * The package ships `register-hooks.d.ts`, not `.d.mts`, so TS's node16/nodenext
+ * resolution can't match it to the `.mjs` file. Re-exporting from the real
+ * declaration keeps this in sync with upstream instead of hand-copying types.
  */
-declare module "import-in-the-middle/register-hooks.mjs" {
-  export type RegisterHooksOptions = {
-    exclude?: (RegExp | string)[];
-    include?: (RegExp | string)[];
-  };
 
-  export function register(options?: RegisterHooksOptions): void;
-  export function supportsSyncHooks(): boolean;
+declare module "import-in-the-middle/register-hooks.mjs" {
+  export * from "import-in-the-middle/register-hooks.d.ts";
 }

--- a/apps/cli/src/adapters/azure-monitor/import-in-the-middle-register-hooks.d.ts
+++ b/apps/cli/src/adapters/azure-monitor/import-in-the-middle-register-hooks.d.ts
@@ -1,0 +1,16 @@
+/**
+ * Ambient module declaration for `import-in-the-middle/register-hooks.mjs`.
+ *
+ * The package ships `register-hooks.d.ts` (not `.d.mts`), which TypeScript's
+ * `node16`/`nodenext` module resolution does not associate with the `.mjs`
+ * implementation file, so the subpath import would otherwise be untyped.
+ */
+declare module "import-in-the-middle/register-hooks.mjs" {
+  export type RegisterHooksOptions = {
+    exclude?: (RegExp | string)[];
+    include?: (RegExp | string)[];
+  };
+
+  export function register(options?: RegisterHooksOptions): void;
+  export function supportsSyncHooks(): boolean;
+}

--- a/apps/cli/src/adapters/azure-monitor/instrumentation.ts
+++ b/apps/cli/src/adapters/azure-monitor/instrumentation.ts
@@ -23,15 +23,33 @@ import { UndiciInstrumentation } from "@opentelemetry/instrumentation-undici";
 // import-in-the-middle and module must be the first imports so that
 // createAddHookMessageChannel / register run as early as possible.
 import { createAddHookMessageChannel } from "import-in-the-middle";
+import {
+  register as registerSyncHooks,
+  supportsSyncHooks,
+} from "import-in-the-middle/register-hooks.mjs";
 import { register } from "module";
 import os from "node:os";
 
-const { registerOptions, waitForAllMessagesAcknowledged } =
-  createAddHookMessageChannel();
-
 // Register the ESM module hook so that subsequent dynamic imports are
 // intercepted by OpenTelemetry's module instrumentation.
-register("import-in-the-middle/hook.mjs", import.meta.url, registerOptions);
+//
+// Prefer the synchronous, non-deprecated `module.registerHooks()` path
+// (import-in-the-middle's register-hooks.mjs) when the running Node.js
+// correctly supports it. Otherwise fall back to the deprecated but broadly
+// compatible `module.register()` + message channel approach, since apps/cli's
+// declared `engines.node` (>=22.0.0) spans patch versions that predate the
+// Node fix `supportsSyncHooks()` checks for (nodejs/node#59929).
+let waitForAllMessagesAcknowledged: () => Promise<void> = () =>
+  Promise.resolve();
+
+if (supportsSyncHooks()) {
+  registerSyncHooks();
+} else {
+  const { registerOptions, waitForAllMessagesAcknowledged: wait } =
+    createAddHookMessageChannel();
+  register("import-in-the-middle/hook.mjs", import.meta.url, registerOptions);
+  waitForAllMessagesAcknowledged = wait;
+}
 
 // Set service name before useAzureMonitor() initialises the Resource so
 // that Azure Monitor picks it up as the cloud_RoleName.
@@ -89,7 +107,8 @@ export const enableAzureMonitor = (): void => {
   });
 };
 
-// Block module evaluation until the hook is fully acknowledged.
-// This ensures that when bin/index.js proceeds to import the CLI entry
-// module, all transitive imports go through the registered hook.
+// Block module evaluation until the hook is fully acknowledged (a no-op on
+// the synchronous path, which needs no acknowledgement). This ensures that
+// when bin/index.js proceeds to import the CLI entry module, all transitive
+// imports go through the registered hook.
 await waitForAllMessagesAcknowledged();


### PR DESCRIPTION
The `dx` CLI preload module (apps/cli/src/adapters/azure-monitor/instrumentation.ts) used `module.register()` from node:module to install the import-in-the-middle ESM hook before any HTTP client libraries are loaded. Since Node.js marked this API as deprecated (DEP0205), every CLI invocation printed:

```
  (node:XXXXX) [DEP0205] DeprecationWarning: `module.register()` is deprecated.
  Use `module.registerHooks()` instead.
```

import-in-the-middle@3.3.2 ships a synchronous alternative based on `module.registerHooks()` (register-hooks.mjs), which avoids the deprecated API and the message-channel round-trip entirely.
It's only supported on Node.js versions where a related core bug (nodejs/node#59929) is fixed: `>=22.22.3, >=24.11.1, >=25.1.0, >=26.0.0`.
Since apps/cli declares `engines.node: >=22.0.0`, a wider range, this change adds a dual path:

- Use the synchronous `registerHooks()` API when `supportsSyncHooks()` reports the running Node.js correctly supports it.
- Otherwise fall back to the existing `module.register()` + `createAddHookMessageChannel`/`waitForAllMessagesAcknowledged` approach, so older supported Node.js versions keep working exactly as before (with the same deprecation warning, since Node itself hasn't removed the old API).

Also adds an ambient module declaration for `import-in-the-middle/register-hooks.mjs`, since the package ships
`register-hooks.d.ts` rather than `register-hooks.d.mts`, which TypeScript's `node16`/`nodenext` module resolution doesn't associate with the `.mjs` file.

Verified manually on Node.js 26 (sync path, no warning) and by temporarily forcing the fallback branch (old behavior, warning still present as expected on unsupported Node versions).

Resolves: CES-2232