### PR TITLE
Build affected Docker images in CI

### DIFF
--- a/.github/workflows/validate-v2.yaml
+++ b/.github/workflows/validate-v2.yaml
@@ -127,6 +127,9 @@ jobs:
       - name: Run code quality checks on affected projects
         run: pnpm validate
 
+      - name: Build affected Docker images
+        run: pnpm nx affected -t docker:build
+
   get-environments:
     name: Get GitHub Environments for Infrastructure
     needs: gate


### PR DESCRIPTION
## Summary

- run the inferred `docker:build` target for affected projects in `validate-v2`
- keep validation scoped through Nx so non-Docker projects and unrelated Docker images are skipped
- support any number of affected Docker image projects without custom path matching

## Validation

- executed `docker:build` for one affected image and for two affected images using a stub Docker CLI
- confirmed a non-Docker change schedules no Docker tasks
- passed all 56 `@pagopa/nx-dx-docker-plugin` tests plus lint and typecheck
- validated workflow formatting and YAML parsing