### PR TITLE
Deactivate GitHub deployments in CI workflows

### DIFF
--- a/.github/workflows/_release-bash-docusaurus-docs-website-azure.yaml
+++ b/.github/workflows/_release-bash-docusaurus-docs-website-azure.yaml
@@ -33,7 +33,9 @@ jobs:
   feed_docs_knowledge_base:
     if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/docs@')
     name: Update MCP Server Knowledge Base
-    environment: app-prod-ci
+    environment:
+      name: app-prod-ci
+      deployment: false
     needs: deploy_to_static_web_app
     runs-on: ubuntu-latest
     permissions:

--- a/.github/workflows/_validate-terraform-test-modules.yaml
+++ b/.github/workflows/_validate-terraform-test-modules.yaml
@@ -50,7 +50,9 @@ jobs:
   terraform-test:
     runs-on: ubuntu-latest
     needs: detect-modules
-    environment: infra-dev-ci
+    environment:
+      name: infra-dev-ci
+      deployment: false
     permissions:
       id-token: write
       contents: read

--- a/.github/workflows/infra_apply.yaml
+++ b/.github/workflows/infra_apply.yaml
@@ -161,7 +161,9 @@ jobs:
       'ubuntu-latest' }}
     needs: [get-terraform-version, tf-modules-check, detect-projects]
     if: ${{ needs.detect-projects.outputs.matrix != '[]' }}
-    environment: ${{ inputs.override_github_environment == '' && inputs.environment || inputs.override_github_environment}}-ci
+    environment:
+      name: ${{ inputs.override_github_environment == '' && inputs.environment || inputs.override_github_environment}}-ci
+      deployment: false
     permissions:
       id-token: write
       contents: read

--- a/.github/workflows/infra_drift_detection.yml
+++ b/.github/workflows/infra_drift_detection.yml
@@ -49,7 +49,9 @@ jobs:
   terraform_driftdetection_job:
     name: Terraform Drift Detection
     runs-on: ${{ inputs.use_labels && inputs.use_private_agent && (inputs.override_labels != '' && inputs.override_labels || inputs.environment) || inputs.use_private_agent && 'self-hosted' || 'ubuntu-latest' }}
-    environment: ${{ inputs.override_github_environment == '' && inputs.environment || inputs.override_github_environment}}-ci
+    environment:
+      name: ${{ inputs.override_github_environment == '' && inputs.environment || inputs.override_github_environment}}-ci
+      deployment: false
     concurrency:
       group: ${{ github.workflow }}-${{ inputs.environment }}-ci
       cancel-in-progress: true

--- a/.github/workflows/infra_plan.yaml
+++ b/.github/workflows/infra_plan.yaml
@@ -184,7 +184,9 @@ jobs:
       (inputs.override_labels != '' && inputs.override_labels ||
       inputs.environment) || inputs.use_private_agent && 'self-hosted' ||
       'ubuntu-latest' }}
-    environment: ${{ inputs.override_github_environment == '' && inputs.environment || inputs.override_github_environment}}-ci
+    environment:
+      name: ${{ inputs.override_github_environment == '' && inputs.environment || inputs.override_github_environment}}-ci
+      deployment: false
     concurrency:
       group: ${{ github.workflow }}-${{ inputs.environment }}-${{ matrix.dir }}-ci
       cancel-in-progress: false

--- a/.github/workflows/opex-dashboard-deploy.yaml
+++ b/.github/workflows/opex-dashboard-deploy.yaml
@@ -75,7 +75,9 @@ jobs:
     needs: generate
     if: needs.generate.outputs.has_changes == 'true'
     runs-on: "ubuntu-latest"
-    environment: opex-${{ matrix.dashboard.environment }}-ci
+    environment:
+      name: opex-${{ matrix.dashboard.environment }}-ci
+      deployment: false
     permissions:
       id-token: write
       contents: read

--- a/.github/workflows/release-azure-appsvc-v1.yaml
+++ b/.github/workflows/release-azure-appsvc-v1.yaml
@@ -124,7 +124,9 @@ jobs:
     name: Validate Web App
     runs-on: ${{ inputs.use_labels && inputs.use_private_agent && (inputs.override_labels != '' && inputs.override_labels || inputs.environment) || inputs.use_private_agent && 'self-hosted' || 'ubuntu-latest' }}
     if: ${{ !github.event.act }}
-    environment: ${{ inputs.environment }}-ci
+    environment:
+      name: ${{ inputs.environment }}-ci
+      deployment: false
 
     permissions:
       id-token: write

--- a/.github/workflows/release-terraform-legacy-v1.yaml
+++ b/.github/workflows/release-terraform-legacy-v1.yaml
@@ -87,7 +87,9 @@ jobs:
     # Default to 'self-hosted' if inputs.use_private_agent is true, or 'ubuntu-latest' otherwise.
     runs-on: ${{ inputs.use_labels && inputs.use_private_agent && (inputs.override_labels != '' && inputs.override_labels || inputs.environment) || inputs.use_private_agent && 'self-hosted' || 'ubuntu-latest' }}
     needs: [get-terraform-version, tf-modules-check]
-    environment: ${{ inputs.environment }}-ci
+    environment:
+      name: ${{ inputs.environment }}-ci
+      deployment: false
     permissions:
       id-token: write
       contents: read


### PR DESCRIPTION
Removes GitHub deployment tracking from CI-only workflow jobs so validation and plan runs no longer generate deployment noise in GitHub.

- Switched CI environment declarations to the `environment.name` form with `deployment: false`.
- Applied the same pattern across validate, Terraform plan/drift, release validation, and related CI workflows.

Close CES-2235 