### PR TITLE
Include Docker builds in validation

### DIFF
--- a/.github/workflows/validate-v2.yaml
+++ b/.github/workflows/validate-v2.yaml
@@ -127,6 +127,9 @@ jobs:
       - name: Run code quality checks on affected projects
         run: pnpm validate
 
+      - name: Build affected Docker images
+        run: pnpm nx affected -t docker:build
+
   get-environments:
     name: Get GitHub Environments for Infrastructure
     needs: gate

--- a/.github/workflows/validate-v2.yaml
+++ b/.github/workflows/validate-v2.yaml
@@ -127,9 +127,6 @@ jobs:
       - name: Run code quality checks on affected projects
         run: pnpm validate
 
-      - name: Build affected Docker images
-        run: pnpm nx affected -t docker:build
-
   get-environments:
     name: Get GitHub Environments for Infrastructure
     needs: gate

--- a/package.json
+++ b/package.json
@@ -21,6 +21,6 @@
   },
   "scripts": {
     "dx": "node ./apps/cli/bin/index.js",
-    "validate": "nx affected --targets=build,test,lint,shellcheck,typecheck --configuration=ci"
+    "validate": "nx affected --targets=build,test,lint,shellcheck,typecheck,docker:build --configuration=ci"
   }
 }


### PR DESCRIPTION
## Summary

- fold `docker:build` into the existing root `validate` script so PR CI stays on a single `nx affected` invocation
- keep Docker image selection scoped to affected projects, including multi-image changes

## Validation

- `pnpm validate --files=containers/self-hosted-runner/Dockerfile --skipNxCache --outputStyle=static`
- `pnpm validate --files=containers/self-hosted-runner/Dockerfile,apps/dx-metrics/Dockerfile --skipNxCache --outputStyle=static`
- `pnpm validate --files=README.md --skipNxCache --outputStyle=static`
- `pnpm nx run-many -t test lint typecheck -p @pagopa/nx-dx-docker-plugin --outputStyle=static`
- `pnpm exec prettier --check package.json .github/workflows/validate-v2.yaml`
- JSON/YAML parse checks for `package.json` and `validate-v2.yaml`
