### PR TITLE
Move integration and e2e tf tests to Nx Terraform Plugin

### DIFF
--- a/.github/skills/terraform-tests/SKILL.md
+++ b/.github/skills/terraform-tests/SKILL.md
@@ -53,10 +53,9 @@ tests/
 Tests are run using NX commands:
 
 ```bash
-nx run <module-name>:test:unit
-nx run <module-name>:test:contract
-nx run <module-name>:test:integration
-nx run <module-name>:test:e2e
+nx run <module-name>:tf-test
+nx run <module-name>:tf-test:integration
+nx run <module-name>:tf-test:e2e
 ```
 
 **Important**: After modifying unit and contract tests, **always execute them** to verify they pass. Integration and E2E tests are slow and should not be run during development, only in CI/CD.

--- a/.github/skills/terraform-tests/templates/test-readme.md
+++ b/.github/skills/terraform-tests/templates/test-readme.md
@@ -8,19 +8,19 @@ This directory contains comprehensive tests for the `<module_name>` Terraform mo
 
 Fast, mocked tests that verify module logic without provisioning infrastructure.
 
-Run: `nx run <module-name>:test:unit`
+Run: `nx run <module-name>:tf-test`
 
 ### Contract Tests (contract.tftest.hcl)
 
 Validate input contracts, constraints, and expected failures.
 
-Run: `nx run <module-name>:test:contract`
+Run: `nx run <module-name>:tf-test`
 
 ### Integration Tests (integration.tftest.hcl)
 
 Provision real Azure resources to test module behavior in isolation.
 
-Run: `nx run <module-name>:test:integration`
+Run: `nx run <module-name>:tf-test:integration`
 
 **Note**: Integration tests provision real Azure resources and may incur costs.
 
@@ -28,7 +28,7 @@ Run: `nx run <module-name>:test:integration`
 
 Deploy complete scenarios with workloads to verify end-to-end functionality.
 
-Run: `nx run <module-name>:test:e2e`
+Run: `nx run <module-name>:tf-test:e2e`
 
 **Note**: E2E tests deploy full infrastructure and workloads, taking longer to complete.
 

--- a/.github/workflows/_cron-terraform-e2e-tests.yaml
+++ b/.github/workflows/_cron-terraform-e2e-tests.yaml
@@ -88,7 +88,8 @@ jobs:
           GOFLAGS: "-p=1"
         run: |
           pnpm nx run-many \
-            --target test:e2e \
+            --target tf-test \
+            --configuration e2e \
             --parallel=1
 
       - name: Notify Slack on failure

--- a/.github/workflows/_cron-terraform-integration-tests.yaml
+++ b/.github/workflows/_cron-terraform-integration-tests.yaml
@@ -71,7 +71,7 @@ jobs:
       - name: Run Terraform Integration Tests
         timeout-minutes: 120
         run: |
-          npx nx run-many --target test:integration
+          npx nx run-many --target tf-test --configuration integration
 
       - name: Notify Slack on failure
         if: failure() && github.event_name == 'schedule'

--- a/.nx/version-plans/version-plan-1786089877538.md
+++ b/.nx/version-plans/version-plan-1786089877538.md
@@ -1,0 +1,5 @@
+---
+'@pagopa/nx-terraform-plugin': patch
+---
+
+Move Terraform integration and e2e tests to dedicated Nx target configurations.

--- a/go.work.sum
+++ b/go.work.sum
@@ -541,6 +541,7 @@ github.com/GoogleCloudPlatform/opentelemetry-operations-go/detectors/gcp v1.26.0
 github.com/GoogleCloudPlatform/opentelemetry-operations-go/detectors/gcp v1.26.0/go.mod h1:2bIszWvQRlJVmJLiuLhukLImRjKPcYdzzsx6darK02A=
 github.com/GoogleCloudPlatform/opentelemetry-operations-go/detectors/gcp v1.30.0/go.mod h1:P4WPRUkOhJC13W//jWpyfJNDAIpvRbAUIYLX/4jtlE0=
 github.com/GoogleCloudPlatform/opentelemetry-operations-go/detectors/gcp v1.31.0/go.mod h1:P4WPRUkOhJC13W//jWpyfJNDAIpvRbAUIYLX/4jtlE0=
+github.com/GoogleCloudPlatform/opentelemetry-operations-go/detectors/gcp v1.32.0/go.mod h1:RD2SsorTmYhF6HkTmDw7KmPYQk8OBYwTkuasChwv7R4=
 github.com/GoogleCloudPlatform/opentelemetry-operations-go/exporter/metric v0.48.1 h1:UQ0AhxogsIRZDkElkblfnwjc3IaltCm2HUMvezQaL7s=
 github.com/GoogleCloudPlatform/opentelemetry-operations-go/exporter/metric v0.48.1/go.mod h1:jyqM3eLpJ3IbIFDTKVz2rF9T/xWGW0rIriGwnz8l9Tk=
 github.com/GoogleCloudPlatform/opentelemetry-operations-go/internal/cloudmock v0.48.1 h1:oTX4vsorBZo/Zdum6OKPA4o7544hm6smoRv1QjpTwGo=
@@ -1174,6 +1175,7 @@ go.opentelemetry.io/contrib/detectors/gcp v1.34.0 h1:JRxssobiPg23otYU5SbWtQC//sn
 go.opentelemetry.io/contrib/detectors/gcp v1.34.0/go.mod h1:cV4BMFcscUR/ckqLkbfQmF0PRsq8w/lMGzdbCSveBHo=
 go.opentelemetry.io/contrib/detectors/gcp v1.39.0/go.mod h1:t/OGqzHBa5v6RHZwrDBJ2OirWc+4q/w2fTbLZwAKjTk=
 go.opentelemetry.io/contrib/detectors/gcp v1.42.0/go.mod h1:W9zQ439utxymRrXsUOzZbFX4JhLxXU4+ZnCt8GG7yA8=
+go.opentelemetry.io/contrib/detectors/gcp v1.43.0/go.mod h1:RyaZMFY7yi1kAs45S6mbFGz8O8rqB0dTY14uzvG4LCs=
 go.opentelemetry.io/contrib/instrumentation/google.golang.org/grpc/otelgrpc v0.49.0/go.mod h1:Mjt1i1INqiaoZOMGR1RIUJN+i3ChKoFRqzrRQhlkbs0=
 go.opentelemetry.io/contrib/instrumentation/google.golang.org/grpc/otelgrpc v0.54.0 h1:r6I7RJCN86bpD/FQwedZ0vSixDpwuWREjW9oRMsmqDc=
 go.opentelemetry.io/contrib/instrumentation/google.golang.org/grpc/otelgrpc v0.54.0/go.mod h1:B9yO6b04uB80CzjedvewuqDhxJxi11s7/GtiGa8bAjI=
@@ -1370,6 +1372,7 @@ golang.org/x/net v0.48.0/go.mod h1:+ndRgGjkh8FGtu1w1FGbEC31if4VrNVMuKTgcAAnQRY=
 golang.org/x/net v0.49.0/go.mod h1:/ysNB2EvaqvesRkuLAyjI1ycPZlQHM3q01F02UY/MV8=
 golang.org/x/net v0.51.0/go.mod h1:aamm+2QF5ogm02fjy5Bb7CQ0WMt1/WVM7FtyaTLlA9Y=
 golang.org/x/net v0.52.0/go.mod h1:R1MAz7uMZxVMualyPXb+VaqGSa3LIaUqk0eEt3w36Sw=
+golang.org/x/net v0.53.0/go.mod h1:JvMuJH7rrdiCfbeHoo3fCQU24Lf5JJwT9W3sJFulfgs=
 golang.org/x/net v0.54.0/go.mod h1:Sj4oj8jK6XmHpBZU/zWHw3BV3abl4Kvi+Ut7cQcY+cQ=
 golang.org/x/oauth2 v0.0.0-20180821212333-d2e6202438be/go.mod h1:N/0e6XlmueqKjAGxoOufVs8QHGRruUQn6yWY3a++T0U=
 golang.org/x/oauth2 v0.0.0-20190226205417-e64efc72b421/go.mod h1:gOpvHmFTYa4IltrdGE7lF6nIHvwfUNPOp7c8zoXwtLw=
@@ -1846,6 +1849,7 @@ google.golang.org/genproto/googleapis/api v0.0.0-20250804133106-a7a43d27e69b/go.
 google.golang.org/genproto/googleapis/api v0.0.0-20251029180050-ab9386a59fda/go.mod h1:fDMmzKV90WSg1NbozdqrE64fkuTv6mlq2zxo9ad+3yo=
 google.golang.org/genproto/googleapis/api v0.0.0-20251202230838-ff82c1b0f217/go.mod h1:+rXWjjaukWZun3mLfjmVnQi18E1AsFbDN9QdJ5YXLto=
 google.golang.org/genproto/googleapis/api v0.0.0-20260226221140-a57be14db171/go.mod h1:M5krXqk4GhBKvB596udGL3UyjL4I1+cTbK0orROM9ng=
+google.golang.org/genproto/googleapis/api v0.0.0-20260414002931-afd174a4e478/go.mod h1:C6ADNqOxbgdUUeRTU+LCHDPB9ttAMCTff6auwCVa4uc=
 google.golang.org/genproto/googleapis/bytestream v0.0.0-20241104194629-dd2ea8efbc28 h1:Gmri4d/ZvKxZsbeZ/JvBHhAIRWXYwhvPyuS+LDQbnZk=
 google.golang.org/genproto/googleapis/bytestream v0.0.0-20241104194629-dd2ea8efbc28/go.mod h1:T8O3fECQbif8cez15vxAcjbwXxvL2xbnvbQ7ZfiMAMs=
 google.golang.org/genproto/googleapis/rpc v0.0.0-20231016165738-49dd2c1f3d0b/go.mod h1:swOH3j0KzcDDgGUWr+SNpyTen5YrXjS3eyPzFYKc6lc=
@@ -1867,6 +1871,8 @@ google.golang.org/genproto/googleapis/rpc v0.0.0-20251124214823-79d6a2a48846/go.
 google.golang.org/genproto/googleapis/rpc v0.0.0-20251202230838-ff82c1b0f217/go.mod h1:7i2o+ce6H/6BluujYR+kqX3GKH+dChPTQU19wjRPiGk=
 google.golang.org/genproto/googleapis/rpc v0.0.0-20260217215200-42d3e9bedb6d/go.mod h1:4Hqkh8ycfw05ld/3BWL7rJOSfebL2Q+DVDeRgYgxUU8=
 google.golang.org/genproto/googleapis/rpc v0.0.0-20260226221140-a57be14db171/go.mod h1:4Hqkh8ycfw05ld/3BWL7rJOSfebL2Q+DVDeRgYgxUU8=
+google.golang.org/genproto/googleapis/rpc v0.0.0-20260406210006-6f92a3bedf2d/go.mod h1:4Hqkh8ycfw05ld/3BWL7rJOSfebL2Q+DVDeRgYgxUU8=
+google.golang.org/genproto/googleapis/rpc v0.0.0-20260414002931-afd174a4e478/go.mod h1:4Hqkh8ycfw05ld/3BWL7rJOSfebL2Q+DVDeRgYgxUU8=
 google.golang.org/grpc v1.19.0/go.mod h1:mqu4LbDTu4XGKhr4mRzUsmM4RtVoemTSY81AxZiDr8c=
 google.golang.org/grpc v1.20.1/go.mod h1:10oTOabMzJvdu6/UiuZezV6QK5dSlG84ov/aaiqXj38=
 google.golang.org/grpc v1.21.1/go.mod h1:oYelfM1adQP15Ek0mdvEgi9Df8B9CZIaU1084ijfRaM=

--- a/infra/modules/azure_app_configuration/package.json
+++ b/infra/modules/azure_app_configuration/package.json
@@ -3,12 +3,5 @@
   "version": "1.0.0",
   "private": true,
   "provider": "azurerm",
-  "description": "Privisions App Configuration instance with private connection and IAM access mode",
-  "scripts": {
-    "tf-init": "terraform init",
-    "test:unit": "terraform test -filter='tests/unit.tftest.hcl'",
-    "test:contract": "terraform test -filter='tests/contract.tftest.hcl'",
-    "test:integration": "terraform test -filter='tests/integration.tftest.hcl'",
-    "test:e2e": "go test -v -timeout 1h ./tests"
-  }
+  "description": "Privisions App Configuration instance with private connection and IAM access mode"
 }

--- a/infra/modules/azure_cdn/package.json
+++ b/infra/modules/azure_cdn/package.json
@@ -3,12 +3,5 @@
   "version": "1.0.0",
   "private": true,
   "provider": "azurerm",
-  "description": "Allows to easily create an Azure FrontDoor CDN",
-  "scripts": {
-    "tf-init": "terraform init",
-    "test:unit": "terraform test -filter='tests/unit.tftest.hcl'",
-    "test:contract": "terraform test -filter='tests/contract.tftest.hcl'",
-    "test:integration": "terraform test -filter='tests/integration.tftest.hcl'",
-    "test:e2e": "go test -v -timeout 1h ./tests"
-  }
+  "description": "Allows to easily create an Azure FrontDoor CDN"
 }

--- a/infra/modules/azure_container_app/package.json
+++ b/infra/modules/azure_container_app/package.json
@@ -3,11 +3,5 @@
   "version": "6.0.1",
   "private": true,
   "provider": "azurerm",
-  "description": "Provisions an Azure Container App with a given configuration",
-  "scripts": {
-    "tf-init": "terraform init",
-    "test:unit": "terraform test -filter='tests/unit.tftest.hcl'",
-    "test:contract": "terraform test -filter='tests/contract.tftest.hcl'",
-    "test:integration": "terraform test -filter='tests/integration.tftest.hcl'"
-  }
+  "description": "Provisions an Azure Container App with a given configuration"
 }

--- a/infra/modules/azure_container_app_environment/package.json
+++ b/infra/modules/azure_container_app_environment/package.json
@@ -3,11 +3,5 @@
   "version": "3.0.0",
   "private": true,
   "provider": "azurerm",
-  "description": "Provisions an Azure Container App Environment with a given configuration",
-  "scripts": {
-    "tf-init": "terraform init",
-    "test:unit": "terraform test -filter='tests/unit.tftest.hcl'",
-    "test:contract": "terraform test -filter='tests/contract.tftest.hcl'",
-    "test:integration": "terraform test -filter='tests/integration.tftest.hcl'"
-  }
+  "description": "Provisions an Azure Container App Environment with a given configuration"
 }

--- a/infra/modules/azure_container_app_environment/tests/README.md
+++ b/infra/modules/azure_container_app_environment/tests/README.md
@@ -8,19 +8,19 @@ This directory contains comprehensive tests for the `azure_container_app_environ
 
 Fast, mocked tests that verify module logic without provisioning infrastructure.
 
-Run: `nx run azure_container_app_environment:test:unit`
+Run: `nx run azure_container_app_environment:tf-test`
 
 ### Contract Tests (contract.tftest.hcl)
 
 Validate input contracts, type constraints, and expected failures.
 
-Run: `nx run azure_container_app_environment:test:contract`
+Run: `nx run azure_container_app_environment:tf-test`
 
 ### Integration Tests (integration.tftest.hcl)
 
 Provision real Azure resources to test module behavior in isolation.
 
-Run: `nx run azure_container_app_environment:test:integration`
+Run: `nx run azure_container_app_environment:tf-test:integration`
 
 **Note**: Integration tests provision real Azure resources and may incur costs.
 

--- a/infra/modules/azure_cosmos_account/package.json
+++ b/infra/modules/azure_cosmos_account/package.json
@@ -3,12 +3,5 @@
   "version": "1.0.0",
   "private": true,
   "provider": "azurerm",
-  "description": "Provisions an Azure Cosmos DB account with monitoring and network settings",
-  "scripts": {
-    "tf-init": "terraform init",
-    "test:unit": "terraform test -filter='tests/unit.tftest.hcl'",
-    "test:contract": "terraform test -filter='tests/contract.tftest.hcl'",
-    "test:integration": "terraform test -filter='tests/integration.tftest.hcl'",
-    "test:e2e": "go test -v -timeout 1h ./tests"
-  }
+  "description": "Provisions an Azure Cosmos DB account with monitoring and network settings"
 }

--- a/infra/modules/azure_github_environment_bootstrap/package.json
+++ b/infra/modules/azure_github_environment_bootstrap/package.json
@@ -3,10 +3,5 @@
   "version": "5.0.1",
   "private": true,
   "provider": "azurerm",
-  "description": "Sets up monorepo's settings and required Azure permissions and roles",
-  "scripts": {
-    "tf-init": "terraform init",
-    "test:unit": "terraform test -filter='tests/unit.tftest.hcl'",
-    "test:contract": "terraform test -filter='tests/contract.tftest.hcl'"
-  }
+  "description": "Sets up monorepo's settings and required Azure permissions and roles"
 }

--- a/infra/modules/azure_managed_redis/README.md
+++ b/infra/modules/azure_managed_redis/README.md
@@ -136,8 +136,7 @@ These features are intentionally left out of v0.x to keep the surface small. The
 ## Testing
 
 ```bash
-pnpm nx run azure_managed_redis:test:unit
-pnpm nx run azure_managed_redis:test:contract
+pnpm nx run azure_managed_redis:tf-test
 ```
 
 Integration and end-to-end test layers are tracked as follow-ups under [CES-1909](https://pagopa.atlassian.net/browse/CES-1909).

--- a/infra/modules/azure_managed_redis/package.json
+++ b/infra/modules/azure_managed_redis/package.json
@@ -3,10 +3,5 @@
   "version": "1.0.0",
   "private": true,
   "provider": "azurerm",
-  "description": "Provisions Azure Managed Redis with DX-oriented defaults, networking, and observability",
-  "scripts": {
-    "tf-init": "terraform init",
-    "test:unit": "terraform test -filter='tests/unit.tftest.hcl'",
-    "test:contract": "terraform test -filter='tests/contract.tftest.hcl'"
-  }
+  "description": "Provisions Azure Managed Redis with DX-oriented defaults, networking, and observability"
 }

--- a/infra/modules/azure_managed_redis/tests/README.md
+++ b/infra/modules/azure_managed_redis/tests/README.md
@@ -18,8 +18,7 @@ terraform test -filter=tests/unit.tftest.hcl
 terraform test -filter=tests/contract.tftest.hcl
 
 # Or via Nx
-pnpm nx run azure_managed_redis:test:unit
-pnpm nx run azure_managed_redis:test:contract
+pnpm nx run azure_managed_redis:tf-test
 ```
 
 ## Mock data

--- a/infra/modules/azure_merge_roles/package.json
+++ b/infra/modules/azure_merge_roles/package.json
@@ -3,11 +3,5 @@
   "version": "1.0.0",
   "private": true,
   "provider": "azurerm",
-  "description": "Easily merge multiple RBAC built-in roles into a single custom role to save on the number of the required role assignments",
-  "scripts": {
-    "tf-init": "terraform init",
-    "test:unit": "terraform test -filter='tests/unit.tftest.hcl'",
-    "test:contract": "terraform test -filter='tests/contract.tftest.hcl'",
-    "test:e2e": "cd tests && GOWORK=off go test -v -timeout 1h ./..."
-  }
+  "description": "Easily merge multiple RBAC built-in roles into a single custom role to save on the number of the required role assignments"
 }

--- a/infra/modules/azure_merge_roles/tests/README.md
+++ b/infra/modules/azure_merge_roles/tests/README.md
@@ -12,17 +12,15 @@ From the module directory:
 
 ```bash
 pnpm run tf-init
-pnpm run test:unit
-pnpm run test:contract
-pnpm run test:e2e
+nx tf-test
+nx tf-test -c e2e
 ```
 
 From the workspace root:
 
 ```bash
-pnpm nx run azure_merge_roles:test:unit
-pnpm nx run azure_merge_roles:test:contract
-pnpm nx run azure_merge_roles:test:e2e
+nx run azure_merge_roles:tf-test
+nx run azure_merge_roles:tf-test:e2e
 ```
 
 ## Notes

--- a/infra/modules/azure_storage_account/package.json
+++ b/infra/modules/azure_storage_account/package.json
@@ -3,11 +3,5 @@
   "version": "3.0.0",
   "private": true,
   "provider": "azurerm",
-  "description": "Provisions an Azure Storage Account with networking, monitoring, and security configurations",
-  "scripts": {
-    "tf-init": "terraform init",
-    "test:unit": "terraform test -filter='tests/unit.tftest.hcl'",
-    "test:contract": "terraform test -filter='tests/contract.tftest.hcl'",
-    "test:integration": "terraform test -filter='tests/integration.tftest.hcl'"
-  }
+  "description": "Provisions an Azure Storage Account with networking, monitoring, and security configurations"
 }

--- a/infra/modules/github_environment_bootstrap/package.json
+++ b/infra/modules/github_environment_bootstrap/package.json
@@ -3,10 +3,5 @@
   "version": "2.0.0",
   "private": true,
   "provider": "github",
-  "description": "Create and configure a new GitHub repository",
-  "scripts": {
-    "tf-init": "terraform init",
-    "test:unit": "terraform test -filter='tests/unit.tftest.hcl'",
-    "test:contract": "terraform test -filter='tests/contract.tftest.hcl'"
-  }
+  "description": "Create and configure a new GitHub repository"
 }

--- a/infra/modules/github_selfhosted_runner_on_container_app_jobs/package.json
+++ b/infra/modules/github_selfhosted_runner_on_container_app_jobs/package.json
@@ -3,12 +3,5 @@
   "version": "2.0.0",
   "private": true,
   "provider": "azurerm",
-  "description": "Deploys GitHub self-hosted runners using Azure Container Apps jobs for scalable CI/CD workflows",
-  "scripts": {
-    "tf-init": "terraform init",
-    "test:unit": "terraform test -filter='tests/unit.tftest.hcl'",
-    "test:contract": "terraform test -filter='tests/contract.tftest.hcl'",
-    "test:integration": "terraform test -filter='tests/integration.tftest.hcl'",
-    "test:e2e": "go test -v -timeout 1h ./tests"
-  }
+  "description": "Deploys GitHub self-hosted runners using Azure Container Apps jobs for scalable CI/CD workflows"
 }

--- a/nx.json
+++ b/nx.json
@@ -31,36 +31,6 @@
         }
       }
     ],
-    "tf-init": {
-      "inputs": ["{projectRoot}/**/*.tf"]
-    },
-    "test:unit": {
-      "dependsOn": ["tf-init"],
-      "inputs": ["{projectRoot}/**/*.tf", "{projectRoot}/**/unit.tftest.hcl"]
-    },
-    "test:contract": {
-      "dependsOn": ["tf-init"],
-      "inputs": [
-        "{projectRoot}/**/*.tf",
-        "{projectRoot}/**/contract.tftest.hcl"
-      ]
-    },
-    "test:integration": {
-      "dependsOn": ["tf-init"],
-      "inputs": [
-        "{projectRoot}/**/*.tf",
-        "{projectRoot}/**/integration.tftest.hcl"
-      ]
-    },
-    "test:e2e": {
-      "dependsOn": ["tf-init"],
-      "inputs": [
-        "{projectRoot}/**/*.tf",
-        "{projectRoot}/**/*.go",
-        "{projectRoot}/**/*.mod",
-        "{projectRoot}/**/Dockerfile"
-      ]
-    },
     "version": {}
   },
   "release": {

--- a/packages/nx-terraform-plugin/README.md
+++ b/packages/nx-terraform-plugin/README.md
@@ -1,0 +1,29 @@
+# Nx Terraform Plugin
+
+`@pagopa/nx-terraform-plugin` is an Nx plugin that discovers Terraform
+configurations and infers targets for formatting, testing, validation, planning,
+applying, documentation, and module publishing.
+
+## Terraform Test Conventions
+
+The inferred `test` target separates Terraform tests into layers by using
+fixed file names under each project's `tests` directory.
+
+| Test layer  | Expected files                      | Nx command                             |
+| ----------- | ----------------------------------- | -------------------------------------- |
+| Unit        | `tests/unit.tftest.hcl`             | `nx run <project>:tf-test`             |
+| Contract    | `tests/contract.tftest.hcl`         | `nx run <project>:tf-test`             |
+| Integration | `tests/integration.tftest.hcl`      | `nx run <project>:tf-test:integration` |
+| End-to-end  | Go test files matching `tests/*.go` | `nx run <project>:tf-test:e2e`         |
+
+The default target runs the unit and contract files together. The `integration`
+configuration runs only `integration.tftest.hcl`, while the `e2e`
+configuration runs `go test` when the `tests` directory contains Go test
+files.
+
+Integration and end-to-end tests can share Terraform setup files from
+`tests/setup/*.tf`. These files are included in the corresponding Nx cache
+inputs.
+
+All inferred test configurations depend on the plugin's Terraform initialization
+target, which is `init` by default.

--- a/packages/nx-terraform-plugin/dist/index.js
+++ b/packages/nx-terraform-plugin/dist/index.js
@@ -101,6 +101,27 @@ const getPublishTarget = (opts, root, publishManifest) => {
 		throw error;
 	}
 };
+const getTestTarget = (initTargetName) => ({
+	cache: true,
+	command: `terraform test`,
+	configurations: {
+		e2e: {
+			args: [],
+			command: `if ls tests/*.go >/dev/null 2>&1; then go test -v -timeout 1h ./tests; fi`,
+			inputs: ["default", "e2eTests"]
+		},
+		integration: {
+			args: ["-filter='tests/integration.tftest.hcl'"],
+			inputs: ["default", "integrationTests"]
+		}
+	},
+	dependsOn: [initTargetName],
+	inputs: ["default", "tests"],
+	options: {
+		args: ["-filter='tests/unit.tftest.hcl'", "-filter='tests/contract.tftest.hcl'"],
+		cwd: "{projectRoot}"
+	}
+});
 const getTargets = (opts, root, projectType, hasRootTflintConfig, publishManifest) => {
 	const rootTflintConfigPath = getRootConfigPath(root, ".tflint.hcl");
 	const formatArgs = ["-list=true", "-recursive=true"];
@@ -108,7 +129,9 @@ const getTargets = (opts, root, projectType, hasRootTflintConfig, publishManifes
 	const inputs = [
 		"default",
 		"examples",
-		"tests"
+		"tests",
+		"integrationTests",
+		"e2eTests"
 	];
 	const targets = [
 		[opts.initTargetName, {
@@ -128,13 +151,7 @@ const getTargets = (opts, root, projectType, hasRootTflintConfig, publishManifes
 				cwd
 			}
 		}],
-		[opts.testTargetName, {
-			cache: true,
-			command: `terraform test`,
-			dependsOn: [opts.initTargetName],
-			inputs: ["default", "tests"],
-			options: { cwd }
-		}],
+		[opts.testTargetName, getTestTarget(opts.initTargetName)],
 		[opts.validateTargetName, {
 			cache: true,
 			command: `terraform validate`,
@@ -231,8 +248,10 @@ const getProject = (opts, root, hasRootTflintConfig = false, publishManifest = v
 		name: getProjectNameFromRoot(root),
 		namedInputs: {
 			default: ["{projectRoot}/*.{tf,tfvars}"],
+			e2eTests: ["{projectRoot}/tests/*.go", "{projectRoot}/tests/setup/*.tf"],
 			examples: ["{projectRoot}/examples/**/*.{tf,tfvars}"],
-			tests: ["{projectRoot}/tests/**/*.{tf,tfvars}", "{projectRoot}/tests/**/*.tftest.hcl"]
+			integrationTests: ["{projectRoot}/tests/integration.tftest.hcl", "{projectRoot}/tests/setup/*.tf"],
+			tests: ["{projectRoot}/tests/unit.tftest.hcl", "{projectRoot}/tests/contract.tftest.hcl"]
 		},
 		projectType,
 		root,

--- a/packages/nx-terraform-plugin/src/__tests__/project.test.ts
+++ b/packages/nx-terraform-plugin/src/__tests__/project.test.ts
@@ -35,10 +35,15 @@ const customOptions = parseOptions({
 
 const expectedNamedInputs = {
   default: ["{projectRoot}/*.{tf,tfvars}"],
+  e2eTests: ["{projectRoot}/tests/*.go", "{projectRoot}/tests/setup/*.tf"],
   examples: ["{projectRoot}/examples/**/*.{tf,tfvars}"],
+  integrationTests: [
+    "{projectRoot}/tests/integration.tftest.hcl",
+    "{projectRoot}/tests/setup/*.tf",
+  ],
   tests: [
-    "{projectRoot}/tests/**/*.{tf,tfvars}",
-    "{projectRoot}/tests/**/*.tftest.hcl",
+    "{projectRoot}/tests/unit.tftest.hcl",
+    "{projectRoot}/tests/contract.tftest.hcl",
   ],
 };
 
@@ -58,13 +63,46 @@ const publishManifestWithOwner = {
 const getExpectedLintTarget = (root: string) => ({
   cache: true,
   command: "tflint",
-  inputs: ["default", "examples", "tests", "{workspaceRoot}/.tflint.hcl"],
+  inputs: [
+    "default",
+    "examples",
+    "tests",
+    "integrationTests",
+    "e2eTests",
+    "{workspaceRoot}/.tflint.hcl",
+  ],
   options: {
     args: [
       "--disable-rule=terraform_required_version",
       "--disable-rule=terraform_required_providers",
       "--config",
       path.relative(root, ".tflint.hcl") || ".tflint.hcl",
+    ],
+    cwd: "{projectRoot}",
+  },
+});
+
+const getExpectedTestTarget = () => ({
+  cache: true,
+  command: "terraform test",
+  configurations: {
+    e2e: {
+      args: [],
+      command:
+        "if ls tests/*.go >/dev/null 2>&1; then go test -v -timeout 1h ./tests; fi",
+      inputs: ["default", "e2eTests"],
+    },
+    integration: {
+      args: ["-filter='tests/integration.tftest.hcl'"],
+      inputs: ["default", "integrationTests"],
+    },
+  },
+  dependsOn: ["tf-init"],
+  inputs: ["default", "tests"],
+  options: {
+    args: [
+      "-filter='tests/unit.tftest.hcl'",
+      "-filter='tests/contract.tftest.hcl'",
     ],
     cwd: "{projectRoot}",
   },
@@ -290,11 +328,13 @@ describe("getProject applications", () => {
       const root = path.join("infra", "resources", "prod", "my_stack");
       const targets = getTargetsOrThrow(getProject(defaultOptions, root));
 
-      expect(targets["tf-test"]?.dependsOn).toEqual(["tf-init"]);
+      expect(targets["tf-test"]).toEqual(getExpectedTestTarget());
       expect(targets["tf-plan"]?.dependsOn).toEqual(["tf-init"]);
       expect(targets["tf-apply"]?.dependsOn).toEqual(["tf-init"]);
     });
+  });
 
+  describe("environment tags", () => {
     it("adds the resource environment tag to flat resource applications", () => {
       const root = path.join("infra", "resources", "dev");
       const project = getProject(defaultOptions, root);

--- a/packages/nx-terraform-plugin/src/project.ts
+++ b/packages/nx-terraform-plugin/src/project.ts
@@ -103,6 +103,31 @@ const getPublishTarget = (
   }
 };
 
+const getTestTarget = (initTargetName: string): TargetConfiguration => ({
+  cache: true,
+  command: `terraform test`,
+  configurations: {
+    e2e: {
+      args: [],
+      command: `if ls tests/*.go >/dev/null 2>&1; then go test -v -timeout 1h ./tests; fi`,
+      inputs: ["default", "e2eTests"],
+    },
+    integration: {
+      args: ["-filter='tests/integration.tftest.hcl'"],
+      inputs: ["default", "integrationTests"],
+    },
+  },
+  dependsOn: [initTargetName],
+  inputs: ["default", "tests"],
+  options: {
+    args: [
+      "-filter='tests/unit.tftest.hcl'",
+      "-filter='tests/contract.tftest.hcl'",
+    ],
+    cwd: "{projectRoot}",
+  },
+});
+
 const getTargets = (
   opts: TerraformPluginOptions,
   root: string,
@@ -158,33 +183,7 @@ const getTargets = (
         },
       },
     ],
-    [
-      opts.testTargetName,
-      {
-        cache: true,
-        command: `terraform test`,
-        configurations: {
-          e2e: {
-            args: [],
-            command: `if ls tests/*.go >/dev/null 2>&1; then go test -v -timeout 1h ./tests; fi`,
-            inputs: ["default", "e2eTests"],
-          },
-          integration: {
-            args: ["-filter='tests/integration.tftest.hcl'"],
-            inputs: ["default", "integrationTests"],
-          },
-        },
-        dependsOn: [opts.initTargetName],
-        inputs: ["default", "tests"],
-        options: {
-          args: [
-            "-filter='tests/unit.tftest.hcl'",
-            "-filter='tests/contract.tftest.hcl'",
-          ],
-          cwd,
-        },
-      },
-    ],
+    [opts.testTargetName, getTestTarget(opts.initTargetName)],
     [
       opts.validateTargetName,
       {

--- a/packages/nx-terraform-plugin/src/project.ts
+++ b/packages/nx-terraform-plugin/src/project.ts
@@ -114,7 +114,13 @@ const getTargets = (
   const formatArgs = ["-list=true", "-recursive=true"];
 
   const cwd = "{projectRoot}";
-  const inputs = ["default", "examples", "tests"];
+  const inputs = [
+    "default",
+    "examples",
+    "tests",
+    "integrationTests",
+    "e2eTests",
+  ];
 
   // Shared targets for applications and libraries.
   // To speed up the development loop, frequently used tasks like "validate"
@@ -157,9 +163,24 @@ const getTargets = (
       {
         cache: true,
         command: `terraform test`,
+        configurations: {
+          e2e: {
+            args: [],
+            command: `if ls tests/*.go >/dev/null 2>&1; then go test -v -timeout 1h ./tests; fi`,
+            inputs: ["default", "e2eTests"],
+          },
+          integration: {
+            args: ["-filter='tests/integration.tftest.hcl'"],
+            inputs: ["default", "integrationTests"],
+          },
+        },
         dependsOn: [opts.initTargetName],
         inputs: ["default", "tests"],
         options: {
+          args: [
+            "-filter='tests/unit.tftest.hcl'",
+            "-filter='tests/contract.tftest.hcl'",
+          ],
           cwd,
         },
       },
@@ -324,10 +345,15 @@ export const getProject = (
     name: getProjectNameFromRoot(root),
     namedInputs: {
       default: ["{projectRoot}/*.{tf,tfvars}"],
+      e2eTests: ["{projectRoot}/tests/*.go", "{projectRoot}/tests/setup/*.tf"],
       examples: ["{projectRoot}/examples/**/*.{tf,tfvars}"],
+      integrationTests: [
+        "{projectRoot}/tests/integration.tftest.hcl",
+        "{projectRoot}/tests/setup/*.tf",
+      ],
       tests: [
-        "{projectRoot}/tests/**/*.{tf,tfvars}",
-        "{projectRoot}/tests/**/*.tftest.hcl",
+        "{projectRoot}/tests/unit.tftest.hcl",
+        "{projectRoot}/tests/contract.tftest.hcl",
       ],
     },
     projectType,

--- a/packages/nx-terraform-plugin/src/project.ts
+++ b/packages/nx-terraform-plugin/src/project.ts
@@ -104,6 +104,7 @@ const getPublishTarget = (
 };
 
 const getTestTarget = (initTargetName: string): TargetConfiguration => ({
+  // Fixed names keep each test layer isolated while exposing one Nx target.
   cache: true,
   command: `terraform test`,
   configurations: {


### PR DESCRIPTION
- Move Terraform integration and e2e tests into dedicated Nx target configurations
- Keep the default `tf-test` target scoped to unit and contract tests
- Remove redundant module scripts and workspace `targetOverrides`
- Add plugin contract coverage, the generated bundle, and a patch version plan
