### PR TITLE
Deactivate GitHub deployment in validate workflow

### DIFF
--- a/.github/workflows/validate-v2.yaml
+++ b/.github/workflows/validate-v2.yaml
@@ -172,7 +172,9 @@ jobs:
     needs: get-environments
     if: ${{ needs.get-environments.outputs.environments != '[]' }}
     runs-on: ["self-hosted", "${{ matrix.target.env-name }}"]
-    environment: ${{ matrix.target.github-environment }}
+    environment:
+      name: ${{ matrix.target.github-environment }}
+      deployment: false
     strategy:
       fail-fast: false
       matrix:


### PR DESCRIPTION
Deactivate GitHub deployment in validate v2 workflow to remove noise from activity logs.

Close CES-2234